### PR TITLE
fix: create project-thumbnails bucket in instrumentation.ts

### DIFF
--- a/apps/editor/instrumentation.ts
+++ b/apps/editor/instrumentation.ts
@@ -10,15 +10,24 @@ export async function register() {
     const supabase = createClient(url, key)
 
     const { data: buckets } = await supabase.storage.listBuckets()
-    const exists = buckets?.some((b) => b.name === 'avatars')
+    const bucketNames = new Set(buckets?.map((b) => b.name))
 
-    if (!exists) {
+    if (!bucketNames.has('avatars')) {
       await supabase.storage.createBucket('avatars', {
         public: true,
         fileSizeLimit: 5 * 1024 * 1024, // 5MB
         allowedMimeTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/gif'],
       })
       console.log('Created "avatars" storage bucket')
+    }
+
+    if (!bucketNames.has('project-thumbnails')) {
+      await supabase.storage.createBucket('project-thumbnails', {
+        public: true,
+        fileSizeLimit: 10 * 1024 * 1024, // 10MB (matches uploadProjectThumbnail validation)
+        allowedMimeTypes: ['image/png'],
+      })
+      console.log('Created "project-thumbnails" storage bucket')
     }
   }
 }


### PR DESCRIPTION
## Problem

`uploadProjectThumbnail` in `actions.ts` writes to a `project-thumbnails` storage bucket, but `instrumentation.ts` only creates the `avatars` bucket on startup. This causes:

```
❌ Failed to upload thumbnail: "Upload failed: Bucket not found"
```

## Fix

Add `project-thumbnails` bucket creation in `instrumentation.ts` with matching constraints:
- **Public** (thumbnails are served via public URLs)
- **10 MB limit** (matches the validation in `uploadProjectThumbnail`)
- **image/png only** (thumbnails are always exported as PNG)

Also refactored the bucket-exists check to use a `Set` for cleaner scaling as more buckets are added.

## Changes

- `apps/editor/instrumentation.ts` — add `project-thumbnails` bucket bootstrap