### PR TITLE
feat(viewer): redesign viewer UI with dark toolbar and camera controls

### DIFF
--- a/apps/editor/app/viewer/[id]/viewer-guest-cta.tsx
+++ b/apps/editor/app/viewer/[id]/viewer-guest-cta.tsx
@@ -12,12 +12,12 @@ export function ViewerGuestCTA() {
 
   return (
     <>
-      <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-20">
-        <div className="bg-white/90 backdrop-blur-sm rounded-xl rounded-smooth-xl px-6 py-3 shadow-[0_4px_16px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.03)] flex items-center gap-4">
-          <p className="text-sm text-neutral-700">Want to create your own 3D project?</p>
+      <div className="absolute top-4 right-4 z-20 dark text-foreground">
+        <div className="pointer-events-auto bg-background/95 backdrop-blur-xl border border-border/40 rounded-2xl px-6 py-3 shadow-lg transition-colors duration-200 ease-out flex flex-col sm:flex-row items-center gap-4">
+          <p className="text-sm font-medium text-foreground text-center">Want to create your own 3D project?</p>
           <button
             onClick={() => setShowSignIn(true)}
-            className="rounded-lg bg-primary px-4 py-2 text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors whitespace-nowrap"
+            className="rounded-lg bg-primary px-4 py-2 text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors whitespace-nowrap w-full sm:w-auto"
           >
             Get Started
           </button>

--- a/apps/editor/components/ui/action-menu/action-button.tsx
+++ b/apps/editor/components/ui/action-menu/action-button.tsx
@@ -12,11 +12,12 @@ interface ActionButtonProps extends React.ComponentProps<typeof Button> {
   shortcut?: string;
   isActive?: boolean;
   tooltipContent?: React.ReactNode;
+  tooltipSide?: "top" | "right" | "bottom" | "left";
 }
 
 export const ActionButton = React.forwardRef<HTMLButtonElement, ActionButtonProps>(
   (
-    { className, children, label, shortcut, isActive, tooltipContent, ...props },
+    { className, children, label, shortcut, isActive, tooltipContent, tooltipSide, ...props },
     ref
   ) => {
     return (
@@ -47,7 +48,7 @@ export const ActionButton = React.forwardRef<HTMLButtonElement, ActionButtonProp
             )}
           </Button>
         </TooltipTrigger>
-        <TooltipContent>
+        <TooltipContent side={tooltipSide}>
           {tooltipContent || (
             <p>
               {label} {shortcut && `(${shortcut})`}

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -89,7 +89,7 @@ const useViewer = create<ViewerState>()(
       levelMode: "stacked",
       setLevelMode: (mode) => set({ levelMode: mode }),
 
-      wallMode: 'cutaway',
+      wallMode: 'up',
       setWallMode: (mode) => set({ wallMode: mode }),
 
       showScans: true,


### PR DESCRIPTION
## Summary
- Redesigned viewer overlay with a unified bottom toolbar replacing scattered right-side panels
- Added dark theme support with animated theme toggle (light/dark)
- Added camera orbit (CW/CCW) and top-view controls via emitter events
- Added `tooltipSide` prop to `ActionButton` for flexible tooltip positioning
- Changed default wall mode from `cutaway` to `up`
- Restyled guest CTA banner to match dark theme
- Fixed TypeScript strict array access errors for level/wall mode cycling

## Test plan
- [ ] Verify viewer toolbar renders correctly at bottom center
- [ ] Test theme toggle between light and dark
- [ ] Test camera orbit and top-view buttons
- [ ] Test level mode cycling (stacked → exploded → solo)
- [ ] Test wall mode cycling (cutaway → up → down)
- [ ] Verify breadcrumb navigation still works
- [ ] Check responsive layout on mobile (orbit buttons hidden on small screens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)