### PR TITLE
fix: correct repository URLs for npm listings

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,8 +54,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-username/pascal-editor.git",
+    "url": "https://github.com/pascalorg/editor.git",
     "directory": "packages/core"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "homepage": "https://github.com/pascalorg/editor/tree/main/packages/core#readme",
+  "bugs": "https://github.com/pascalorg/editor/issues"
 }

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -49,8 +49,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-username/pascal-editor.git",
+    "url": "https://github.com/pascalorg/editor.git",
     "directory": "packages/viewer"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "homepage": "https://github.com/pascalorg/editor/tree/main/packages/viewer#readme",
+  "bugs": "https://github.com/pascalorg/editor/issues"
 }


### PR DESCRIPTION
Updates `repository.url`, `homepage`, and `bugs` in both `@pascal-app/core` and `@pascal-app/viewer` to point to `pascalorg/editor` instead of the placeholder `your-username/pascal-editor`.

npm picks these up on next publish — the sidebar links will show the correct repo.