### PR TITLE
Add site support: renderer, editor and UI

### DIFF
--- a/apps/editor/components/editor/index.tsx
+++ b/apps/editor/components/editor/index.tsx
@@ -43,7 +43,7 @@ export default function Editor() {
         {/* Editor only system to toggle zone visibility */}
         <ZoneSystem />
         {/* <Stats /> */}
-        <Grid cellColor="#666" sectionColor="#999" fadeDistance={30} />
+        <Grid cellColor="#666" sectionColor="#999" fadeDistance={100} />
         <ToolManager />
         <CustomCameraControls />
       </Viewer>

--- a/apps/editor/components/tools/site/site-boundary-editor.tsx
+++ b/apps/editor/components/tools/site/site-boundary-editor.tsx
@@ -1,0 +1,314 @@
+import { type SiteNode, useScene } from '@pascal-app/core'
+import { useThree } from '@react-three/fiber'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  BufferGeometry,
+  Float32BufferAttribute,
+  type Mesh,
+  Plane,
+  Raycaster,
+  Vector2,
+  Vector3,
+} from 'three'
+
+const Y_OFFSET = 0.02
+
+type DragState = {
+  isDragging: boolean
+  vertexIndex: number
+  initialPosition: [number, number]
+  pointerId: number
+}
+
+/** Find the site node ID from rootNodeIds (runs once, stable result) */
+function useSiteNodeId() {
+  return useScene((state) => {
+    for (const id of state.rootNodeIds) {
+      if (state.nodes[id]?.type === 'site') return id
+    }
+    return null
+  })
+}
+
+/**
+ * Site boundary editor - allows editing site polygon vertices when in site/edit mode
+ */
+export const SiteBoundaryEditor: React.FC = () => {
+  const { gl, camera, invalidate } = useThree()
+  const siteId = useSiteNodeId()
+  // Direct selector for the site node (same pattern as ZoneBoundaryEditor)
+  const siteNode = useScene((state) =>
+    siteId ? (state.nodes[siteId] as SiteNode | undefined) ?? null : null,
+  )
+  const updateNode = useScene((state) => state.updateNode)
+
+  const polygon = siteNode?.polygon?.points ?? []
+
+  // Local state for dragging
+  const [dragState, setDragState] = useState<DragState | null>(null)
+  const [previewPolygon, setPreviewPolygon] = useState<Array<[number, number]> | null>(null)
+  const [hoveredVertex, setHoveredVertex] = useState<number | null>(null)
+  const [hoveredMidpoint, setHoveredMidpoint] = useState<number | null>(null)
+
+  // Refs for raycasting during drag
+  const dragPlane = useRef(new Plane(new Vector3(0, 1, 0), -Y_OFFSET))
+  const raycaster = useRef(new Raycaster())
+  const lineRef = useRef<Mesh>(null!)
+
+  // The polygon to display (preview during drag, or actual site polygon)
+  const displayPolygon = previewPolygon ?? polygon
+
+  // Calculate midpoints for adding new vertices
+  const midpoints = useMemo(() => {
+    if (displayPolygon.length < 2) return []
+    return displayPolygon.map(([x1, z1], index) => {
+      const nextIndex = (index + 1) % displayPolygon.length
+      const [x2, z2] = displayPolygon[nextIndex]!
+      return [(x1! + x2) / 2, (z1! + z2) / 2] as [number, number]
+    })
+  }, [displayPolygon])
+
+  // Handle vertex drag
+  const handleVertexDrag = useCallback(
+    (clientX: number, clientY: number, vertexIndex: number) => {
+      if (!siteNode) return
+
+      const canvas = gl.domElement
+      const rect = canvas.getBoundingClientRect()
+      const x = ((clientX - rect.left) / rect.width) * 2 - 1
+      const y = -((clientY - rect.top) / rect.height) * 2 + 1
+
+      raycaster.current.setFromCamera(new Vector2(x, y), camera)
+      const intersection = new Vector3()
+      raycaster.current.ray.intersectPlane(dragPlane.current, intersection)
+
+      if (intersection) {
+        // Snap to 0.5 grid
+        const gridX = Math.round(intersection.x * 2) / 2
+        const gridZ = Math.round(intersection.z * 2) / 2
+
+        const basePolygon = previewPolygon ?? polygon
+        const newPolygon = [...basePolygon]
+        newPolygon[vertexIndex] = [gridX, gridZ]
+        setPreviewPolygon(newPolygon)
+      }
+    },
+    [siteNode, gl, camera, previewPolygon, polygon],
+  )
+
+  // Commit polygon changes
+  const commitPolygonChange = useCallback(() => {
+    if (previewPolygon && siteId) {
+      updateNode(siteId, {
+        polygon: { type: 'polygon' as const, points: previewPolygon },
+      })
+    }
+    setPreviewPolygon(null)
+    setDragState(null)
+  }, [previewPolygon, siteId, updateNode])
+
+  // Handle adding a new vertex at midpoint
+  const handleAddVertex = useCallback(
+    (afterIndex: number, position: [number, number]) => {
+      if (!siteNode) return -1
+
+      const basePolygon = previewPolygon ?? polygon
+      const newPolygon = [
+        ...basePolygon.slice(0, afterIndex + 1),
+        position,
+        ...basePolygon.slice(afterIndex + 1),
+      ]
+
+      setPreviewPolygon(newPolygon)
+      return afterIndex + 1
+    },
+    [siteNode, previewPolygon, polygon],
+  )
+
+  // Handle deleting a vertex
+  const handleDeleteVertex = useCallback(
+    (index: number) => {
+      if (!siteNode || !siteId) return
+
+      const basePolygon = previewPolygon ?? polygon
+      if (basePolygon.length <= 3) return
+
+      const newPolygon = basePolygon.filter((_, i) => i !== index)
+      updateNode(siteId, {
+        polygon: { type: 'polygon' as const, points: newPolygon },
+      })
+      setPreviewPolygon(null)
+    },
+    [siteNode, siteId, previewPolygon, polygon, updateNode],
+  )
+
+  // Set up pointer move/up listeners for dragging with pointer capture
+  useEffect(() => {
+    if (!dragState?.isDragging) return
+
+    const canvas = gl.domElement
+    const pointerId = dragState.pointerId
+
+    canvas.setPointerCapture(pointerId)
+
+    const handlePointerMove = (e: PointerEvent) => {
+      handleVertexDrag(e.clientX, e.clientY, dragState.vertexIndex)
+    }
+
+    const handlePointerUp = (e: PointerEvent) => {
+      if (canvas.hasPointerCapture(e.pointerId)) {
+        canvas.releasePointerCapture(e.pointerId)
+      }
+      commitPolygonChange()
+    }
+
+    canvas.addEventListener('pointermove', handlePointerMove)
+    canvas.addEventListener('pointerup', handlePointerUp)
+
+    return () => {
+      if (canvas.hasPointerCapture(pointerId)) {
+        canvas.releasePointerCapture(pointerId)
+      }
+      canvas.removeEventListener('pointermove', handlePointerMove)
+      canvas.removeEventListener('pointerup', handlePointerUp)
+    }
+  }, [dragState, gl, handleVertexDrag, commitPolygonChange])
+
+  // Update line geometry when polygon changes
+  useEffect(() => {
+    if (!lineRef.current || displayPolygon.length < 2) return
+
+    const positions: number[] = []
+    for (const [x, z] of displayPolygon) {
+      positions.push(x!, Y_OFFSET + 0.01, z!)
+    }
+    // Close the loop
+    const first = displayPolygon[0]!
+    positions.push(first[0]!, Y_OFFSET + 0.01, first[1]!)
+
+    const geometry = new BufferGeometry()
+    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3))
+
+    lineRef.current.geometry.dispose()
+    lineRef.current.geometry = geometry
+
+    // Force R3F to re-render the frame
+    invalidate()
+  }, [displayPolygon, invalidate])
+
+  if (!siteNode || displayPolygon.length < 3) return null
+
+  const canDelete = displayPolygon.length > 3
+
+  return (
+    <group>
+      {/* Border line */}
+      {/* @ts-ignore */}
+      <line ref={lineRef} frustumCulled={false} renderOrder={10}>
+        <bufferGeometry />
+        <lineBasicNodeMaterial
+          color={'#10b981'}
+          linewidth={2}
+          depthTest={false}
+          depthWrite={false}
+          transparent
+          opacity={0.8}
+        />
+      </line>
+
+      {/* Vertex handles */}
+      {displayPolygon.map(([x, z], index) => {
+        const isHovered = hoveredVertex === index
+        const isDragging = dragState?.vertexIndex === index
+
+        return (
+          <mesh
+            key={`vertex-${index}`}
+            position={[x!, Y_OFFSET, z!]}
+            onPointerEnter={(e) => {
+              e.stopPropagation()
+              setHoveredVertex(index)
+            }}
+            onPointerLeave={(e) => {
+              e.stopPropagation()
+              setHoveredVertex(null)
+            }}
+            onPointerDown={(e) => {
+              e.stopPropagation()
+              setDragState({
+                isDragging: true,
+                vertexIndex: index,
+                initialPosition: [x!, z!],
+                pointerId: e.nativeEvent.pointerId,
+              })
+            }}
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
+            onDoubleClick={(e) => {
+              e.stopPropagation()
+              if (canDelete) {
+                handleDeleteVertex(index)
+              }
+            }}
+          >
+            <sphereGeometry args={[isHovered || isDragging ? 0.3 : 0.2, 16, 16]} />
+            <meshBasicMaterial
+              color={
+                isDragging ? '#fbbf24' : isHovered ? (canDelete ? '#ef4444' : '#ffffff') : '#10b981'
+              }
+              depthTest={false}
+              depthWrite={false}
+            />
+          </mesh>
+        )
+      })}
+
+      {/* Midpoint handles for adding vertices (hidden while dragging) */}
+      {!dragState &&
+        midpoints.map(([x, z], index) => {
+          const isHovered = hoveredMidpoint === index
+
+          return (
+            <mesh
+              key={`midpoint-${index}`}
+              position={[x!, Y_OFFSET, z!]}
+              onPointerEnter={(e) => {
+                e.stopPropagation()
+                setHoveredMidpoint(index)
+              }}
+              onPointerLeave={(e) => {
+                e.stopPropagation()
+                setHoveredMidpoint(null)
+              }}
+              onPointerDown={(e) => {
+                e.stopPropagation()
+                const newVertexIndex = handleAddVertex(index, [x!, z!])
+                if (newVertexIndex >= 0) {
+                  setDragState({
+                    isDragging: true,
+                    vertexIndex: newVertexIndex,
+                    initialPosition: [x!, z!],
+                    pointerId: e.nativeEvent.pointerId,
+                  })
+                  setHoveredMidpoint(null)
+                }
+              }}
+              onClick={(e) => {
+                e.stopPropagation()
+              }}
+            >
+              <sphereGeometry args={[isHovered ? 0.15 : 0.1, 16, 16]} />
+              <meshBasicMaterial
+                color={isHovered ? '#10b981' : '#ffffff'}
+                depthTest={false}
+                depthWrite={false}
+                transparent
+                opacity={isHovered ? 1 : 0.4}
+              />
+            </mesh>
+          )
+        })}
+    </group>
+  )
+}

