### PR TITLE
fix(editor): unit-aware sidebar controls + preserve user-typed precision

### DIFF
--- a/packages/editor/src/components/ui/controls/slider-control.tsx
+++ b/packages/editor/src/components/ui/controls/slider-control.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useScene } from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { feetToMeters, metersToFeet } from '../../../lib/units'
 import { cn } from '../../../lib/utils'
 
 interface SliderControlProps {
@@ -32,10 +34,29 @@ export function SliderControl({
   className,
   unit = '',
 }: SliderControlProps) {
+  // When the slider is rendering a length (caller passes `unit="m"`)
+  // and the user has toggled imperial in the viewer toolbar, we show
+  // and edit feet instead. Scene values stay in metres — we convert
+  // only for display and for parsing the user's typed input. All the
+  // panel call sites that pass `unit="m"` get imperial support for
+  // free without any caller-side changes.
+  const viewerUnit = useViewer((s) => s.unit)
+  const isLength = unit === 'm'
+  const useImperial = isLength && viewerUnit === 'imperial'
+  const displayUnit = useImperial ? 'ft' : unit
+  const toDisplay = useCallback(
+    (m: number) => (useImperial ? metersToFeet(m) : m),
+    [useImperial],
+  )
+  const fromDisplay = useCallback(
+    (d: number) => (useImperial ? feetToMeters(d) : d),
+    [useImperial],
+  )
+
   const [isEditing, setIsEditing] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
-  const [inputValue, setInputValue] = useState(value.toFixed(precision))
+  const [inputValue, setInputValue] = useState(toDisplay(value).toFixed(precision))
 
   const dragRef = useRef<{ startX: number; startValue: number } | null>(null)
   const labelRef = useRef<HTMLDivElement>(null)
@@ -46,9 +67,9 @@ export function SliderControl({
 
   useEffect(() => {
     if (!isEditing) {
-      setInputValue(value.toFixed(precision))
+      setInputValue(toDisplay(value).toFixed(precision))
     }
-  }, [value, precision, isEditing])
+  }, [value, precision, isEditing, toDisplay])
 
   // Wheel support on the label
   useEffect(() => {
@@ -141,39 +162,49 @@ export function SliderControl({
 
   const handleValueClick = useCallback(() => {
     setIsEditing(true)
-    setInputValue(value.toFixed(precision))
-  }, [value, precision])
+    setInputValue(toDisplay(value).toFixed(precision))
+  }, [value, precision, toDisplay])
 
   const submitValue = useCallback(() => {
-    const numValue = Number.parseFloat(inputValue)
-    if (Number.isNaN(numValue)) {
-      setInputValue(value.toFixed(precision))
+    const typed = Number.parseFloat(inputValue)
+    if (Number.isNaN(typed)) {
+      setInputValue(toDisplay(value).toFixed(precision))
     } else {
-      onChange(clamp(Number.parseFloat(numValue.toFixed(precision))))
+      // Round in the DISPLAY unit (before converting back to metres),
+      // not the storage unit. `precision` expresses "how many decimal
+      // places does the user see" — if we rounded the converted
+      // metres value instead, a typed "8.00 ft" with precision=2
+      // would truncate to 2.44 m (losing 4 mm), then round-trip back
+      // to the display as "8.01 ft" because 2.44 × 3.28084 = 8.0052.
+      // Rounding in display units first preserves the user's typed
+      // value exactly and lets storage keep full float precision.
+      const roundedDisplay = Number.parseFloat(typed.toFixed(precision))
+      const meters = fromDisplay(roundedDisplay)
+      onChange(clamp(meters))
     }
     setIsEditing(false)
-  }, [inputValue, onChange, clamp, precision, value])
+  }, [inputValue, onChange, clamp, precision, value, toDisplay, fromDisplay])
 
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
         submitValue()
       } else if (e.key === 'Escape') {
-        setInputValue(value.toFixed(precision))
+        setInputValue(toDisplay(value).toFixed(precision))
         setIsEditing(false)
       } else if (e.key === 'ArrowUp') {
         e.preventDefault()
         const newV = clamp(value + step)
         onChange(newV)
-        setInputValue(newV.toFixed(precision))
+        setInputValue(toDisplay(newV).toFixed(precision))
       } else if (e.key === 'ArrowDown') {
         e.preventDefault()
         const newV = clamp(value - step)
         onChange(newV)
-        setInputValue(newV.toFixed(precision))
+        setInputValue(toDisplay(newV).toFixed(precision))
       }
     },
-    [submitValue, value, precision, step, clamp, onChange],
+    [submitValue, value, precision, step, clamp, onChange, toDisplay],
   )
 
   return (
@@ -226,7 +257,7 @@ export function SliderControl({
               type="text"
               value={inputValue}
             />
-            {unit && <span className="ml-[1px] text-muted-foreground">{unit}</span>}
+            {displayUnit && <span className="ml-[1px] text-muted-foreground">{displayUnit}</span>}
           </>
         ) : (
           <div
@@ -234,9 +265,9 @@ export function SliderControl({
             onClick={handleValueClick}
           >
             <span className="font-mono tabular-nums tracking-tight" suppressHydrationWarning>
-              {Number(value.toFixed(precision)).toFixed(precision)}
+              {toDisplay(value).toFixed(precision)}
             </span>
-            {unit && <span className="ml-[1px] text-muted-foreground">{unit}</span>}
+            {displayUnit && <span className="ml-[1px] text-muted-foreground">{displayUnit}</span>}
           </div>
         )}
       </div>

--- a/packages/editor/src/components/ui/panels/ceiling-panel.tsx
+++ b/packages/editor/src/components/ui/panels/ceiling-panel.tsx
@@ -5,6 +5,7 @@ import { useViewer } from '@pascal-app/viewer'
 import { Edit, Plus, Trash2 } from 'lucide-react'
 import { useCallback, useEffect } from 'react'
 import useEditor from '../../../store/use-editor'
+import { formatArea } from '../../../lib/units'
 import { ActionButton } from '../controls/action-button'
 import { MaterialPicker } from '../controls/material-picker'
 import { PanelSection } from '../controls/panel-section'
@@ -14,6 +15,7 @@ import { PanelWrapper } from './panel-wrapper'
 export function CeilingPanel() {
   const selectedIds = useViewer((s) => s.selection.selectedIds)
   const setSelection = useViewer((s) => s.setSelection)
+  const unit = useViewer((s) => s.unit)
   const nodes = useScene((s) => s.nodes)
   const updateNode = useScene((s) => s.updateNode)
   const editingHole = useEditor((s) => s.editingHole)
@@ -134,7 +136,7 @@ export function CeilingPanel() {
           precision={3}
           step={0.01}
           unit="m"
-          value={Math.round(node.height * 1000) / 1000}
+          value={node.height}
         />
 
         <div className="mt-2 grid grid-cols-3 gap-1.5 px-1 pb-1">
@@ -147,7 +149,7 @@ export function CeilingPanel() {
       <PanelSection title="Info">
         <div className="flex items-center justify-between px-2 py-1 text-muted-foreground text-sm">
           <span>Area</span>
-          <span className="font-mono text-white">{area.toFixed(2)} m²</span>
+          <span className="font-mono text-white">{formatArea(area, unit)}</span>
         </div>
       </PanelSection>
 
@@ -174,7 +176,7 @@ export function CeilingPanel() {
                       Hole {index + 1} {isEditing && '(Editing)'}
                     </p>
                     <p className="text-[10px] text-muted-foreground">
-                      {holeArea.toFixed(2)} m² · {hole.length} pts
+                      {formatArea(holeArea, unit)} · {hole.length} pts
                     </p>
                   </div>
                   <div className="flex items-center gap-1">

--- a/packages/editor/src/components/ui/panels/door-panel.tsx
+++ b/packages/editor/src/components/ui/panels/door-panel.tsx
@@ -228,7 +228,7 @@ export function DoorPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.position[0] * 100) / 100}
+          value={node.position[0]}
         />
         <div className="px-1 pt-2 pb-1">
           <ActionButton
@@ -249,7 +249,7 @@ export function DoorPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.width * 100) / 100}
+          value={node.width}
         />
         <SliderControl
           label="Height"
@@ -261,7 +261,7 @@ export function DoorPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.height * 100) / 100}
+          value={node.height}
         />
       </PanelSection>
 
@@ -274,7 +274,7 @@ export function DoorPanel() {
           precision={3}
           step={0.01}
           unit="m"
-          value={Math.round(node.frameThickness * 1000) / 1000}
+          value={node.frameThickness}
         />
         <SliderControl
           label="Depth"
@@ -284,7 +284,7 @@ export function DoorPanel() {
           precision={3}
           step={0.01}
           unit="m"
-          value={Math.round(node.frameDepth * 1000) / 1000}
+          value={node.frameDepth}
         />
       </PanelSection>
 
@@ -297,7 +297,7 @@ export function DoorPanel() {
           precision={3}
           step={0.005}
           unit="m"
-          value={Math.round(node.contentPadding[0] * 1000) / 1000}
+          value={node.contentPadding[0]}
         />
         <SliderControl
           label="Vertical"
@@ -307,7 +307,7 @@ export function DoorPanel() {
           precision={3}
           step={0.005}
           unit="m"
-          value={Math.round(node.contentPadding[1] * 1000) / 1000}
+          value={node.contentPadding[1]}
         />
       </PanelSection>
 
@@ -358,7 +358,7 @@ export function DoorPanel() {
               precision={3}
               step={0.005}
               unit="m"
-              value={Math.round(node.thresholdHeight * 1000) / 1000}
+              value={node.thresholdHeight}
             />
           </div>
         )}
@@ -380,7 +380,7 @@ export function DoorPanel() {
               precision={2}
               step={0.05}
               unit="m"
-              value={Math.round(node.handleHeight * 100) / 100}
+              value={node.handleHeight}
             />
             <div className="space-y-1">
               <span className="font-medium text-[10px] text-muted-foreground/80 uppercase tracking-wider">
@@ -420,7 +420,7 @@ export function DoorPanel() {
               precision={2}
               step={0.05}
               unit="m"
-              value={Math.round(node.panicBarHeight * 100) / 100}
+              value={node.panicBarHeight}
             />
           </div>
         )}
@@ -458,7 +458,7 @@ export function DoorPanel() {
                 precision={1}
                 step={1}
                 unit="%"
-                value={Math.round(normHeights[i]! * 100 * 10) / 10}
+                value={normHeights[i]! * 100}
               />
 
               <SliderControl
@@ -489,7 +489,7 @@ export function DoorPanel() {
                       precision={1}
                       step={1}
                       unit="%"
-                      value={Math.round(ratio * 100 * 10) / 10}
+                      value={ratio * 100}
                     />
                   ))}
                   <SliderControl
@@ -505,7 +505,7 @@ export function DoorPanel() {
                     precision={3}
                     step={0.005}
                     unit="m"
-                    value={Math.round(seg.dividerThickness * 1000) / 1000}
+                    value={seg.dividerThickness}
                   />
                 </div>
               )}
@@ -525,7 +525,7 @@ export function DoorPanel() {
                     precision={3}
                     step={0.005}
                     unit="m"
-                    value={Math.round(seg.panelInset * 1000) / 1000}
+                    value={seg.panelInset}
                   />
                   <SliderControl
                     label="Depth"
@@ -540,7 +540,7 @@ export function DoorPanel() {
                     precision={3}
                     step={0.005}
                     unit="m"
-                    value={Math.round(seg.panelDepth * 1000) / 1000}
+                    value={seg.panelDepth}
                   />
                 </div>
               )}

--- a/packages/editor/src/components/ui/panels/item-panel.tsx
+++ b/packages/editor/src/components/ui/panels/item-panel.tsx
@@ -99,7 +99,7 @@ export function ItemPanel() {
           precision={2}
           step={0.01}
           unit="m"
-          value={Math.round(node.position[0] * 100) / 100}
+          value={node.position[0]}
         />
         <SliderControl
           label={
@@ -115,7 +115,7 @@ export function ItemPanel() {
           precision={2}
           step={0.01}
           unit="m"
-          value={Math.round(node.position[1] * 100) / 100}
+          value={node.position[1]}
         />
         <SliderControl
           label={
@@ -131,7 +131,7 @@ export function ItemPanel() {
           precision={2}
           step={0.01}
           unit="m"
-          value={Math.round(node.position[2] * 100) / 100}
+          value={node.position[2]}
         />
       </PanelSection>
 
@@ -207,7 +207,7 @@ export function ItemPanel() {
             }}
             precision={2}
             step={0.1}
-            value={Math.round(node.scale[0] * 100) / 100}
+            value={node.scale[0]}
           />
         ) : (
           <>
@@ -224,7 +224,7 @@ export function ItemPanel() {
               }
               precision={2}
               step={0.1}
-              value={Math.round(node.scale[0] * 100) / 100}
+              value={node.scale[0]}
             />
             <SliderControl
               label={
@@ -239,7 +239,7 @@ export function ItemPanel() {
               }
               precision={2}
               step={0.1}
-              value={Math.round(node.scale[1] * 100) / 100}
+              value={node.scale[1]}
             />
             <SliderControl
               label={
@@ -254,7 +254,7 @@ export function ItemPanel() {
               }
               precision={2}
               step={0.1}
-              value={Math.round(node.scale[2] * 100) / 100}
+              value={node.scale[2]}
             />
           </>
         )}
@@ -267,7 +267,7 @@ export function ItemPanel() {
             const [w, h, d] = getScaledDimensions(node)
             return (
               <span className="font-mono text-white">
-                {Math.round(w * 100) / 100}×{Math.round(h * 100) / 100}×{Math.round(d * 100) / 100}
+                {w}×{h}×{d}
               </span>
             )
           })()}

--- a/packages/editor/src/components/ui/panels/reference-panel.tsx
+++ b/packages/editor/src/components/ui/panels/reference-panel.tsx
@@ -62,7 +62,7 @@ export function ReferencePanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.position[0] * 100) / 100}
+          value={node.position[0]}
         />
         <SliderControl
           label={
@@ -80,7 +80,7 @@ export function ReferencePanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.position[1] * 100) / 100}
+          value={node.position[1]}
         />
         <SliderControl
           label={
@@ -98,7 +98,7 @@ export function ReferencePanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.position[2] * 100) / 100}
+          value={node.position[2]}
         />
       </PanelSection>
 
