### PR TITLE
feat: add delete functionality for walls, slabs and other structural elements

### DIFF
--- a/packages/editor/src/components/tools/delete-tool.tsx
+++ b/packages/editor/src/components/tools/delete-tool.tsx
@@ -1,0 +1,101 @@
+import {
+  type AnyNode,
+  type AnyNodeId,
+  emitter,
+  useScene,
+} from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
+import { useEffect } from 'react'
+import { sfxEmitter } from '../../../lib/sfx-bus'
+
+const DELETABLE_TYPES = new Set<AnyNode['type']>([
+  'wall',
+  'slab',
+  'ceiling',
+  'window',
+  'door',
+  'item',
+  'zone',
+  'roof',
+  'roof-segment',
+  'column',
+  'stair',
+])
+
+function isDeletable(node: AnyNode): boolean {
+  return DELETABLE_TYPES.has(node.type)
+}
+
+/**
+ * DeleteTool — activated when the editor is in "delete" mode.
+ * Clicking on a deletable node removes it from the scene.
+ */
+export const DeleteTool: React.FC = () => {
+  useEffect(() => {
+    const { levelId, zoneId } = useViewer.getState().selection
+
+    const handleClick = (event: { node: AnyNode; stopPropagation: () => void }) => {
+      const node = event.node
+      if (!isDeletable(node)) return
+
+      // Only delete nodes on the currently selected level/zone
+      const nodes = useScene.getState().nodes
+      let onLevel = false
+      if (node.parentId === levelId) {
+        onLevel = true
+      }
+      // Wall-attached children (window, door, item)
+      if (
+        (node.type === 'window' || node.type === 'door' || node.type === 'item') &&
+        node.parentId
+      ) {
+        const parent = nodes[node.parentId as AnyNodeId]
+        if (parent?.type === 'wall' && parent.parentId === levelId) {
+          onLevel = true
+        }
+      }
+      if (!onLevel) return
+
+      // Zone check: if a zone is selected, only delete nodes in that zone
+      if (zoneId) {
+        const isZoneChild = node.parentId === zoneId || node.id === zoneId
+        if (!isZoneChild) return
+      }
+
+      // Determine sfx type
+      if (node.type === 'item' || node.type === 'window' || node.type === 'door') {
+        sfxEmitter.emit('sfx:item-delete')
+      } else {
+        sfxEmitter.emit('sfx:structure-delete')
+      }
+
+      useScene.getState().deleteNode(node.id)
+      event.stopPropagation()
+    }
+
+    const handlers: Array<{ event: string; handler: typeof handleClick }> = [
+      { event: 'wall:click', handler: handleClick },
+      { event: 'slab:click', handler: handleClick },
+      { event: 'ceiling:click', handler: handleClick },
+      { event: 'window:click', handler: handleClick },
+      { event: 'door:click', handler: handleClick },
+      { event: 'item:click', handler: handleClick },
+      { event: 'zone:click', handler: handleClick },
+      { event: 'roof:click', handler: handleClick },
+      { event: 'roof-segment:click', handler: handleClick },
+    ]
+
+    for (const { event, handler } of handlers) {
+      emitter.on(event, handler as any)
+    }
+
+    return () => {
+      for (const { event, handler } of handlers) {
+        emitter.off(event, handler as any)
+      }
+    }
+  }, [])
+
+  // No 3D visual needed — the cursor/hover feedback comes from the viewer
+  return null
+}

--- a/packages/editor/src/components/tools/tool-manager.tsx
+++ b/packages/editor/src/components/tools/tool-manager.tsx
@@ -21,6 +21,7 @@ import { SlabHoleEditor } from './slab/slab-hole-editor'
 import { SlabTool } from './slab/slab-tool'
 import { StairTool } from './stair/stair-tool'
 import { CurveWallTool } from './wall/curve-wall-tool'
+import { DeleteTool } from './delete-tool'
 import { WallTool } from './wall/wall-tool'
 import { WindowTool } from './window/window-tool'
 import { ZoneBoundaryEditor } from './zone/zone-boundary-editor'
@@ -118,6 +119,9 @@ export const ToolManager: React.FC = () => {
 
   const BuildToolComponent = showBuildTool ? tools[phase]?.[tool] : null
 
+  // Show delete tool when in delete mode
+  const showDeleteTool = mode === 'delete'
+
   return (
     <>
       {showSiteBoundaryEditor && <SiteBoundaryEditor />}
@@ -143,6 +147,7 @@ export const ToolManager: React.FC = () => {
           <CeilingHoleEditor ceilingId={selectedCeilingId} holeIndex={editingHole.holeIndex} />
         )}
         {curvingWall && <CurveWallTool node={curvingWall} />}
+        {showDeleteTool && <DeleteTool />}
         {movingNode && movingNode.type !== 'building' && <MoveTool />}
         {!movingNode && BuildToolComponent && <BuildToolComponent />}
       </group>


### PR DESCRIPTION
## Summary

Add ability to delete structural elements (walls, slabs, ceilings, doors, windows, items, zones, roofs) when the editor is in **delete mode** (shortcut: `D`).

The delete mode button already existed in the UI toolbar but had no handler — clicking on elements did nothing.

## Changes

- **New `DeleteTool` component** (`packages/editor/src/components/tools/delete-tool.tsx`)
  - Listens to click events on all deletable node types via the event bus
  - Validates the clicked node belongs to the current level/zone selection
  - Calls `useScene.deleteNode()` to remove the node
  - Plays appropriate SFX (item-delete or structure-delete)

- **Updated `ToolManager`** to render `DeleteTool` when mode is `delete`

## Testing

1. Open the editor and switch to Structure phase
2. Click the Delete mode button (trash icon) or press `D`
3. Click on a wall, slab, or other structural element → it should be deleted
4. Verify undo (Ctrl+Z) restores the deleted element
5. Verify delete only works on elements in the selected level/zone

Fixes #156