### PR TITLE
feat: add STL and OBJ export formats

### DIFF
--- a/packages/editor/src/components/editor/export-manager.tsx
+++ b/packages/editor/src/components/editor/export-manager.tsx
@@ -4,13 +4,15 @@ import { useViewer } from '@pascal-app/viewer'
 import { useThree } from '@react-three/fiber'
 import { useEffect } from 'react'
 import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js'
+import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js'
+import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter.js'
 
 export function ExportManager() {
   const scene = useThree((state) => state.scene)
   const setExportScene = useViewer((state) => state.setExportScene)
 
   useEffect(() => {
-    const exportFn = async () => {
+    const exportFn = async (format: 'glb' | 'stl' | 'obj' = 'glb') => {
       // Find the scene renderer group by name
       const sceneGroup = scene.getObjectByName('scene-renderer')
       if (!sceneGroup) {
@@ -18,20 +20,33 @@ export function ExportManager() {
         return
       }
 
-      const exporter = new GLTFExporter()
       const date = new Date().toISOString().split('T')[0]
+
+      if (format === 'stl') {
+        const exporter = new STLExporter()
+        const result = exporter.parse(sceneGroup, { binary: true })
+        const blob = new Blob([result], { type: 'model/stl' })
+        downloadBlob(blob, `model_${date}.stl`)
+        return
+      }
+
+      if (format === 'obj') {
+        const exporter = new OBJExporter()
+        const result = exporter.parse(sceneGroup)
+        const blob = new Blob([result], { type: 'model/obj' })
+        downloadBlob(blob, `model_${date}.obj`)
+        return
+      }
+
+      // Default: GLB export (existing behavior)
+      const exporter = new GLTFExporter()
 
       return new Promise<void>((resolve, reject) => {
         exporter.parse(
           sceneGroup,
           (gltf) => {
             const blob = new Blob([gltf as ArrayBuffer], { type: 'model/gltf-binary' })
-            const url = URL.createObjectURL(blob)
-            const link = document.createElement('a')
-            link.href = url
-            link.download = `model_${date}.glb`
-            link.click()
-            URL.revokeObjectURL(url)
+            downloadBlob(blob, `model_${date}.glb`)
             resolve()
           },
           (error) => {
@@ -51,4 +66,13 @@ export function ExportManager() {
   }, [scene, setExportScene])
 
   return null
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.click()
+  URL.revokeObjectURL(url)
 }

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
@@ -202,9 +202,9 @@ export function SettingsPanel({
 
   const isLocalProject = false // Props-based; only show cloud sections when projectId provided
 
-  const handleExport = async () => {
+  const handleExport = async (format: 'glb' | 'stl' | 'obj' = 'glb') => {
     if (exportScene) {
-      await exportScene()
+      await exportScene(format)
     }
   }
 
@@ -318,9 +318,17 @@ export function SettingsPanel({
       {/* Export Section */}
       <div className="space-y-2">
         <label className="font-medium text-muted-foreground text-xs uppercase">Export</label>
-        <Button className="w-full justify-start gap-2" onClick={handleExport} variant="outline">
+        <Button className="w-full justify-start gap-2" onClick={() => handleExport('glb')} variant="outline">
           <Download className="size-4" />
-          Export 3D Model
+          Export as GLB
+        </Button>
+        <Button className="w-full justify-start gap-2" onClick={() => handleExport('stl')} variant="outline">
+          <Download className="size-4" />
+          Export as STL
+        </Button>
+        <Button className="w-full justify-start gap-2" onClick={() => handleExport('obj')} variant="outline">
+          <Download className="size-4" />
+          Export as OBJ
         </Button>
       </div>
 

--- a/packages/viewer/src/store/use-viewer.d.ts
+++ b/packages/viewer/src/store/use-viewer.d.ts
@@ -27,8 +27,8 @@ type ViewerState = {
   setSelection: (updates: Partial<SelectionPath>) => void
   resetSelection: () => void
   outliner: Outliner
-  exportScene: (() => Promise<void>) | null
-  setExportScene: (fn: (() => Promise<void>) | null) => void
+  exportScene: ((format?: 'glb' | 'stl' | 'obj') => Promise<void>) | null
+  setExportScene: (fn: ((format?: 'glb' | 'stl' | 'obj') => Promise<void>) | null) => void
 }
 declare const useViewer: import('zustand').UseBoundStore<import('zustand').StoreApi<ViewerState>>
 export default useViewer

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -61,8 +61,8 @@ type ViewerState = {
   outliner: Outliner // No setter as we will manipulate directly the arrays
 
   // Export functionality
-  exportScene: (() => Promise<void>) | null
-  setExportScene: (fn: (() => Promise<void>) | null) => void
+  exportScene: ((format?: 'glb' | 'stl' | 'obj') => Promise<void>) | null
+  setExportScene: (fn: ((format?: 'glb' | 'stl' | 'obj') => Promise<void>) | null) => void
 
   debugColors: boolean
   setDebugColors: (enabled: boolean) => void


### PR DESCRIPTION
## Summary

Adds STL and OBJ export options alongside the existing GLB export. Uses Three.js built-in exporters, no new dependencies.

## Why this matters

[#145](https://github.com/pascalorg/editor/issues/145) has an active community discussion requesting export format support. STL is the standard for 3D printing (physical scale models for clients), and OBJ is widely used in rendering pipelines.

The existing GLB export (`export-manager.tsx`) already grabs the `scene-renderer` group and runs it through `GLTFExporter`. STL and OBJ are parallel paths using Three.js's bundled `STLExporter` and `OBJExporter`.

## Changes

4 files, 48 insertions, 16 deletions:

- **`packages/editor/src/components/editor/export-manager.tsx`** - Import `STLExporter` and `OBJExporter`. Accept format parameter (`'glb' | 'stl' | 'obj'`, defaults to `'glb'`). Extract `downloadBlob` helper to reduce duplication.
- **`packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx`** - Replace single "Export 3D Model" button with three format-specific buttons: GLB, STL, OBJ.
- **`packages/viewer/src/store/use-viewer.ts`** + **`.d.ts`** - Update `exportScene` type signature to accept optional format parameter. Backward compatible since it defaults to `'glb'`.

The command palette's `exportScene()` call still works without changes since the format parameter is optional.

## Testing

The STL and OBJ exporters operate on the Three.js scene graph (Object3D trees and BufferGeometry data), independent of the renderer. They should work correctly with the WebGPU renderer since they don't touch the rendering pipeline.

Manual testing recommended with a project that has walls, slabs, and roof geometry to verify all node types export correctly.

This contribution was developed with AI assistance (Claude Code).

Relates to #145

## Video Demo
![Demo](https://files.catbox.moe/m0hwkn.gif)