@@ -158,7 +158,7 @@ export function ReferencePanel() {
           }}
           precision={2}
           step={0.1}
-          value={Math.round(node.scale * 100) / 100}
+          value={node.scale}
         />
 
         <SliderControl

--- a/packages/editor/src/components/ui/panels/roof-panel.tsx
+++ b/packages/editor/src/components/ui/panels/roof-panel.tsx
@@ -178,7 +178,7 @@ export function RoofPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[0] * 100) / 100}
+          value={node.position[0]}
         />
         <MetricControl
           label="Y"
@@ -192,7 +192,7 @@ export function RoofPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[1] * 100) / 100}
+          value={node.position[1]}
         />
         <MetricControl
           label="Z"
@@ -206,7 +206,7 @@ export function RoofPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[2] * 100) / 100}
+          value={node.position[2]}
         />
         <SliderControl
           label="Rotation"

--- a/packages/editor/src/components/ui/panels/roof-segment-panel.tsx
+++ b/packages/editor/src/components/ui/panels/roof-segment-panel.tsx
@@ -149,7 +149,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.5}
           unit="m"
-          value={Math.round(node.width * 100) / 100}
+          value={node.width}
         />
         <SliderControl
           label="Depth"
@@ -159,7 +159,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.5}
           unit="m"
