### PR TITLE
fix: Supabase branching — safety check + stale env cleanup

### DIFF
--- a/apps/editor/lib/supabase/server.ts
+++ b/apps/editor/lib/supabase/server.ts
@@ -3,6 +3,26 @@ import type { SupabaseDatabase } from '@pascal-app/db'
 import { env } from '@/env.mjs'
 
 /**
+ * Safety check: warn loudly if a Vercel preview deployment is using
+ * the production Supabase instance. This catches misconfigured branching.
+ */
+if (
+  process.env.VERCEL_ENV === 'preview' &&
+  process.env.SUPABASE_URL &&
+  env.NEXT_PUBLIC_SUPABASE_URL === process.env.SUPABASE_URL
+) {
+  // If the Supabase integration set a branch-specific SUPABASE_URL,
+  // it should differ from NEXT_PUBLIC_SUPABASE_URL (which comes from the
+  // generic env vars pointing at production). When they match, the
+  // integration likely skipped branch creation for this PR.
+  console.warn(
+    '⚠️  [supabase] Preview deployment appears to be using the PRODUCTION ' +
+    'Supabase instance. Supabase branching may not be configured for this PR. ' +
+    'See: https://supabase.com/docs/guides/deployment/branching',
+  )
+}
+
+/**
  * Supabase client for server-side use with service role key
  * Bypasses Row Level Security (RLS) - use with caution
  * Always filter by user_id to enforce permissions


### PR DESCRIPTION
## Problem

Preview deployments are silently hitting **production Supabase**. Supabase branching only creates preview DB branches for PRs with migration changes. PRs without migrations (like UI fixes) get `SKIPPED` and fall through to generic Vercel env vars that include `preview` in their targets — pointing straight at prod.

## What was done

### 1. Cleaned up stale Vercel env vars (already applied)
Removed 9 branch-specific env vars locked to the deleted `feat/refactor-supabase-setup` branch. These were leftover from the initial integration setup and served no purpose.

### 2. Added runtime safety warning
`lib/supabase/server.ts` now logs a `⚠️` warning when a Vercel preview deployment detects it's using the production Supabase instance. This makes misconfigured branching visible in function logs instead of silently writing to prod.

## What still needs to happen (manual config)

The code change is a guardrail, not the full fix. To properly isolate preview data:

1. **Supabase Dashboard** → Project Settings → Integrations → Vercel  
   - Ensure branching is enabled and set to create preview branches for **all PRs** (not just ones with migrations)
   
2. **Vercel env vars** — once branching works for all PRs:
   - Remove `preview` from the generic `SUPABASE_*` / `NEXT_PUBLIC_SUPABASE_*` env var targets
   - Only keep `production` and `development` on those
   - The Supabase integration will set branch-specific preview vars automatically

3. **Verify** by opening a PR without migrations and confirming the preview connects to a Supabase branch (not prod)

## References
- [Supabase Branching docs](https://supabase.com/docs/guides/deployment/branching)
- Production Supabase project: `byrpxoiotywskoojsrzd`