### PR TITLE
ci: add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,11 +39,13 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
-
-      - name: Configure npm auth
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Configure git
         run: |
@@ -51,6 +55,8 @@ jobs:
       - name: Bump & publish core
         if: inputs.package == 'core' || inputs.package == 'both'
         working-directory: packages/core
+        env:
+          NODE_AUTH_TOKEN: ""
         run: |
           npm version ${{ inputs.bump }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
@@ -60,15 +66,17 @@ jobs:
 
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/core@$VERSION"
-            npm publish --dry-run
+            npm publish --dry-run --access public
           else
-            npm publish --access public
+            npm publish --access public --provenance
             echo "📦 Published @pascal-app/core@$VERSION"
           fi
 
       - name: Bump & publish viewer
         if: inputs.package == 'viewer' || inputs.package == 'both'
         working-directory: packages/viewer
+        env:
+          NODE_AUTH_TOKEN: ""
         run: |
           npm version ${{ inputs.bump }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
@@ -78,9 +86,9 @@ jobs:
 
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/viewer@$VERSION"
-            npm publish --dry-run
+            npm publish --dry-run --access public
           else
-            npm publish --access public
+            npm publish --access public --provenance
             echo "📦 Published @pascal-app/viewer@$VERSION"
           fi
 


### PR DESCRIPTION
Adds a GitHub Actions workflow for publishing `@pascal-app/core` and `@pascal-app/viewer` to npm.

## How to use

**From GitHub UI:** Actions tab → Release → Run workflow → pick package + version bump

**From CLI:**
```bash
# Release both packages (patch bump)
gh workflow run release.yml -f package=both -f bump=patch

# Release just core (minor bump)
gh workflow run release.yml -f package=core -f bump=minor

# Dry run first
gh workflow run release.yml -f package=both -f bump=patch -f dry-run=true
```

## Setup required
Add `NPM_TOKEN` as a repository secret (Settings → Secrets → Actions):
```
npm token create
```