### PR TITLE
fix: prevent crash when duplicating elements

### DIFF
--- a/packages/editor/src/components/editor/floating-action-menu.tsx
+++ b/packages/editor/src/components/editor/floating-action-menu.tsx
@@ -121,6 +121,7 @@ export function FloatingActionMenu() {
           duplicate.start = [duplicate.start[0] + 1, duplicate.start[1] + 1]
           duplicate.end = [duplicate.end[0] + 1, duplicate.end[1] + 1]
         } else if (node.type === 'roof') {
+          duplicateInfo.children = []
           duplicate = RoofNode.parse(duplicateInfo)
         } else if (node.type === 'roof-segment') {
           duplicate = RoofSegmentNode.parse(duplicateInfo)
@@ -134,6 +135,12 @@ export function FloatingActionMenu() {
         }
       } catch (error) {
         console.error('Failed to parse duplicate', error)
+        useScene.temporal.getState().resume()
+        return
+      }
+
+      if (!duplicate) {
+        useScene.temporal.getState().resume()
         return
       }
 

--- a/packages/editor/src/components/editor/selection-manager.tsx
+++ b/packages/editor/src/components/editor/selection-manager.tsx
@@ -919,13 +919,13 @@ const EditorOutlinerSync = () => {
     outliner.selectedObjects.length = 0
     for (const id of idsToHighlight) {
       const obj = sceneRegistry.nodes.get(id)
-      if (obj) outliner.selectedObjects.push(obj)
+      if (obj?.parent) outliner.selectedObjects.push(obj)
     }
 
     outliner.hoveredObjects.length = 0
     if (hoveredId) {
       const obj = sceneRegistry.nodes.get(hoveredId)
-      if (obj) outliner.hoveredObjects.push(obj)
+      if (obj?.parent) outliner.hoveredObjects.push(obj)
     }
   }, [phase, previewSelectedIds, selection, hoveredId, outliner])
 

--- a/packages/viewer/src/lib/merged-outline-node.ts
+++ b/packages/viewer/src/lib/merged-outline-node.ts
@@ -600,9 +600,14 @@ export class MergedOutlineNode extends TempNode {
 
   private _buildCache(objects: Object3D[], cache: Set<Object3D>) {
     for (const obj of objects) {
-      obj.traverse((child: any) => {
-        if (child.isMesh || child.isSprite) cache.add(child)
-      })
+      if (!obj || !obj.traverse) continue
+      try {
+        obj.traverse((child: any) => {
+          if (child.isMesh || child.isSprite) cache.add(child)
+        })
+      } catch {
+        // Skip objects that were disposed or removed from the scene graph
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Guard `_buildCache` in `merged-outline-node` against stale/disposed Object3D refs that cause `TypeError: Cannot read properties of undefined (reading 'id')` during WebGPU render pass
- Reset `children` array when duplicating roofs to prevent inconsistent parent-child relationships (matching existing stair duplication behavior)
- Use `obj?.parent` check in `EditorOutlinerSync` to ensure objects removed from the scene graph don't reach the outline pass
- Resume `temporal` state on parse failure to prevent permanent undo/redo freeze

Closes #232

## Root cause
The crash occurs due to a race condition between the post-processing render pipeline and the outliner sync. When duplication modifies the scene, renderer components may unmount/remount, leaving stale `Object3D` references in the outliner arrays. The `MergedOutlineNode._buildCache()` then calls `.traverse()` on these stale refs, and the WebGPU pipeline crashes accessing `.id` on disposed internals.

## Test plan
- [x] Duplicate an item (select → click copy icon) — no crash
- [x] Duplicate a door/window on a wall — no crash
- [x] Duplicate a roof — children are independent from original
- [x] Cancel a failed duplicate — undo/redo still works
- [x] Existing selection outlines and hover highlights still work