### PR TITLE
chore: encourage screen recordings in PR and bug report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,9 @@ body:
     id: screenshots
     attributes:
       label: Screenshots or screen recordings
-      description: If applicable, add screenshots or a short video to help explain the problem.
+      description: |
+        A short screen recording is the fastest way to show us the bug.
+        Drag and drop a video file or paste a link — even a quick clip helps a lot.
     validations:
       required: false
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,14 @@
 2. 
 3. 
 
-## Screenshots / recordings
+## Screenshots / screen recording
 
-<!-- If this is a visual change, add before/after screenshots or a short recording -->
+<!--
+🎥 Screen recordings are strongly encouraged for any visual or interactive change.
+Even a quick 15-second clip helps reviewers understand the change far better than screenshots alone.
+
+Drag and drop a video or paste a link here.
+-->
 
 ## Checklist
 


### PR DESCRIPTION
Updates the PR template and bug report template to more prominently encourage screen recordings for visual/interactive changes.

**Changes:**
- PR template: renamed section to 'Screenshots / screen recording' with a visible nudge explaining that even a 15-second clip helps
- Bug report template: updated the screenshots field description to emphasize video recordings as the fastest way to show a bug