### PR TITLE
fix: remove unused @ts-expect-error directive in asset-url.ts

### DIFF
--- a/packages/viewer/src/lib/asset-url.ts
+++ b/packages/viewer/src/lib/asset-url.ts
@@ -1,6 +1,5 @@
 import { loadAssetUrl } from '@pascal-app/core'
 
-// @ts-expect-error
 export const ASSETS_CDN_URL = process.env.NEXT_PUBLIC_ASSETS_CDN_URL || 'https://editor.pascal.app'
 
 /**


### PR DESCRIPTION
## Summary

- Removes an unused `@ts-expect-error` directive in `packages/viewer/src/lib/asset-url.ts`
- TypeScript now correctly types `process.env`, so the suppression directive is no longer needed and causes `tsc --build` to fail with `TS2578: Unused '@ts-expect-error' directive`

## Test plan

- [x] Run `tsc --build` in `packages/viewer` — should pass with no errors
- [x] No behavior changes, logic is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)