### PR TITLE
fix(viewer): skip post-processing pipeline when WebGPU is unavailable

### DIFF
--- a/packages/viewer/src/components/viewer/post-processing.tsx
+++ b/packages/viewer/src/components/viewer/post-processing.tsx
@@ -117,6 +117,24 @@ const PostProcessingPasses = () => {
 
     hasPipelineErrorRef.current = false
 
+    // WebGPU availability check: SSGI, denoise, and RenderPipeline are all
+    // WebGPU-only APIs. When the browser falls back to WebGL2 (no
+    // `navigator.gpu`, or the device couldn't be created), building the
+    // pipeline either throws silently or produces a broken output where
+    // the scene renders for a few frames and then goes black as the retry
+    // loop fights the direct-render fallback path. Short-circuit here so
+    // `useFrame` uses the direct `renderer.render(scene, camera)` path
+    // exclusively and never attempts the TSL pipeline.
+    const hasWebGPU = typeof navigator !== 'undefined' && typeof navigator.gpu !== 'undefined'
+    if (!hasWebGPU) {
+      console.warn(
+        '[viewer] WebGPU unavailable — rendering without post-processing (SSGI, outlines, denoise).',
+      )
+      hasPipelineErrorRef.current = true
+      renderPipelineRef.current = null
+      return
+    }
+
     // Clear outliner arrays synchronously to prevent stale Object3D refs
     // from the previous project leaking into the new pipeline's outline passes.
     const outliner = useViewer.getState().outliner
@@ -263,15 +281,7 @@ const PostProcessingPasses = () => {
       }
       renderPipelineRef.current = null
     }
-  }, [
-    renderer,
-    scene,
-    camera,
-    hoverHighlightMode,
-    zoneLayers,
-    projectId,
-    pipelineVersion,
-  ])
+  }, [renderer, scene, camera, hoverHighlightMode, zoneLayers, projectId, pipelineVersion])
 
   useFrame((_, delta) => {
     // Animate background colour toward the current theme target (same lerp as AnimatedBackground)


### PR DESCRIPTION
## Problem

On a browser where `navigator.gpu` is undefined (Safari without the WebGPU flag, most iOS WebKit builds, older Chrome on machines without a WebGPU device), the `WebGPURenderer` falls back to WebGL2. When that happens, the TSL-based post-processing pipeline in `post-processing.tsx` can't be built — `RenderPipeline`, `ssgi`, `denoise`, and the MRT pass setup from `three/webgpu` / `three/tsl` are all WebGPU-only.

The existing error path in `useFrame` retries the pipeline up to 3 times with a 500ms delay between attempts. Each retry fights the direct-render fallback, and the net result is \"scene renders for about a second, then goes black and stays black.\"

## Fix

Add a short-circuit at the top of the pipeline-setup `useEffect`:

```ts
const hasWebGPU =
  typeof navigator !== 'undefined' && typeof navigator.gpu !== 'undefined'
if (!hasWebGPU) {
  console.warn('[viewer] WebGPU unavailable — rendering without post-processing (SSGI, outlines, denoise).')
  hasPipelineErrorRef.current = true
  renderPipelineRef.current = null
  return
}
```

When the guard fires, `hasPipelineErrorRef.current` is set at setup time, so `useFrame`'s existing `if (hasPipelineErrorRef.current || !renderPipelineRef.current)` branch takes the direct `renderer.render(scene, camera)` path and never attempts the TSL pipeline. The retry loop is skipped entirely.

## Scope

- **WebGPU mode**: `navigator.gpu` is defined, the guard passes, nothing changes. SSGI, outlines, denoise all still run.
- **No WebGPU**: the guard fires, direct render only, no post FX (the scene is still visible — just flat shading).
- **WebGPU API exposed but device creation fails at runtime**: not handled specially — falls through the existing `try { … } catch` block exactly like today.

Pairs well with #233 (await `renderer.init()` in the gl factory), which fixes the direct-render path itself so the fallback actually works in WebGL2.

## Test

On a WebGL2-only browser:
- Before: scene blinks on, retries loop, goes permanently black, console spam.
- After: one-time `[viewer] WebGPU unavailable` warning, scene renders without post FX, stays rendered.