### PR TITLE
ci: add lint and typecheck quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Type check
+        run: bun run check-types


### PR DESCRIPTION
## Summary

Closes #147

Adds a CI workflow that runs the repo's existing quality scripts on every push/PR:

| Step | Command | What it checks |
|------|---------|---------------|
| Lint | `bun run lint` | Biome lint rules from `biome.jsonc` |
| Type check | `bun run check-types` | `tsc --noEmit` via turbo across workspaces |

## Why `lint` not `check`

`bun run check` (lint + format) currently fails with 191 pre-existing format violations across 189 files. Using `bun run lint` enforces lint rules without requiring a massive formatting PR first. Format enforcement can be added separately.

## Setup

Matches `release.yml` exactly — bun package manager, Node 22, frozen lockfile.

## Context

I opened #147 with this exact approach on March 22. This PR implements it.