### PR TITLE
Add sizes and loading props to catalog item images

### DIFF
--- a/packages/editor/src/components/ui/item-catalog/item-catalog.tsx
+++ b/packages/editor/src/components/ui/item-catalog/item-catalog.tsx
@@ -190,6 +190,8 @@ export function ItemCatalog({ category }: { category: CatalogCategory }) {
                     alt={item.name}
                     className="rounded-lg object-cover"
                     fill
+                    loading="eager"
+                    sizes="56px"
                     src={resolveCdnUrl(item.thumbnail) || ''}
                   />
                   {attachmentIcon && (


### PR DESCRIPTION
## What does this PR do?

The branch fixed a nextjs Image component warning in item-catalog

## How to test

1. Open the item catalog - navigate to the editor and open the furniture panel
2. Verify images load immediately
3. Open console and ensure no warnings appear (e.g., "Image with fill and no sizes prop", "Image without explicit width/height")

## Screenshots / recordings

n/a

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch
