### PR TITLE
feat(viewer): configurable walkthrough FOV with slider overlay

### DIFF
--- a/packages/editor/src/components/editor/first-person-controls.tsx
+++ b/packages/editor/src/components/editor/first-person-controls.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { WalkthroughFovSlider } from '@pascal-app/viewer'
 import { useFrame, useThree } from '@react-three/fiber'
 import { useCallback, useEffect, useRef } from 'react'
 import { Euler, Vector3 } from 'three'
@@ -224,6 +225,10 @@ export const FirstPersonOverlay = ({ onExit }: { onExit: () => void }) => {
           <span className="text-muted-foreground/60 text-xs">Click to look around</span>
         </div>
       </div>
+
+      {/* FOV slider — bottom-right. Only visible during walkthrough,
+          component handles its own gate on walkthroughMode. */}
+      <WalkthroughFovSlider />
     </>
   )
 }

--- a/packages/editor/src/store/use-editor.tsx
+++ b/packages/editor/src/store/use-editor.tsx
@@ -477,6 +477,13 @@ const useEditor = create<EditorState>()(
           const currentViewMode = get().viewMode
           useViewer.getState().setCameraMode('perspective')
           useViewer.getState().setWallMode('up')
+          // Mirror the flag into the viewer store so viewer-side
+          // reactive visuals (wider FOV in viewer-camera.tsx, any
+          // future first-person-only overlays) pick it up. Safe
+          // because custom-camera-controls.tsx early-returns on
+          // isFirstPersonMode *before* mounting WalkthroughControls,
+          // so there's no pointer-lock conflict.
+          useViewer.getState().setWalkthroughMode(true)
           set({
             isFirstPersonMode: true,
             _viewModeBeforeFirstPerson: currentViewMode,
@@ -489,6 +496,7 @@ const useEditor = create<EditorState>()(
           useViewer.getState().setSelection({ selectedIds: [], zoneId: null })
         } else {
           const prevMode = get()._viewModeBeforeFirstPerson
+          useViewer.getState().setWalkthroughMode(false)
           set({
             isFirstPersonMode: false,
             _viewModeBeforeFirstPerson: null,

--- a/packages/viewer/src/components/viewer/viewer-camera.tsx
+++ b/packages/viewer/src/components/viewer/viewer-camera.tsx
@@ -1,11 +1,25 @@
 import { OrthographicCamera, PerspectiveCamera } from '@react-three/drei'
 import useViewer from '../../store/use-viewer'
 
+// Orbit FOV — a photographic ~50° framing used for the default
+// outside-looking-in view. Walkthrough FOV lives in useViewer state
+// (walkthroughFov) because it's user-adjustable at runtime via the
+// WalkthroughFovSlider.
+const ORBIT_FOV = 50
+
 export const ViewerCamera = () => {
   const cameraMode = useViewer((state) => state.cameraMode)
+  const walkthroughMode = useViewer((state) => state.walkthroughMode)
+  const walkthroughFov = useViewer((state) => state.walkthroughFov)
 
   return cameraMode === 'perspective' ? (
-    <PerspectiveCamera far={1000} fov={50} makeDefault near={0.1} position={[10, 10, 10]} />
+    <PerspectiveCamera
+      far={1000}
+      fov={walkthroughMode ? walkthroughFov : ORBIT_FOV}
+      makeDefault
+      near={0.1}
+      position={[10, 10, 10]}
+    />
   ) : (
     <OrthographicCamera far={1000} makeDefault near={-1000} position={[10, 10, 10]} zoom={20} />
   )

--- a/packages/viewer/src/components/viewer/walkthrough-fov-slider.tsx
+++ b/packages/viewer/src/components/viewer/walkthrough-fov-slider.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import useViewer from '../../store/use-viewer'
+
+/**
+ * Standalone DOM overlay slider that controls the walkthrough FOV via
+ * `useViewer.walkthroughFov`. Renders nothing when `walkthroughMode` is
+ * off so consumers can mount it unconditionally alongside their
+ * walkthrough UI. Styled with plain inline CSS + a class name so it
+ * works in any host app without needing Tailwind, shadcn, or the
+ * editor's design tokens — important because this lives in the viewer
+ * package and has to stay editor-agnostic.
+ *
+ * Range is 50–110° with 1° steps. Below 50° first-person feels like a
+ * sniper scope; above 110° the near-wall fisheye distortion becomes
+ * intolerable. Both bounds are also enforced by `setWalkthroughFov`.
+ *
+ * Default position is bottom-right. Override via the `className` prop
+ * if the host wants to place it elsewhere — the slider adapts to its
+ * container since there's no fixed positioning baked in.
+ */
+export function WalkthroughFovSlider({ className }: { className?: string }) {
+  const walkthroughMode = useViewer((s) => s.walkthroughMode)
+  const walkthroughFov = useViewer((s) => s.walkthroughFov)
+  const setWalkthroughFov = useViewer((s) => s.setWalkthroughFov)
+
+  if (!walkthroughMode) return null
+
+  return (
+    <div
+      className={className}
+      style={
+        className
+          ? undefined
+          : {
+              position: 'fixed',
+              bottom: '1.5rem',
+              right: '1.5rem',
+              zIndex: 50,
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.625rem',
+              padding: '0.625rem 0.875rem',
+              borderRadius: '0.75rem',
+              background: 'rgba(0, 0, 0, 0.65)',
+              backdropFilter: 'blur(12px)',
+              color: 'white',
+              fontSize: '0.75rem',
+              fontFamily: 'system-ui, sans-serif',
+              boxShadow: '0 4px 20px rgba(0, 0, 0, 0.25)',
+              pointerEvents: 'auto',
+            }
+      }
+    >
+      <span style={{ opacity: 0.7, fontWeight: 500 }}>FOV</span>
+      <input
+        type="range"
+        min={50}
+        max={110}
+        step={1}
+        value={walkthroughFov}
+        onChange={(e) => setWalkthroughFov(Number(e.target.value))}
+        style={{ width: '8rem', accentColor: '#8b5cf6' }}
+      />
+      <span
+        style={{
+          minWidth: '2.5rem',
+          textAlign: 'right',
+          fontVariantNumeric: 'tabular-nums',
+          fontWeight: 600,
+        }}
+      >
+        {walkthroughFov}°
+      </span>
+    </div>
+  )
+}

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -1,6 +1,7 @@
 export { default as Viewer } from './components/viewer'
 export { SSGI_PARAMS } from './components/viewer/post-processing'
 export { WalkthroughControls } from './components/viewer/walkthrough-controls'
+export { WalkthroughFovSlider } from './components/viewer/walkthrough-fov-slider'
 export { ASSETS_CDN_URL, resolveAssetUrl, resolveCdnUrl } from './lib/asset-url'
 export { SCENE_LAYER, ZONE_LAYER } from './lib/layers'
 export {

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -74,6 +74,16 @@ type ViewerState = {
   walkthroughMode: boolean
   setWalkthroughMode: (mode: boolean) => void
 
+  /**
+   * FOV in degrees used by the perspective camera while `walkthroughMode`
+   * is active. Defaults to 85° (standard FPS-ish). 50° orbit FOV feels
+   * telephoto when you're standing inside the scene, so walkthrough gets
+   * its own setting. Persisted so users' preferred FOV sticks across
+   * sessions.
+   */
+  walkthroughFov: number
+  setWalkthroughFov: (fov: number) => void
+
   cameraDragging: boolean
   setCameraDragging: (dragging: boolean) => void
 }
@@ -200,6 +210,12 @@ const useViewer = create<ViewerState>()(
       walkthroughMode: false,
       setWalkthroughMode: (mode) => set({ walkthroughMode: mode }),
 
+      walkthroughFov: 85,
+      setWalkthroughFov: (fov) =>
+        // Clamp to a sane range. Below ~50 it feels sniper-scope; above
+        // ~110 the near-wall distortion is intolerable.
+        set({ walkthroughFov: Math.max(50, Math.min(110, fov)) }),
+
       cameraDragging: false,
       setCameraDragging: (dragging) => set({ cameraDragging: dragging }),
     }),
@@ -212,6 +228,7 @@ const useViewer = create<ViewerState>()(
         levelMode: state.levelMode,
         wallMode: state.wallMode,
         projectPreferences: state.projectPreferences,
+        walkthroughFov: state.walkthroughFov,
       }),
     },
   ),


### PR DESCRIPTION
## Problem

`packages/viewer/src/components/viewer/viewer-camera.tsx` hardcodes `fov={50}` on the perspective camera. That framing is photogenic for outside-looking-in orbit views, but feels telephoto once the user enters walkthrough mode — standing inside a typical room the scene reads as a narrow viewport instead of a walkable space, and peripheral context disappears as soon as you start moving with WASD. There was no way to adjust it without editing the source.

## Fix

Add a `walkthroughFov` setting on `useViewer` (default 85°, clamped 50–110° by the setter, persisted under the existing `viewer-preferences` key). `ViewerCamera` reads it and swaps the perspective camera's FOV while `walkthroughMode` is true, reverting to the 50° orbit framing when walkthrough exits.

85° is in the standard FPS range (Quake/CS ≈ 90°, Valorant 103°) without the near-wall fisheye distortion wider values produce. The clamp in the setter keeps values from drifting into sniper-scope territory on the low end or unusable fisheye on the high end.

A new `<WalkthroughFovSlider />` component exported from `@pascal-app/viewer` provides runtime adjustment:

- Self-gates on `walkthroughMode` (returns `null` otherwise), so consumers can mount it unconditionally alongside their walkthrough UI without their own visibility checks
- Plain inline styles with a violet-500 accent to match the editor palette — no Tailwind / shadcn / design-token dependencies, because the viewer package has to stay editor-agnostic and work in any host app
- Renders bottom-right by default, overridable via `className`

The editor's `FirstPersonOverlay` now mounts the slider alongside the existing crosshair and controls hint.

### Shared walkthrough state

One small coupling: `setFirstPersonMode` in `packages/editor/src/store/use-editor.tsx` now mirrors its flag into `useViewer.walkthroughMode`. The editor and viewer each had their own walkthrough state — `isFirstPersonMode` in `useEditor`, `walkthroughMode` in `useViewer` — and the desktop editor's walkthrough button only flipped the editor-side flag. Without the mirror, the FOV conditional in `viewer-camera.tsx` never tripped on \`/edit/[id]\` because `walkthroughMode` stayed false the whole time.

Safe because `custom-camera-controls.tsx` already early-returns on `isFirstPersonMode` before it would mount `WalkthroughControls`, so there's no pointer-lock conflict between `FirstPersonControls` and `WalkthroughControls`.

## Scope

- **Perspective camera + walkthrough**: new behaviour, wider FOV and a slider.
- **Perspective camera + orbit**: unchanged (still 50°).
- **Orthographic camera**: unchanged — ortho has no FOV concept.
- **Read-only `/viewer/[id]` path**: the slider is opt-in via the exported component, so consumers that don't mount it see no visual or behavioural difference.

## How to test

1. `bun dev`, open \`/edit/[id]\` on an existing scene.
2. Click the desktop editor's walkthrough toggle: the FOV should widen to 85° and the slider should appear bottom-right.
3. Drag the slider between 50° and 110°: the camera FOV should update live.
4. Exit walkthrough: FOV reverts to 50° orbit framing.
5. Reload the page: last-used FOV persists (stored in \`localStorage\` under \`viewer-preferences\`).
6. Try setting the FOV below 50 or above 110 programmatically: the setter clamps silently.
7. `bun check`, `bun check-types`, `bun run build` all clean on the touched packages.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (`bun check` passes on the touched files — verified via `biome check` at `@biomejs/biome@^2.4.6`)
- [x] I've updated relevant documentation (N/A — no docs affected)
- [x] This PR targets the `main` branch