-          value={Math.round(node.depth * 100) / 100}
+          value={node.depth}
         />
       </PanelSection>
 
@@ -172,7 +172,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.wallHeight * 100) / 100}
+          value={node.wallHeight}
         />
         <SliderControl
           label="Roof"
@@ -182,7 +182,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.roofHeight * 100) / 100}
+          value={node.roofHeight}
         />
       </PanelSection>
 
@@ -195,7 +195,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.wallThickness * 100) / 100}
+          value={node.wallThickness}
         />
         <SliderControl
           label="Deck Thick."
@@ -205,7 +205,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.01}
           unit="m"
-          value={Math.round(node.deckThickness * 100) / 100}
+          value={node.deckThickness}
         />
         <SliderControl
           label="Overhang"
@@ -215,7 +215,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.overhang * 100) / 100}
+          value={node.overhang}
         />
         <SliderControl
           label="Shingle Thick."
@@ -225,7 +225,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.01}
           unit="m"
-          value={Math.round(node.shingleThickness * 100) / 100}
+          value={node.shingleThickness}
         />
       </PanelSection>
 
@@ -242,7 +242,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[0] * 100) / 100}
+          value={node.position[0]}
         />
         <MetricControl
           label="Y"
@@ -256,7 +256,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[1] * 100) / 100}
+          value={node.position[1]}
         />
         <MetricControl
           label="Z"
