### PR TITLE
docs: fix stale folder name editor-v2 and add missing ui package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ https://github.com/user-attachments/assets/8b50e7cf-cebe-4579-9cf3-8786b35f7b6b
 This is a Turborepo monorepo with three main packages:
 
 ```
-editor-v2/
+editor/
 ├── apps/
 │   └── editor/          # Next.js application
 ├── packages/
 │   ├── core/            # Schema definitions, state management, systems
-│   └── viewer/          # 3D rendering components
+│   ├── viewer/          # 3D rendering components
+│   └── ui/              # Shared UI components
 ```
 
 ### Separation of Concerns


### PR DESCRIPTION
Closes #244

## Changes
- Fixed the root folder label in the Repository Architecture diagram from `editor-v2/` to `editor/`
- Added the missing `ui/` package to the diagram (it exists in the repo but was absent from README)

Both `SETUP.md` and `CONTRIBUTING.md` already use `editor/` correctly. This brings `README.md` into alignment.

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>