### PR TITLE
feat: Esc exits build mode back to select mode

### DIFF
--- a/apps/editor/hooks/use-keyboard.ts
+++ b/apps/editor/hooks/use-keyboard.ts
@@ -15,6 +15,12 @@ export const useKeyboard = () => {
       if (e.key === 'Escape') {
         e.preventDefault()
         emitter.emit('tool:cancel')
+
+        // If in build mode, switch back to select mode
+        const { mode } = useEditor.getState()
+        if (mode === 'build') {
+          useEditor.getState().setMode('select')
+        }
       } else if (e.key === '1' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
         useEditor.getState().setPhase('site')


### PR DESCRIPTION
When in build mode, pressing Escape now switches back to select mode in addition to canceling any in-progress tool operation (via `tool:cancel`).

**How it works:**
- `tool:cancel` fires first → active tools clean up their in-progress operations (wall drawing, item placement, etc.)
- Then `setMode('select')` switches back to select mode, which also clears the active tool

**Change:** `apps/editor/hooks/use-keyboard.ts` — 5 lines added

Requested by Julien.