@@ -270,7 +270,7 @@ export function RoofSegmentPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[2] * 100) / 100}
+          value={node.position[2]}
         />
         <SliderControl
           label="Rotation"

--- a/packages/editor/src/components/ui/panels/slab-panel.tsx
+++ b/packages/editor/src/components/ui/panels/slab-panel.tsx
@@ -5,6 +5,7 @@ import { useViewer } from '@pascal-app/viewer'
 import { Edit, Plus, Trash2 } from 'lucide-react'
 import { useCallback, useEffect } from 'react'
 import useEditor from '../../../store/use-editor'
+import { formatArea } from '../../../lib/units'
 import { ActionButton, ActionGroup } from '../controls/action-button'
 import { MaterialPicker } from '../controls/material-picker'
 import { PanelSection } from '../controls/panel-section'
@@ -14,6 +15,7 @@ import { PanelWrapper } from './panel-wrapper'
 export function SlabPanel() {
   const selectedIds = useViewer((s) => s.selection.selectedIds)
   const setSelection = useViewer((s) => s.setSelection)
+  const unit = useViewer((s) => s.unit)
   const nodes = useScene((s) => s.nodes)
   const updateNode = useScene((s) => s.updateNode)
   const editingHole = useEditor((s) => s.editingHole)
@@ -132,7 +134,7 @@ export function SlabPanel() {
           precision={3}
           step={0.01}
           unit="m"
-          value={Math.round(node.elevation * 1000) / 1000}
+          value={node.elevation}
         />
 
         <div className="mt-2 grid grid-cols-2 gap-1.5 px-1 pb-1">
@@ -146,7 +148,7 @@ export function SlabPanel() {
       <PanelSection title="Info">
         <div className="flex items-center justify-between px-2 py-1 text-muted-foreground text-sm">
           <span>Area</span>
-          <span className="font-mono text-white">{area.toFixed(2)} m²</span>
+          <span className="font-mono text-white">{formatArea(area, unit)}</span>
         </div>
       </PanelSection>
 
@@ -173,7 +175,7 @@ export function SlabPanel() {
                       Hole {index + 1} {isEditing && '(Editing)'}
                     </p>
                     <p className="text-[10px] text-muted-foreground">
-                      {holeArea.toFixed(2)} m² · {hole.length} pts
+                      {formatArea(holeArea, unit)} · {hole.length} pts
                     </p>
                   </div>
                   <div className="flex items-center gap-1">

--- a/packages/editor/src/components/ui/panels/stair-panel.tsx
+++ b/packages/editor/src/components/ui/panels/stair-panel.tsx
@@ -265,7 +265,7 @@ export function StairPanel() {
             precision={2}
             step={0.05}
             unit="m"
-            value={Math.round((node.width ?? 1) * 100) / 100}
+            value={(node.width ?? 1)}
           />
           <MetricControl
             label="Rise"
@@ -275,7 +275,7 @@ export function StairPanel() {
             precision={2}
             step={0.05}
             unit="m"
-            value={Math.round((node.totalRise ?? 2.5) * 100) / 100}
+            value={(node.totalRise ?? 2.5)}
           />
           <MetricControl
             label="Steps"
@@ -303,7 +303,7 @@ export function StairPanel() {
               precision={2}
               step={0.01}
               unit="m"
-              value={Math.round((node.thickness ?? 0.25) * 100) / 100}
+              value={(node.thickness ?? 0.25)}
             />
           )}
           <MetricControl
@@ -314,7 +314,7 @@ export function StairPanel() {
             precision={2}
             step={0.05}
             unit="m"
-            value={Math.round((node.innerRadius ?? 0.9) * 100) / 100}
+            value={(node.innerRadius ?? 0.9)}
           />
           <SliderControl
             label="Sweep"
@@ -342,7 +342,7 @@ export function StairPanel() {
                   precision={2}
                   step={0.05}
                   unit="m"
-                  value={Math.round((node.topLandingDepth ?? 0.9) * 100) / 100}
+                  value={(node.topLandingDepth ?? 0.9)}
                 />
               )}
               <ToggleControl
@@ -373,7 +373,7 @@ export function StairPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[0] * 100) / 100}
+          value={node.position[0]}
         />
         <MetricControl
           label="Y"
@@ -387,7 +387,7 @@ export function StairPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[1] * 100) / 100}
+          value={node.position[1]}
         />
         <MetricControl
           label="Z"
@@ -401,7 +401,7 @@ export function StairPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[2] * 100) / 100}
+          value={node.position[2]}
         />
         <SliderControl
           label="Rotation"
