### PR TITLE
fix: README badge colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A 3D building editor built with React Three Fiber and WebGPU.
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![npm @pascal-app/core](https://img.shields.io/npm/v/@pascal-app/core?label=%40pascal-app%2Fcore&color=cb3837)](https://www.npmjs.com/package/@pascal-app/core)
-[![npm @pascal-app/viewer](https://img.shields.io/npm/v/@pascal-app/viewer?label=%40pascal-app%2Fviewer&color=cb3837)](https://www.npmjs.com/package/@pascal-app/viewer)
-[![Discord](https://img.shields.io/discord/1430943778449002577?label=Discord&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/SaBRA9t2)
+[![npm @pascal-app/core](https://img.shields.io/npm/v/@pascal-app/core?label=%40pascal-app%2Fcore)](https://www.npmjs.com/package/@pascal-app/core)
+[![npm @pascal-app/viewer](https://img.shields.io/npm/v/@pascal-app/viewer?label=%40pascal-app%2Fviewer)](https://www.npmjs.com/package/@pascal-app/viewer)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/SaBRA9t2)
 [![X (Twitter)](https://img.shields.io/badge/follow-%40pascal__app-black?logo=x&logoColor=white)](https://x.com/pascal_app)
 
 https://github.com/user-attachments/assets/8b50e7cf-cebe-4579-9cf3-8786b35f7b6b


### PR DESCRIPTION
- npm badges: remove forced red color, use shields.io defaults (green for version)
- Discord badge: switch from widget-dependent member count to static 'Join Server' badge (no widget needed)