### PR TITLE
fix: resolve react-doctor errors (hooks order, reduced motion, key prop)

### DIFF
--- a/apps/editor/app/globals.css
+++ b/apps/editor/app/globals.css
@@ -144,3 +144,14 @@
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/apps/editor/components/ui/action-menu/index.tsx
+++ b/apps/editor/components/ui/action-menu/index.tsx
@@ -8,6 +8,7 @@ import { ControlModes } from "./control-modes";
 import { PhaseSwitcher } from "./phase-switcher";
 import { StructureTools } from "./structure-tools";
 import useEditor from "@/store/use-editor";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { AnimatePresence, motion } from "motion/react";
 import { ItemCatalog } from "../item-catalog/item-catalog";
 import { FurnishTools } from "./furnish-tools";
@@ -18,6 +19,8 @@ export function ActionMenu({ className }: { className?: string }) {
   const mode = useEditor((state) => state.mode);
   const tool = useEditor((state) => state.tool);
   const catalogCategory = useEditor((state) => state.catalogCategory);
+  const reducedMotion = useReducedMotion();
+  const transition = reducedMotion ? { duration: 0 } : undefined;
 
   return (
     <TooltipProvider>
@@ -57,8 +60,9 @@ export function ActionMenu({ className }: { className?: string }) {
                 paddingBottom: 0,
                 borderBottomWidth: 0,
               }}
+              transition={transition}
             >
-              <ItemCatalog category={catalogCategory} />
+              <ItemCatalog key={catalogCategory} category={catalogCategory} />
             </motion.div>
           )}
         </AnimatePresence>
@@ -91,6 +95,7 @@ export function ActionMenu({ className }: { className?: string }) {
                 paddingBottom: 0,
                 borderBottomWidth: 0,
               }}
+              transition={transition}
             >
               <div className="mx-auto w-max">
                 <FurnishTools />
@@ -127,6 +132,7 @@ export function ActionMenu({ className }: { className?: string }) {
                 paddingBottom: 0,
                 borderBottomWidth: 0,
               }}
+              transition={transition}
             >
               <div className="w-max">
                 <StructureTools />

--- a/apps/editor/components/ui/item-catalog/item-catalog.tsx
+++ b/apps/editor/components/ui/item-catalog/item-catalog.tsx
@@ -21,12 +21,6 @@ export function ItemCatalog({ category }: { category: CatalogCategory }) {
   const [activePlacementTag, setActivePlacementTag] = useState<string | null>(null);
   const [activeFunctionalTag, setActiveFunctionalTag] = useState<string | null>(null);
 
-  // Reset tag filters when category changes
-  useEffect(() => {
-    setActivePlacementTag(null);
-    setActiveFunctionalTag(null);
-  }, [category]);
-
   const categoryItems = CATALOG_ITEMS.filter(
     (item) => item.category === category,
   );

--- a/apps/editor/components/ui/sidebar/panels/site-panel/references-dialog.tsx
+++ b/apps/editor/components/ui/sidebar/panels/site-panel/references-dialog.tsx
@@ -38,15 +38,6 @@ export function ReferencesDialog({ levelId, open, onOpenChange }: ReferencesDial
   const scanInputRef = useRef<HTMLInputElement>(null)
   const guideInputRef = useRef<HTMLInputElement>(null)
 
-  const level = nodes[levelId as AnyNodeId] as LevelNode | undefined
-  if (!level) return null
-
-  // Find all scan and guide children of this level
-  const references = Object.values(nodes).filter(
-    (node): node is ScanNode | GuideNode =>
-      (node.type === 'scan' || node.type === 'guide') && node.parentId === levelId,
-  )
-
   const handleAddScan = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0]
@@ -98,6 +89,15 @@ export function ReferencesDialog({ levelId, open, onOpenChange }: ReferencesDial
       deleteNode(nodeId as AnyNodeId)
     },
     [deleteNode],
+  )
+
+  const level = nodes[levelId as AnyNodeId] as LevelNode | undefined
+  if (!level) return null
+
+  // Find all scan and guide children of this level
+  const references = Object.values(nodes).filter(
+    (node): node is ScanNode | GuideNode =>
+      (node.type === 'scan' || node.type === 'guide') && node.parentId === levelId,
   )
 
   return (

--- a/apps/editor/hooks/use-reduced-motion.ts
+++ b/apps/editor/hooks/use-reduced-motion.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns true when the user has requested reduced motion via OS settings.
+ * Useful for disabling animations (WCAG 2.3.3).
+ */
+export function useReducedMotion(): boolean {
+  const [reducedMotion, setReducedMotion] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReducedMotion(mql.matches)
+
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  return reducedMotion
+}


### PR DESCRIPTION
## React Doctor Scan Results

Ran `react-doctor` across the monorepo:

| Package | Score | Issues |
|---------|-------|--------|
| **apps/editor** | **81/100** | 7 errors, 248 warnings |
| packages/core | 100/100 | Clean ✅ |
| packages/eslint-config | 100/100 | Clean ✅ |
| packages/ui | 100/100 | Clean ✅ |
| packages/viewer | 99/100 | 81 warnings (Three.js false positives) |

## Fixes (all 4 errors)

### 1. Hooks called conditionally — `references-dialog.tsx`
Moved `useCallback` hooks above the early `if (!level) return null` guard to comply with the Rules of Hooks. React requires hooks to be called in the same order every render.

### 2. State reset via useEffect → key prop — `item-catalog.tsx`
Replaced a `useEffect` that reset filter state when `category` changed with a `key={catalogCategory}` prop on `<ItemCatalog>`. This lets React handle the remount naturally — cleaner and avoids a wasted render cycle.

### 3. No `prefers-reduced-motion` handling — accessibility (WCAG 2.3.3)
- Added `useReducedMotion()` hook that listens to `prefers-reduced-motion: reduce`
- Applied `transition={{ duration: 0 }}` to all `motion.div` animations when active
- Added global CSS `@media (prefers-reduced-motion: reduce)` fallback for all CSS transitions/animations

### 4. `fetch()` inside useEffect (viewer page)
This is flagged because `app/viewer/[id]/page.tsx` uses `useEffect` + `fetch` for demo files, but the page also calls server actions (`getProjectModelPublic`). Converting to a full server component would require restructuring the 3D viewer initialization. **Left as-is for now** — the server action path is already correct, and the demo fetch is a static JSON load.

## Not addressed (warnings only)
- **147+ "unknown property" warnings** in tool/renderer files — these are Three.js/R3F props (`position`, `rotation`, etc.), not DOM props. False positives.
- **Array index as key** (14) — most are in geometry rendering where items don't reorder. Low risk.
- **Label/a11y warnings** (40+) — real but separate scope, worth a follow-up PR.