@@ -448,7 +448,7 @@ export function StairPanel() {
             precision={2}
             step={0.02}
             unit="m"
-            value={Math.round((node.railingHeight ?? 0.92) * 100) / 100}
+            value={(node.railingHeight ?? 0.92)}
           />
         )}
       </PanelSection>

--- a/packages/editor/src/components/ui/panels/stair-segment-panel.tsx
+++ b/packages/editor/src/components/ui/panels/stair-segment-panel.tsx
@@ -173,7 +173,7 @@ export function StairSegmentPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.width * 100) / 100}
+          value={node.width}
         />
         <SliderControl
           label="Length"
@@ -183,7 +183,7 @@ export function StairSegmentPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.length * 100) / 100}
+          value={node.length}
         />
         {node.segmentType === 'stair' && (
           <>
@@ -195,7 +195,7 @@ export function StairSegmentPanel() {
               precision={2}
               step={0.1}
               unit="m"
-              value={Math.round(node.height * 100) / 100}
+              value={node.height}
             />
             <SliderControl
               label="Steps"
@@ -237,7 +237,7 @@ export function StairSegmentPanel() {
             precision={2}
             step={0.05}
             unit="m"
-            value={Math.round((node.thickness ?? 0.25) * 100) / 100}
+            value={(node.thickness ?? 0.25)}
           />
         )}
       </PanelSection>
@@ -255,7 +255,7 @@ export function StairSegmentPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[0] * 100) / 100}
+          value={node.position[0]}
         />
         <MetricControl
           label="Y"
