### PR TITLE
 Improvements for GLTF loading and scene registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Node storage is a flat dictionary (`nodes: Record<id, AnyNode>`). Systems are pu
 
 - **components/viewer/** — Root `<Viewer>` canvas, camera, lights, post-processing, selection manager
 - **components/renderers/** — One renderer per node type (`WallRenderer`, `SlabRenderer`, …), dispatched by `NodeRenderer` → `SceneRenderer`
+- **hooks/** — `useCachedGLTF` (URL-level GLTF caching to avoid redundant loads)
 - **systems/** — Viewer-specific systems: `LevelSystem` (stacked/exploded/solo), `WallCutout`, `ZoneSystem`, `InteractiveSystem`
 - **store/** — `useViewer`: selection path, camera mode, level mode, wall mode, theme, display toggles
 

--- a/packages/core/src/hooks/scene-registry/scene-registry.ts
+++ b/packages/core/src/hooks/scene-registry/scene-registry.ts
@@ -51,7 +51,8 @@ export function useRegistry(
     // 4. Cleanup when component unmounts
     return () => {
       sceneRegistry.nodes.delete(id)
-      sceneRegistry.byType[type].delete(id)
+      const bucket = sceneRegistry.byType[type]
+      if (bucket) bucket.delete(id)
     }
   }, [id, type, ref])
 }

--- a/packages/editor/src/components/ui/item-catalog/item-catalog.tsx
+++ b/packages/editor/src/components/ui/item-catalog/item-catalog.tsx
@@ -190,6 +190,8 @@ export function ItemCatalog({ category }: { category: CatalogCategory }) {
                     alt={item.name}
                     className="rounded-lg object-cover"
                     fill
+                    loading="eager"
+                    sizes="56px"
                     src={resolveCdnUrl(item.thumbnail) || ''}
                   />
                   {attachmentIcon && (

--- a/packages/viewer/src/components/renderers/item/item-renderer.tsx
+++ b/packages/viewer/src/components/renderers/item/item-renderer.tsx
@@ -12,41 +12,16 @@ import { useAnimations } from '@react-three/drei'
 import { Clone } from '@react-three/drei/core/Clone'
 import { useFrame } from '@react-three/fiber'
 import { Suspense, useEffect, useRef } from 'react'
-import type { AnimationAction, Group, Material } from 'three'
+import type { AnimationAction, Group } from 'three'
 import { MathUtils } from 'three'
 import { positionLocal, smoothstep, time } from 'three/tsl'
-import { DoubleSide, MeshStandardNodeMaterial } from 'three/webgpu'
+import { MeshStandardNodeMaterial } from 'three/webgpu'
 import { useCachedGLTF } from '../../../hooks/use-cached-gltf'
 import { useNodeEvents } from '../../../hooks/use-node-events'
 import { resolveCdnUrl } from '../../../lib/asset-url'
 import { useItemLightPool } from '../../../store/use-item-light-pool'
 import { ErrorBoundary } from '../../error-boundary'
 import { NodeRenderer } from '../node-renderer'
-
-// Shared materials to avoid creating new instances for every mesh
-const defaultMaterial = new MeshStandardNodeMaterial({
-  color: 0xff_ff_ff,
-  roughness: 1,
-  metalness: 0,
-})
-
-const glassMaterial = new MeshStandardNodeMaterial({
-  name: 'glass',
-  color: 'lightgray',
-  roughness: 0.8,
-  metalness: 0,
-  transparent: true,
-  opacity: 0.35,
-  side: DoubleSide,
-  depthWrite: false,
-})
-
-const getMaterialForOriginal = (original: Material): MeshStandardNodeMaterial => {
-  if (original.name.toLowerCase() === 'glass') {
-    return glassMaterial
-  }
-  return defaultMaterial
-}
 
 const BrokenItemFallback = ({ node }: { node: ItemNode }) => {
   const handlers = useNodeEvents(node, 'item')
@@ -111,10 +86,6 @@ const ModelRenderer = ({ node }: { node: ItemNode }) => {
   const { actions } = useAnimations(animations, ref)
   // Freeze the interactive definition at mount — asset schemas don't change at runtime
   const interactiveRef = useRef(node.asset.interactive)
-
-  if (nodes.cutout) {
-    nodes.cutout.visible = false
-  }
 
   const handlers = useNodeEvents(node, 'item')
 

--- a/packages/viewer/src/components/renderers/item/item-renderer.tsx
+++ b/packages/viewer/src/components/renderers/item/item-renderer.tsx
@@ -23,6 +23,9 @@ import { useItemLightPool } from '../../../store/use-item-light-pool'
 import { ErrorBoundary } from '../../error-boundary'
 import { NodeRenderer } from '../node-renderer'
 
+// Cache for processed GLTF scenes — prevents redundant traverse() calls
+const processedScenes = new Set<Group>()
+
 // Shared materials to avoid creating new instances for every mesh
 const defaultMaterial = new MeshStandardNodeMaterial({
   color: 0xff_ff_ff,
@@ -131,6 +134,7 @@ const ModelRenderer = ({ node }: { node: ItemNode }) => {
   }, [node.id])
 
   useMemo(() => {
+    if (processedScenes.has(scene)) return
     scene.traverse((child) => {
       if ((child as Mesh).isMesh) {
         const mesh = child as Mesh
@@ -153,6 +157,7 @@ const ModelRenderer = ({ node }: { node: ItemNode }) => {
         mesh.receiveShadow = !hasGlass
       }
     })
+    processedScenes.add(scene)
   }, [scene])
 
   const interactive = interactiveRef.current

--- a/packages/viewer/src/components/renderers/item/item-renderer.tsx
+++ b/packages/viewer/src/components/renderers/item/item-renderer.tsx
@@ -10,21 +10,18 @@ import {
 } from '@pascal-app/core'
 import { useAnimations } from '@react-three/drei'
 import { Clone } from '@react-three/drei/core/Clone'
-import { useGLTF } from '@react-three/drei/core/Gltf'
 import { useFrame } from '@react-three/fiber'
-import { Suspense, useEffect, useMemo, useRef } from 'react'
-import type { AnimationAction, Group, Material, Mesh } from 'three'
+import { Suspense, useEffect, useRef } from 'react'
+import type { AnimationAction, Group, Material } from 'three'
 import { MathUtils } from 'three'
 import { positionLocal, smoothstep, time } from 'three/tsl'
 import { DoubleSide, MeshStandardNodeMaterial } from 'three/webgpu'
+import { useCachedGLTF } from '../../../hooks/use-cached-gltf'
 import { useNodeEvents } from '../../../hooks/use-node-events'
 import { resolveCdnUrl } from '../../../lib/asset-url'
 import { useItemLightPool } from '../../../store/use-item-light-pool'
 import { ErrorBoundary } from '../../error-boundary'
 import { NodeRenderer } from '../node-renderer'
-
-// Cache for processed GLTF scenes — prevents redundant traverse() calls
-const processedScenes = new Set<Group>()
 
 // Shared materials to avoid creating new instances for every mesh
 const defaultMaterial = new MeshStandardNodeMaterial({
@@ -109,7 +106,7 @@ const multiplyScales = (
 ): [number, number, number] => [a[0] * b[0], a[1] * b[1], a[2] * b[2]]
 
 const ModelRenderer = ({ node }: { node: ItemNode }) => {
-  const { scene, nodes, animations } = useGLTF(resolveCdnUrl(node.asset.src) || '')
+  const { scene, nodes, animations } = useCachedGLTF(resolveCdnUrl(node.asset.src) || '')
   const ref = useRef<Group>(null!)
   const { actions } = useAnimations(animations, ref)
   // Freeze the interactive definition at mount — asset schemas don't change at runtime
@@ -132,33 +129,6 @@ const ModelRenderer = ({ node }: { node: ItemNode }) => {
     useInteractive.getState().initItem(node.id, interactive)
     return () => useInteractive.getState().removeItem(node.id)
   }, [node.id])
-
-  useMemo(() => {
-    if (processedScenes.has(scene)) return
-    scene.traverse((child) => {
-      if ((child as Mesh).isMesh) {
-        const mesh = child as Mesh
-        if (mesh.name === 'cutout') {
-          child.visible = false
-          return
-        }
-
-        let hasGlass = false
-
-        // Handle both single material and material array cases
-        if (Array.isArray(mesh.material)) {
-          mesh.material = mesh.material.map((mat) => getMaterialForOriginal(mat))
-          hasGlass = mesh.material.some((mat) => mat.name === 'glass')
-        } else {
-          mesh.material = getMaterialForOriginal(mesh.material)
-          hasGlass = mesh.material.name === 'glass'
-        }
-        mesh.castShadow = !hasGlass
-        mesh.receiveShadow = !hasGlass
-      }
-    })
-    processedScenes.add(scene)
-  }, [scene])
 
   const interactive = interactiveRef.current
   const animEffect =

--- a/packages/viewer/src/hooks/use-cached-gltf.ts
+++ b/packages/viewer/src/hooks/use-cached-gltf.ts
@@ -1,13 +1,17 @@
 import { useGLTF } from '@react-three/drei/core/Gltf'
+import type { ObjectMap } from '@react-three/fiber'
 import { useMemo } from 'react'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const gltfCache = new Map<string, any>()
+interface GLTFWithObjectMap extends ObjectMap {
+  scene: import('three').Group
+  nodes: Record<string, import('three').Object3D>
+  animations: import('three').AnimationClip[]
+}
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useCachedGLTF(url: string): any {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const gltf: any = useGLTF(url)
+const gltfCache = new Map<string, GLTFWithObjectMap>()
+
+export function useCachedGLTF(url: string): GLTFWithObjectMap {
+  const gltf = useGLTF(url) as GLTFWithObjectMap
 
   return useMemo(() => {
     if (!gltfCache.has(url)) {

--- a/packages/viewer/src/hooks/use-cached-gltf.ts
+++ b/packages/viewer/src/hooks/use-cached-gltf.ts
@@ -1,0 +1,22 @@
+import { useGLTF } from '@react-three/drei/core/Gltf'
+import { useMemo } from 'react'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gltfCache = new Map<string, any>()
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useCachedGLTF(url: string): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const gltf: any = useGLTF(url)
+
+  return useMemo(() => {
+    if (!gltfCache.has(url)) {
+      gltfCache.set(url, gltf)
+    }
+    return gltfCache.get(url)!
+  }, [url, gltf])
+}
+
+export function clearGLTFCache() {
+  gltfCache.clear()
+}

--- a/packages/viewer/src/hooks/use-cached-gltf.ts
+++ b/packages/viewer/src/hooks/use-cached-gltf.ts
@@ -1,6 +1,32 @@
 import { useGLTF } from '@react-three/drei/core/Gltf'
 import type { ObjectMap } from '@react-three/fiber'
 import { useMemo } from 'react'
+import type { Material, Mesh } from 'three'
+import { DoubleSide, MeshStandardNodeMaterial } from 'three/webgpu'
+
+const defaultMaterial = new MeshStandardNodeMaterial({
+  color: 0xff_ff_ff,
+  roughness: 1,
+  metalness: 0,
+})
+
+const glassMaterial = new MeshStandardNodeMaterial({
+  name: 'glass',
+  color: 'lightgray',
+  roughness: 0.8,
+  metalness: 0,
+  transparent: true,
+  opacity: 0.35,
+  side: DoubleSide,
+  depthWrite: false,
+})
+
+function getMaterialForOriginal(original: Material): MeshStandardNodeMaterial {
+  if (original.name.toLowerCase() === 'glass') {
+    return glassMaterial
+  }
+  return defaultMaterial
+}
 
 interface GLTFWithObjectMap extends ObjectMap {
   scene: import('three').Group
@@ -10,11 +36,36 @@ interface GLTFWithObjectMap extends ObjectMap {
 
 const gltfCache = new Map<string, GLTFWithObjectMap>()
 
+function processSceneMaterials(scene: import('three').Group) {
+  scene.traverse((child) => {
+    if ((child as Mesh).isMesh) {
+      const mesh = child as Mesh
+      if (mesh.name === 'cutout') {
+        child.visible = false
+        return
+      }
+
+      let hasGlass = false
+
+      if (Array.isArray(mesh.material)) {
+        mesh.material = mesh.material.map((mat) => getMaterialForOriginal(mat))
+        hasGlass = mesh.material.some((mat) => mat.name === 'glass')
+      } else {
+        mesh.material = getMaterialForOriginal(mesh.material)
+        hasGlass = mesh.material.name === 'glass'
+      }
+      mesh.castShadow = !hasGlass
+      mesh.receiveShadow = !hasGlass
+    }
+  })
+}
+
 export function useCachedGLTF(url: string): GLTFWithObjectMap {
   const gltf = useGLTF(url) as GLTFWithObjectMap
 
   return useMemo(() => {
     if (!gltfCache.has(url)) {
+      processSceneMaterials(gltf.scene)
       gltfCache.set(url, gltf)
     }
     return gltfCache.get(url)!


### PR DESCRIPTION
## What does this PR do?

Performance improvements for GLTF loading and scene registry:

- Added `useCachedGLTF` hook that caches loaded GLTFs by URL, eliminating redundant network requests when multiple items use the same asset.
- Removed redundant scene.traverse() call per item mount (previously ran once per item even with identical assets)
- Fixed registry cleanup null check for edge cases

## How to test

<!-- Steps for reviewers to verify this change works -->

1. Open network tab and load a scene with multiple items of the same type (e.g., 10+ identical chairs)
2. Verify only 1 network request is made per unique GLTF asset
3. Place, move, and delete items to ensure no crashes or visual glitches occur with the cached GLTF and registry cleanup

## Screenshots / recordings

n/a

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch
