### PR TITLE
ci: add lint and typecheck workflow on push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint & format check
+        run: bun run check
+
+      - name: Type check
+        run: bun run check-types


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs `bun run check` (Biome lint + format) and `bun run check-types` (TypeScript) on push/PR to `main`
- Uses concurrency groups to cancel stale runs
- Matches existing repo conventions from `release.yml`

Closes #148

## Test plan
- [ ] Push a PR to verify the workflow triggers
- [ ] Confirm `bun run check` and `bun run check-types` pass in CI