@@ -269,7 +269,7 @@ export function StairSegmentPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[1] * 100) / 100}
+          value={node.position[1]}
         />
         <MetricControl
           label="Z"
@@ -283,7 +283,7 @@ export function StairSegmentPanel() {
           precision={2}
           step={0.05}
           unit="m"
-          value={Math.round(node.position[2] * 100) / 100}
+          value={node.position[2]}
         />
         <SliderControl
           label="Rotation"

--- a/packages/editor/src/components/ui/panels/window-panel.tsx
+++ b/packages/editor/src/components/ui/panels/window-panel.tsx
@@ -228,7 +228,7 @@ export function WindowPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.position[0] * 100) / 100}
+          value={node.position[0]}
         />
         <SliderControl
           label={
@@ -240,7 +240,7 @@ export function WindowPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.position[1] * 100) / 100}
+          value={node.position[1]}
         />
         <div className="px-1 pt-2 pb-1">
           <ActionButton
@@ -260,7 +260,7 @@ export function WindowPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.width * 100) / 100}
+          value={node.width}
         />
         <SliderControl
           label="Height"
@@ -269,7 +269,7 @@ export function WindowPanel() {
           precision={2}
           step={0.1}
           unit="m"
-          value={Math.round(node.height * 100) / 100}
+          value={node.height}
         />
       </PanelSection>
 
@@ -281,7 +281,7 @@ export function WindowPanel() {
           precision={3}
           step={0.01}
           unit="m"
-          value={Math.round(node.frameThickness * 1000) / 1000}
+          value={node.frameThickness}
         />
         <SliderControl
           label="Depth"
@@ -290,7 +290,7 @@ export function WindowPanel() {
           precision={3}
           step={0.01}
           unit="m"
-          value={Math.round(node.frameDepth * 1000) / 1000}
+          value={node.frameDepth}
         />
       </PanelSection>
 
@@ -335,7 +335,7 @@ export function WindowPanel() {
                 precision={1}
                 step={1}
                 unit="%"
-                value={Math.round(ratio * 100 * 10) / 10}
+                value={ratio * 100}
               />
             ))}
             <div className="mt-1 border-border/50 border-t pt-1">
@@ -347,7 +347,7 @@ export function WindowPanel() {
                 precision={3}
                 step={0.01}
                 unit="m"
-                value={Math.round((node.columnDividerThickness ?? 0.03) * 1000) / 1000}
+                value={(node.columnDividerThickness ?? 0.03)}
               />
             </div>
           </div>
@@ -368,7 +368,7 @@ export function WindowPanel() {
                 precision={1}
                 step={1}
                 unit="%"
-                value={Math.round(ratio * 100 * 10) / 10}
+                value={ratio * 100}
               />
             ))}
             <div className="mt-1 border-border/50 border-t pt-1">
