### PR TITLE
fix: implement T key for counter-clockwise rotation on selected nodes

### DIFF
--- a/packages/editor/src/hooks/use-keyboard.ts
+++ b/packages/editor/src/hooks/use-keyboard.ts
@@ -114,6 +114,25 @@ export const useKeyboard = () => {
             sfxEmitter.emit('sfx:item-rotate') // Play a sound for feedback
           }
         }
+      } else if (e.key === 't' || e.key === 'T') {
+        // Rotate selected node counter-clockwise
+        const selectedNodeIds = useViewer.getState().selection.selectedIds as AnyNodeId[]
+        if (selectedNodeIds.length === 1) {
+          const node = useScene.getState().nodes[selectedNodeIds[0]!]
+          if (node && 'rotation' in node) {
+            e.preventDefault()
+            const ROTATION_STEP = Math.PI / 4
+
+            if (typeof node.rotation === 'number') {
+              useScene.getState().updateNode(node.id, { rotation: node.rotation - ROTATION_STEP })
+            } else if (Array.isArray(node.rotation)) {
+              useScene.getState().updateNode(node.id, {
+                rotation: [node.rotation[0], node.rotation[1] - ROTATION_STEP, node.rotation[2]],
+              })
+            }
+            sfxEmitter.emit('sfx:item-rotate')
+          }
+        }
       } else if (e.key === 'Delete' || e.key === 'Backspace') {
         e.preventDefault()
 


### PR DESCRIPTION
## Summary
- The keyboard shortcuts dialog documents `T` as "Rotate item counter-clockwise by 90 degrees"
- `T` already works during **placement/move mode** (`use-placement-coordinator.tsx`, `move-roof-tool.tsx`)
- But pressing `T` on an **already selected node** did nothing — only `R` (clockwise) worked
- This adds the missing `T` handler in `use-keyboard.ts` matching the existing `R` handler pattern

## Steps to reproduce (before fix)
Select item/door/window → press `R` → rotates clockwise → press `T` → nothing happens

## After fix
Select item/door/window → press `R` → rotates clockwise → press `T` → rotates counter-clockwise

## Test plan
- [x] Select a placed item → press T → rotates counter-clockwise by 45 degrees
- [x] Select a placed item → press R → still rotates clockwise
- [x] Select a roof node → press T → rotates counter-clockwise
- [x] T key ignored when typing in input fields (existing guard at line 11)
- [x] T key still works during placement mode (unchanged code path)