--- a/apps/editor/components/tools/tool-manager.tsx
+++ b/apps/editor/components/tools/tool-manager.tsx
@@ -6,6 +6,7 @@ import { MoveTool } from "./item/move-tool";
 import { RoofTool } from "./roof/roof-tool";
 import { SlabTool } from "./slab/slab-tool";
 import { WallTool } from "./wall/wall-tool";
+import { SiteBoundaryEditor } from "./site/site-boundary-editor";
 import { ZoneBoundaryEditor } from "./zone/zone-boundary-editor";
 import { ZoneTool } from "./zone/zone-tool";
 
@@ -31,6 +32,9 @@ export const ToolManager: React.FC = () => {
   const movingNode = useEditor((state) => state.movingNode);
   const selectedZoneId = useViewer((state) => state.selection.zoneId);
 
+  // Show site boundary editor when in site/edit mode
+  const showSiteBoundaryEditor = phase === "site" && mode === "edit";
+
   // Show zone boundary editor when in structure/select mode with a zone selected
   const showZoneBoundaryEditor =
     phase === "structure" && mode === "select" && selectedZoneId !== null;
@@ -42,6 +46,7 @@ export const ToolManager: React.FC = () => {
 
   return (
     <>
+      {showSiteBoundaryEditor && <SiteBoundaryEditor />}
       {showZoneBoundaryEditor && <ZoneBoundaryEditor />}
       {movingNode && <MoveTool />}
       {!movingNode && BuildToolComponent && <BuildToolComponent />}

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3000",
+    "dev": "set -a && . ./.env 2>/dev/null && set +a && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "biome lint",

--- a/packages/core/src/hooks/scene-registry/scene-registry.ts
+++ b/packages/core/src/hooks/scene-registry/scene-registry.ts
@@ -8,6 +8,7 @@ export const sceneRegistry = {
   // Categorized lookups: Type -> Set of IDs
   // Using a Set is faster for adding/deleting than an Array
   byType: {
+    site: new Set<string>(),
     building: new Set<string>(),
     ceiling: new Set<string>(),
     level: new Set<string>(),

--- a/packages/viewer/src/components/renderers/node-renderer.tsx
+++ b/packages/viewer/src/components/renderers/node-renderer.tsx
@@ -2,6 +2,7 @@
 
 import { type AnyNode, useScene } from '@pascal-app/core'
 import { BuildingRenderer } from './building/building-renderer'
+import { SiteRenderer } from './site/site-renderer'
 import { CeilingRenderer } from './ceiling/ceiling-renderer'
 import { GuideRenderer } from './guide/guide-renderer'
 import { ItemRenderer } from './item/item-renderer'
@@ -19,6 +20,7 @@ export const NodeRenderer = ({ nodeId }: { nodeId: AnyNode['id'] }) => {
 
   return (
     <>
+      {node.type === 'site' && <SiteRenderer node={node} />}
       {node.type === 'building' && <BuildingRenderer node={node} />}
       {node.type === 'ceiling' && <CeilingRenderer node={node} />}
       {node.type === 'level' && <LevelRenderer node={node} />}

--- a/packages/viewer/src/components/renderers/site/site-renderer.tsx
+++ b/packages/viewer/src/components/renderers/site/site-renderer.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { type SiteNode, useRegistry } from '@pascal-app/core'
+import { Html } from '@react-three/drei'
+import { useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef } from 'react'
+import {
+  BufferGeometry,
+  DoubleSide,
+  Float32BufferAttribute,
+  type Group,
+  type Mesh,
+  Shape,
+} from 'three'
+import { float, color } from 'three/tsl'
+import { MeshBasicNodeMaterial } from 'three/webgpu'
+
+const Y_OFFSET = 0.01
+
+const createFloorMaterial = () => {
+  return new MeshBasicNodeMaterial({
+    transparent: true,
+    colorNode: color(0xffffff),
+    opacityNode: float(0.04),
+    side: DoubleSide,
+    depthWrite: false,
+  })
+}
+
+export const SiteRenderer = ({ node }: { node: SiteNode }) => {
+  const ref = useRef<Group>(null!)
+  const lineRef = useRef<Mesh>(null!)
+  const { invalidate } = useThree()
+
+  useRegistry(node.id, 'site', ref)
+
+  const polygon = node.polygon?.points ?? []
+
+  // Floor shape
+  const floorShape = useMemo(() => {
+    if (polygon.length < 3) return null
+    const shape = new Shape()
+    const first = polygon[0]!
+    shape.moveTo(first[0]!, -first[1]!)
+    for (let i = 1; i < polygon.length; i++) {
+      const pt = polygon[i]!
+      shape.lineTo(pt[0]!, -pt[1]!)
+    }
+    shape.closePath()
+    return shape
+  }, [polygon])
+
+  const floorMaterial = useMemo(() => createFloorMaterial(), [])
+
+  // Update line geometry
+  useEffect(() => {
+    if (!lineRef.current || polygon.length < 2) return
+
+    const positions: number[] = []
+    for (const [x, z] of polygon) {
+      positions.push(x!, Y_OFFSET + 0.005, z!)
+    }
+    // Close loop
+    const first = polygon[0]!
+    positions.push(first[0]!, Y_OFFSET + 0.005, first[1]!)
+
+    const geometry = new BufferGeometry()
+    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3))
+
+    lineRef.current.geometry.dispose()
+    lineRef.current.geometry = geometry
+
+    invalidate()
+  }, [polygon, invalidate])
+
+  // Edge distances
+  const edges = useMemo(() => {
+    if (polygon.length < 2) return []
+    return polygon.map(([x1, z1], i) => {
+      const [x2, z2] = polygon[(i + 1) % polygon.length]!
+      const midX = (x1! + x2) / 2
+      const midZ = (z1! + z2) / 2
+      const dist = Math.sqrt((x2 - x1!) ** 2 + (z2 - z1!) ** 2)
+      return { midX, midZ, dist }
+    })
+  }, [polygon])
+
+  if (polygon.length < 3) return null
+
+  return (
+    <group ref={ref}>
+      {/* Floor fill */}
+      {floorShape && (
+        <mesh position={[0, Y_OFFSET, 0]} rotation={[-Math.PI / 2, 0, 0]} material={floorMaterial}>
+          <shapeGeometry args={[floorShape]} />
+        </mesh>
+      )}
+
+      {/* Border line */}
+      {/* @ts-ignore */}
+      <line ref={lineRef} frustumCulled={false} renderOrder={5}>
+        <bufferGeometry />
+        <lineBasicNodeMaterial
+          color={0xffffff}
+          linewidth={1}
+          depthTest={false}
+          depthWrite={false}
+          transparent
+          opacity={0.4}
+        />
+      </line>
+
+      {/* Edge distance labels */}
+      {edges.map((edge, i) => (
+        <Html
+          center
+          key={`edge-${i}`}
+          position={[edge.midX, 0.5, edge.midZ]}
+          style={{ pointerEvents: 'none', userSelect: 'none' }}
+          zIndexRange={[100, 0]}
+        >
+          <div className="whitespace-nowrap rounded bg-black/75 px-1.5 py-0.5 font-mono text-white text-xs backdrop-blur-sm">
+            {edge.dist.toFixed(2)}m
+          </div>
+        </Html>
+      ))}
+    </group>
+  )
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://v2-8-1.turborepo.dev/schema.json",
-  "ui": "tui",
+  "ui": "stream",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Introduce site (property) support and editing/visualization features.

- Add SiteRenderer to render site polygon fill, border and edge distance labels (packages/viewer).
- Add SiteBoundaryEditor to visually edit site polygon vertices with drag, midpoints and pointer capture (apps/editor).
- Integrate site editor into ToolManager and NodeRenderer so site nodes are rendered and editable.
- Add Property Line section to the Site panel showing area, perimeter and an editable vertex list (apps/editor UI).
- Ensure scene contains a SiteNode: register site type in sceneRegistry and create/restore a SiteNode on scene load (packages/core store/hooks).
- Minor editor/viewer tweaks: increase editor Grid fadeDistance, update dev script in apps/editor/package.json, and change Turbo UI from "tui" to "stream".

These changes enable creating, visualizing and interactively editing site polygons in the editor.