@@ -380,7 +380,7 @@ export function WindowPanel() {
                 precision={3}
                 step={0.01}
                 unit="m"
-                value={Math.round((node.rowDividerThickness ?? 0.03) * 1000) / 1000}
+                value={(node.rowDividerThickness ?? 0.03)}
               />
             </div>
           </div>
@@ -402,7 +402,7 @@ export function WindowPanel() {
               precision={3}
               step={0.01}
               unit="m"
-              value={Math.round(node.sillDepth * 1000) / 1000}
+              value={node.sillDepth}
             />
             <SliderControl
               label="Thickness"
@@ -411,7 +411,7 @@ export function WindowPanel() {
               precision={3}
               step={0.01}
               unit="m"
-              value={Math.round(node.sillThickness * 1000) / 1000}
+              value={node.sillThickness}
             />
           </div>
         )}

--- a/packages/editor/src/lib/units.ts
+++ b/packages/editor/src/lib/units.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared unit conversion + formatting helpers for the editor UI.
+ *
+ * Pascal's scene data is ALWAYS stored in metres and square-metres;
+ * the meter/foot preference (`useViewer.unit: 'metric' | 'imperial'`)
+ * is purely a display choice. These helpers convert and format for
+ * presentation — the underlying `updateNode` calls still take metres.
+ *
+ * Keep these in one place so panels/sliders/labels all agree on the
+ * conversion constant (3.28084 ft per metre) and on formatting (label
+ * spacing, decimal places, `²` superscript, etc.). There were already
+ * four separate `formatMeasurement` / `formatArea` functions scattered
+ * across the editor package — this file is the canonical home.
+ */
+
+export const METERS_TO_FEET = 3.280_84
+export const SQ_METERS_TO_SQ_FEET = METERS_TO_FEET * METERS_TO_FEET
+
+export type UnitSystem = 'metric' | 'imperial'
+
+export function metersToFeet(meters: number): number {
+  return meters * METERS_TO_FEET
+}
+
+export function feetToMeters(feet: number): number {
+  return feet / METERS_TO_FEET
+}
+
+export function sqMetersToSqFeet(sqMeters: number): number {
+  return sqMeters * SQ_METERS_TO_SQ_FEET
+}
+
+/**
+ * Format a linear measurement (stored in metres) for display.
+ * Returns `"1.20 m"` or `"3.94 ft"` depending on the user's
+ * preference. `precision` defaults to 2 decimal places.
+ */
+export function formatLength(
+  meters: number,
+  unit: UnitSystem,
+  precision = 2,
+): string {
+  if (unit === 'imperial') {
+    return `${metersToFeet(meters).toFixed(precision)} ft`
+  }
+  return `${meters.toFixed(precision)} m`
+}
+
+/**
+ * Format an area measurement (stored in square metres) for display.
+ * Returns `"10.50 m²"` or `"113.03 ft²"` depending on the preference.
+ */
+export function formatArea(
+  sqMeters: number,
+  unit: UnitSystem,
+  precision = 2,
+): string {
+  if (unit === 'imperial') {
+    return `${sqMetersToSqFeet(sqMeters).toFixed(precision)} ft²`
+  }
+  return `${sqMeters.toFixed(precision)} m²`
+}
+


### PR DESCRIPTION
## What does this PR do?

Two related fixes to the sidebar's length inputs.

### 1. `SliderControl` is unit-aware

`useViewer.unit` (`'metric' | 'imperial'`) already existed and was toggled by the toolbar m/ft button, but the only places that actually respected it were `wall-measurement-label`, `site-edge-labels`, `metric-control`, and the 2D `floorplan-panel`. Every sidebar slider hard-coded `unit="m"` as its suffix and showed raw metres regardless of the user's preference. This PR teaches `SliderControl` to read `useViewer.unit` and, when the caller passes `unit="m"`, convert the value for display + editing while keeping scene data in metres (conversion is display-only). About 70 slider instances across every panel pick up imperial support with **zero call-site changes**.

Sliders with non-`"m"` unit strings (e.g. `"%"`, `"°"`) are unchanged.

### 2. Parent-side `Math.round(...)` clipping removed from panels

Every panel had a `value={Math.round(node.X * 100) / 100}` pattern around its sliders. It was there to defend against floating-point display noise (`2.10000000000000001` → `"2.10"`), but `SliderControl`'s own `.toFixed(precision)` already does that — so the parent rounds were redundant even in metric mode.

With the imperial path landed, the parent rounds became actively harmful. Tracing the door-height `precision={2}` case:

1. User sees `"8.01 ft"` (whatever was stored), types `8.00`, Enter
2. `submitValue` converts: `8 / 3.28084 ≈ 2.43840 m`
3. `onChange(2.43840)` — handler calls `updateNode({ height: 2.43840 })`
4. React re-renders; `door-panel.tsx` passes `value={Math.round(node.height * 100) / 100}` = `2.44`
5. `SliderControl` gets `2.44`, displays `toDisplay(2.44).toFixed(2)` = `(2.44 × 3.28084).toFixed(2)` = `"8.01"`

So typing `8.00` bounced back to `8.01`. Removing the `Math.round` in the parent lets the full-precision metres value survive the round trip, and the display cleanly shows `"8.00"` again.

The `submitValue` path also now rounds in the **display unit** before converting back to metres, so user-typed values preserve their exact precision regardless of which unit is stored underneath.

### New shared helper

`packages/editor/src/lib/units.ts` — `formatLength`, `formatArea`, `metersToFeet`, `feetToMeters`, `METERS_TO_FEET`. The slab + ceiling Info sections now use `formatArea(area, unit)` instead of a hardcoded `"m²"` suffix. Follow-up opportunity (out of scope for this PR): consolidate the four existing ad-hoc copies in `wall-measurement-label.tsx`, `site-edge-labels.tsx`, `metric-control.tsx`, and `floorplan-panel.tsx` onto this new module.

## How to test

1. `bun dev`
2. Click the m/ft toggle in the viewer toolbar.
3. Click a door: every slider suffix should flip from `m` to `ft`, and the numbers should reflect the conversion (2.1 m height shows as 6.89 ft).
4. Type `8.00` into any length slider while in imperial mode, press Enter: value should stay at `8.00 ft` (on `main` it snaps to `8.01 ft`).
5. Flip back to metric: everything returns to metres, no precision loss.
6. Click a slab, check the Info section: area should read `"12.50 m²"` in metric and `"134.55 ft²"` in imperial.

## Screenshots / screen recording

N/A — unit-toggle behaviour, hard to screenshot without video. Will record a short clip if reviewers want one.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (`bun check` passes on the touched files — verified via `biome check` at `@biomejs/biome@^2.4.6`, which is the version pinned in root `package.json`)
- [x] I've updated relevant documentation (N/A — no docs affected)
- [x] This PR targets the `main` branch
