### PR TITLE
fix: scene robustness (remount, empty geometry, asset URLs, first-person camera)

### DIFF
--- a/packages/core/src/systems/wall/wall-system.tsx
+++ b/packages/core/src/systems/wall/wall-system.tsx
@@ -7,15 +7,15 @@ import { spatialGridManager } from '../../hooks/spatial-grid/spatial-grid-manage
 import { resolveLevelId } from '../../hooks/spatial-grid/spatial-grid-sync'
 import type { AnyNode, AnyNodeId, WallNode } from '../../schema'
 import useScene from '../../store/use-scene'
-import { DEFAULT_WALL_HEIGHT, getWallPlanFootprint, getWallThickness } from './wall-footprint'
 import { getWallCurveFrameAt, getWallSurfacePolygon, isCurvedWall } from './wall-curve'
+import { DEFAULT_WALL_HEIGHT, getWallPlanFootprint, getWallThickness } from './wall-footprint'
 import {
   calculateLevelMiters,
   getAdjacentWallIds,
   getWallMiterBoundaryPoints,
   type Point2D,
-  type WallMiterData,
   pointToKey,
+  type WallMiterData,
 } from './wall-mitering'
 
 // Reusable CSG evaluator for better performance
@@ -181,14 +181,32 @@ function updateWallGeometry(wallId: string, miterData: WallMiterData) {
 
   const newGeo = generateExtrudedWall(node, childrenNodes, miterData, slabElevation)
 
+  // Defensive: if the wall collapsed to zero length (bad data, or a
+  // cluster pass that over-merged short walls), `generateExtrudedWall`
+  // returns an empty BufferGeometry with no position attribute. The
+  // WebGPU renderer crashes reading `.count` on undefined, so hide the
+  // mesh instead of assigning the empty geometry. The wall stays in
+  // the scene graph (so Ctrl+Z can still recover it) but draws
+  // nothing until the start/end become valid again.
+  if (!newGeo.attributes.position) {
+    newGeo.dispose()
+    mesh.visible = false
+    return
+  }
+  mesh.visible = node.visible ?? true
+
   mesh.geometry.dispose()
   mesh.geometry = newGeo
   // Update collision mesh
   const collisionMesh = mesh.getObjectByName('collision-mesh') as THREE.Mesh
   if (collisionMesh) {
     const collisionGeo = generateExtrudedWall(node, [], miterData, slabElevation)
-    collisionMesh.geometry.dispose()
-    collisionMesh.geometry = collisionGeo
+    if (collisionGeo.attributes.position) {
+      collisionMesh.geometry.dispose()
+      collisionMesh.geometry = collisionGeo
+    } else {
+      collisionGeo.dispose()
+    }
   }
 
   mesh.position.set(node.start[0], slabElevation, node.start[1])

--- a/packages/editor/src/components/editor/custom-camera-controls.tsx
+++ b/packages/editor/src/components/editor/custom-camera-controls.tsx
@@ -22,6 +22,7 @@ const DEBUG_MAX_POLAR_ANGLE = Math.PI - 0.05
 export const CustomCameraControls = () => {
   const controls = useRef<CameraControlsImpl>(null!)
   const isPreviewMode = useEditor((s) => s.isPreviewMode)
+  const isFirstPersonMode = useEditor((s) => s.isFirstPersonMode)
   const walkthroughMode = useViewer((s) => s.walkthroughMode)
   const allowUndergroundCamera = useEditor((s) => s.allowUndergroundCamera)
   const selection = useViewer((s) => s.selection)
@@ -364,6 +365,17 @@ export const CustomCameraControls = () => {
   const onRest = useCallback(() => {
     useViewer.getState().setCameraDragging(false)
   }, [])
+
+  // The editor's first-person mode is driven by <FirstPersonControls />
+  // (mounted as a sibling in editor/index.tsx via isFirstPersonMode).
+  // It takes over the camera with pointer lock + WASD, so we must
+  // return null here — otherwise drei's CameraControls runs in parallel
+  // and fights FirstPersonControls for the camera, which is exactly why
+  // the "walkthrough" button on desktop appeared to do nothing (the
+  // user saw orbit behaviour because CameraControls was still winning).
+  if (isFirstPersonMode) {
+    return null
+  }
 
   if (walkthroughMode) {
     return <WalkthroughControls />

--- a/packages/viewer/src/components/renderers/ceiling/ceiling-renderer.tsx
+++ b/packages/viewer/src/components/renderers/ceiling/ceiling-renderer.tsx
@@ -1,5 +1,11 @@
-import { type CeilingNode, getMaterialPresetByRef, resolveMaterial, useRegistry } from '@pascal-app/core'
-import { useMemo, useRef } from 'react'
+import {
+  type CeilingNode,
+  getMaterialPresetByRef,
+  resolveMaterial,
+  useRegistry,
+  useScene,
+} from '@pascal-app/core'
+import { useLayoutEffect, useMemo, useRef } from 'react'
 import { float, mix, positionWorld, smoothstep } from 'three/tsl'
 import { BackSide, FrontSide, type Mesh, MeshBasicNodeMaterial } from 'three/webgpu'
 import { useNodeEvents } from '../../../hooks/use-node-events'
@@ -38,12 +44,26 @@ export const CeilingRenderer = ({ node }: { node: CeilingNode }) => {
   useRegistry(node.id, 'ceiling', ref)
   const handlers = useNodeEvents(node, 'ceiling')
 
+  // Mark dirty on mount so CeilingSystem regenerates the polygon
+  // geometry after a <Viewer> remount. Without this the placeholder
+  // zero-size box persists and the ceiling disappears. See
+  // WallRenderer for the same pattern.
+  useLayoutEffect(() => {
+    useScene.getState().markDirty(node.id)
+  }, [node.id])
+
   const materials = useMemo(() => {
     const preset = getMaterialPresetByRef(node.materialPreset)
     const props = preset?.mapProperties ?? resolveMaterial(node.material)
     const color = props.color || '#999999'
     return createCeilingMaterials(color)
-  }, [node.materialPreset, node.material, node.material?.preset, node.material?.properties, node.material?.texture])
+  }, [
+    node.materialPreset,
+    node.material,
+    node.material?.preset,
+    node.material?.properties,
+    node.material?.texture,
+  ])
 
   return (
     <mesh material={materials.bottomMaterial} ref={ref}>

--- a/packages/viewer/src/components/renderers/door/door-renderer.tsx
+++ b/packages/viewer/src/components/renderers/door/door-renderer.tsx
@@ -1,5 +1,5 @@
-import { type DoorNode, useRegistry } from '@pascal-app/core'
-import { useMemo, useRef } from 'react'
+import { type DoorNode, useRegistry, useScene } from '@pascal-app/core'
+import { useLayoutEffect, useMemo, useRef } from 'react'
 import type { Mesh } from 'three'
 import { useNodeEvents } from '../../../hooks/use-node-events'
 import { createMaterial, DEFAULT_DOOR_MATERIAL } from '../../../lib/materials'
@@ -10,6 +10,16 @@ export const DoorRenderer = ({ node }: { node: DoorNode }) => {
   useRegistry(node.id, 'door', ref)
   const handlers = useNodeEvents(node, 'door')
   const isTransient = !!(node.metadata as Record<string, unknown> | null)?.isTransient
+
+  // Mark this node dirty on mount so DoorSystem regenerates its
+  // geometry on the next frame. Without this, the DoorRenderer keeps
+  // its zero-size placeholder box forever whenever the <Viewer>
+  // remounts (e.g. entering preview mode, switching view modes), and
+  // the door visually disappears — DoorSystem only processes nodes in
+  // the dirtyNodes set. See WallRenderer for the same pattern.
+  useLayoutEffect(() => {
+    useScene.getState().markDirty(node.id)
+  }, [node.id])
 
   const material = useMemo(() => {
     const mat = node.material

--- a/packages/viewer/src/components/renderers/item/item-renderer.tsx
+++ b/packages/viewer/src/components/renderers/item/item-renderer.tsx
@@ -48,13 +48,40 @@ export const ItemRenderer = ({ node }: { node: ItemNode }) => {
 
   useRegistry(node.id, node.type, ref)
 
+  // Pick a render path based on whether the item has a loadable model.
+  //
+  // - Items with a resolvable `asset.src` → load the GLTF via useGLTF,
+  //   show the animated `PreviewModel` as the Suspense fallback while
+  //   the model downloads.
+  //
+  // - Items without a resolvable src (e.g. scanned furniture from
+  //   RoomPlan that ships with a `placeholder` asset and no URL) →
+  //   render `PlaceholderBox` instead. This is a SOLID opaque box, NOT
+  //   the animated preview material. Using PreviewModel as a
+  //   permanent render looks broken: it has `depthTest: false` and an
+  //   animated time-based opacity, so it renders on top of walls and
+  //   pulses, which is what the "flashing / see-through furniture"
+  //   bug report turned out to be.
+  //
+  // Also guards `useGLTF('')` — when `resolveCdnUrl` returned null
+  // (e.g. for `asset://` URLs) the empty-string fallback resolved to
+  // the current page URL, got HTML back, and crashed GLTFLoader's JSON
+  // parser with an unrecoverable error that Suspense refused to
+  // retry (re-throwing the cached promise every render).
+  const src = node.asset.src
+  const resolvedUrl = src ? resolveCdnUrl(src) : null
+
   return (
     <group position={node.position} ref={ref} rotation={node.rotation} visible={node.visible}>
-      <ErrorBoundary fallback={<BrokenItemFallback node={node} />}>
-        <Suspense fallback={<PreviewModel node={node} />}>
-          <ModelRenderer node={node} />
-        </Suspense>
-      </ErrorBoundary>
+      {resolvedUrl ? (
+        <ErrorBoundary fallback={<BrokenItemFallback node={node} />}>
+          <Suspense fallback={<PreviewModel node={node} />}>
+            <ModelRenderer modelUrl={resolvedUrl} node={node} />
+          </Suspense>
+        </ErrorBoundary>
+      ) : (
+        <PlaceholderBox node={node} />
+      )}
       {node.children?.map((childId) => (
         <NodeRenderer key={childId} nodeId={childId} />
       ))}
@@ -84,13 +111,33 @@ const PreviewModel = ({ node }: { node: ItemNode }) => {
   )
 }
 
+// Opaque stand-in for items that have no GLTF model to load. Unlike
+// `previewMaterial`, this one has normal depth testing and no animated
+// transparency, so scanned furniture renders as plain grey boxes that
+// sit behind walls correctly instead of pulsing through them.
+const placeholderMaterial = new MeshStandardNodeMaterial({
+  color: '#a8adb3',
+  roughness: 0.75,
+  metalness: 0.05,
+})
+
+const PlaceholderBox = ({ node }: { node: ItemNode }) => {
+  const handlers = useNodeEvents(node, 'item')
+  const [w, h, d] = node.asset.dimensions
+  return (
+    <mesh castShadow material={placeholderMaterial} position-y={h / 2} receiveShadow {...handlers}>
+      <boxGeometry args={[w, h, d]} />
+    </mesh>
+  )
+}
+
 const multiplyScales = (
   a: [number, number, number],
   b: [number, number, number],
 ): [number, number, number] => [a[0] * b[0], a[1] * b[1], a[2] * b[2]]
 
-const ModelRenderer = ({ node }: { node: ItemNode }) => {
-  const { scene, nodes, animations } = useGLTF(resolveCdnUrl(node.asset.src) || '')
+const ModelRenderer = ({ modelUrl, node }: { modelUrl: string; node: ItemNode }) => {
+  const { scene, nodes, animations } = useGLTF(modelUrl)
   const ref = useRef<Group>(null!)
   const { actions } = useAnimations(animations, ref)
   // Freeze the interactive definition at mount — asset schemas don't change at runtime

--- a/packages/viewer/src/components/renderers/slab/slab-renderer.tsx
+++ b/packages/viewer/src/components/renderers/slab/slab-renderer.tsx
@@ -1,7 +1,7 @@
-import { type SlabNode, useRegistry } from '@pascal-app/core'
-import { useEffect, useMemo, useRef } from 'react'
-import * as THREE from 'three'
+import { type SlabNode, useRegistry, useScene } from '@pascal-app/core'
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import type { Mesh } from 'three'
+import * as THREE from 'three'
 import { useNodeEvents } from '../../../hooks/use-node-events'
 import {
   createMaterial,
@@ -16,9 +16,17 @@ export const SlabRenderer = ({ node }: { node: SlabNode }) => {
 
   const handlers = useNodeEvents(node, 'slab')
 
+  // Mark dirty on mount so SlabSystem regenerates the polygon geometry
+  // after a <Viewer> remount (preview mode, view mode switches).
+  // Otherwise the zero-size placeholder persists. See WallRenderer.
+  useLayoutEffect(() => {
+    useScene.getState().markDirty(node.id)
+  }, [node.id])
+
   const material = useMemo(() => {
     const presetMaterial = createMaterialFromPresetRef(node.materialPreset)
-    const sourceMaterial = presetMaterial ?? (node.material ? createMaterial(node.material) : DEFAULT_SLAB_MATERIAL)
+    const sourceMaterial =
+      presetMaterial ?? (node.material ? createMaterial(node.material) : DEFAULT_SLAB_MATERIAL)
     const slabMaterial = sourceMaterial.clone()
 
     // Slabs participate in the WebGPU MRT scene pass. Keeping them opaque avoids

--- a/packages/viewer/src/components/renderers/window/window-renderer.tsx
+++ b/packages/viewer/src/components/renderers/window/window-renderer.tsx
@@ -1,5 +1,5 @@
-import { useRegistry, type WindowNode } from '@pascal-app/core'
-import { useMemo, useRef } from 'react'
+import { useRegistry, useScene, type WindowNode } from '@pascal-app/core'
+import { useLayoutEffect, useMemo, useRef } from 'react'
 import type { Mesh } from 'three'
 import { useNodeEvents } from '../../../hooks/use-node-events'
 import { createMaterial, DEFAULT_WINDOW_MATERIAL } from '../../../lib/materials'
@@ -10,6 +10,15 @@ export const WindowRenderer = ({ node }: { node: WindowNode }) => {
   useRegistry(node.id, 'window', ref)
   const handlers = useNodeEvents(node, 'window')
   const isTransient = !!(node.metadata as Record<string, unknown> | null)?.isTransient
+
+  // Mark dirty on mount so WindowSystem regenerates the geometry when
+  // the <Viewer> component remounts (entering preview mode, view mode
+  // switches, etc.). Without this, the placeholder zero-size box
+  // persists forever because WindowSystem only walks dirtyNodes. Same
+  // pattern as WallRenderer.
+  useLayoutEffect(() => {
+    useScene.getState().markDirty(node.id)
+  }, [node.id])
 
   const material = useMemo(() => {
     const mat = node.material


### PR DESCRIPTION
## What does this PR do?

A bundle of four small, defensive fixes to the viewer and editor that I hit while stress-testing various scene workflows in Pascal. Each is self-contained — happy to split this into four separate PRs if reviewers prefer, just let me know.

> **Note:** This supersedes #235, which was opened against an older base and became unmergeable after #231 (catalog-based material presets) and #236 (curved walls) landed on main and rewrote adjacent code in \`wall-system.tsx\`, \`slab-renderer.tsx\`, and \`ceiling-renderer.tsx\`. Same four fixes, reapplied cleanly on top of current main. Closing #235 in favour of this.

### 1. Renderer \`markDirty\` on \`<Viewer>\` remount (door / window / slab / ceiling)

When \`<Viewer>\` unmounts and remounts (preview mode toggle, view-mode switch, split-view toggle, etc.), these four renderers get stuck with their \`<boxGeometry args={[0, 0, 0]}>\` placeholder forever:

1. Renderer mounts, registers via \`useRegistry\`, renders the zero-size placeholder.
2. The corresponding system (DoorSystem, WindowSystem, SlabSystem, CeilingSystem) only processes nodes in \`useScene.dirtyNodes\`.
3. On remount the dirty set is empty — no one re-added the node after the previous unmount — so the system never regenerates the real geometry.
4. The renderer keeps the 0×0×0 placeholder until the user edits the node manually.

\`WallRenderer\` already handles this with a \`useLayoutEffect\` that marks its own node dirty on mount. This PR applies the same pattern to the four other renderers.

### 2. Defensive empty-geometry guard in \`WallSystem\`

When \`generateExtrudedWall\` returns an empty \`BufferGeometry\` (wall \`start === end\`, or a pathological mitering input), the previous \`updateWallGeometry\` assigned it to \`mesh.geometry\`, and the WebGPU renderer crashed in its next draw reading \`.count\` on \`geometry.attributes.position\` (undefined). Now we dispose the empty geometry, hide the mesh, and return early. The wall stays in the scene graph so Ctrl+Z can recover it.

### 3. \`ItemRenderer\`: guard \`useGLTF\` from empty URL + opaque placeholder

Two related issues:

- \`useGLTF(resolveCdnUrl(node.asset.src) || '')\` fell back to the empty string when \`resolveCdnUrl\` returned null (e.g. for \`asset://\` URLs, which need the async \`resolveAssetUrl\`). \`useGLTF('')\` resolves to the current page URL, gets HTML back, and GLTFLoader's JSON parser crashes with an unrecoverable error that Suspense refuses to retry (re-throwing the cached promise each render). Now we short-circuit on an unresolvable URL and render a solid placeholder instead.
- The \`PreviewModel\` Suspense fallback uses a material with \`depthTest: false\` and an animated time-based \`opacityNode\`. When it was used as the *permanent* render for items with no GLTF at all, the furniture pulsed and rendered through walls. Added a dedicated \`PlaceholderBox\` with a solid opaque \`MeshStandardNodeMaterial\` so item nodes without a model look like plain grey boxes that respect depth correctly.

### 4. \`CustomCameraControls\` returns null during editor first-person mode

\`isFirstPersonMode\` in \`useEditor\` mounts \`<FirstPersonControls />\` (pointer lock + WASD) as a sibling inside the viewer, but \`CustomCameraControls\` was still rendering drei's \`<CameraControls>\` alongside it because it only bailed on \`walkthroughMode\` (the viewer-package state, which the editor button doesn't flip). Two controllers fighting for the same camera meant the "walkthrough" button on desktop appeared to do nothing. Now \`CustomCameraControls\` returns \`null\` when \`isFirstPersonMode === true\`, leaving \`FirstPersonControls\` as the only camera driver.

## How to test

1. \`bun dev\`, open any scene with walls, doors, windows, slabs, and ceilings.
2. **Renderer remount fix:** toggle preview mode on and off, or swap between 3D / 2D / split view modes. Every element should remain visible. On \`main\`, doors / windows / slabs / ceilings vanish until you touch them.
3. **Wall empty-geometry guard:** defensive; not easily reachable via the UI (would need a wall with \`start === end\`). Exercised by manually calling \`updateNode\` on a wall to make its \`end\` equal to its \`start\` — the mesh hides instead of crashing the scene.
4. **Item empty-URL guard:** defensive; exercised by an \`ItemNode\` whose \`asset.src\` is \`undefined\` or \`asset://…\`. Instead of crashing on the HTML-is-not-JSON error, the item renders as a plain grey box that respects depth and sits correctly behind walls.
5. **First-person camera fix:** click the walkthrough / first-person button in the viewer toolbar on desktop; the camera should drop to eye height and WASD + mouse look should work. On \`main\`, the camera stays in orbit mode because drei's \`CameraControls\` is still winning the race with \`FirstPersonControls\`.

## Screenshots / screen recording

N/A — all four are regression / defensive fixes, most visible as "things that used to disappear or crash on \`main\` now don't."

## Checklist

- [x] I've tested this locally with \`bun dev\`
- [x] My code follows the existing code style (\`bun check\` passes on the touched files — verified via \`biome check\` at \`@biomejs/biome@^2.4.6\` matching the repo's version)
- [x] I've updated relevant documentation (N/A — no docs affected)
- [x] This PR targets the \`main\` branch