### PR TITLE
Sync tree expansion and scroll with node selection

### DIFF
--- a/components/tree.tsx
+++ b/components/tree.tsx
@@ -251,6 +251,7 @@ export const TreeNodeTrigger = ({
         isSelected && 'bg-accent/80',
         className,
       )}
+      data-node-id={nodeId}
       onClick={(e) => {
         handleSelection(nodeId, e.ctrlKey || e.metaKey)
         onClick?.(e)


### PR DESCRIPTION
Added logic to layers-menu to automatically expand ancestor nodes and scroll the selected node into view when selection changes. Updated tree node trigger to include a data attribute for easier DOM targeting.