### PR TITLE
fix(viewer): preserve GLTF materials in ItemRenderer

### DIFF
--- a/packages/viewer/src/components/renderers/item/item-renderer.tsx
+++ b/packages/viewer/src/components/renderers/item/item-renderer.tsx
@@ -1,7 +1,6 @@
 import {
   type AnimationEffect,
   type AnyNodeId,
-  baseMaterial,
   glassMaterial,
   type Interactive,
   type ItemNode,
@@ -15,7 +14,7 @@ import { Clone } from '@react-three/drei/core/Clone'
 import { useGLTF } from '@react-three/drei/core/Gltf'
 import { useFrame } from '@react-three/fiber'
 import { Suspense, useEffect, useMemo, useRef } from 'react'
-import type { AnimationAction, Group, Material, Mesh } from 'three'
+import type { AnimationAction, Group, Material, Mesh, MeshStandardMaterial } from 'three'
 import { MathUtils } from 'three'
 import { positionLocal, smoothstep, time } from 'three/tsl'
 import { MeshStandardNodeMaterial } from 'three/webgpu'
@@ -25,11 +24,53 @@ import { useItemLightPool } from '../../../store/use-item-light-pool'
 import { ErrorBoundary } from '../../error-boundary'
 import { NodeRenderer } from '../node-renderer'
 
+const convertedMaterialCache = new WeakMap<Material, MeshStandardNodeMaterial>()
+
+/**
+ * Convert a GLTF's `MeshStandardMaterial` to `MeshStandardNodeMaterial`
+ * while preserving color, textures, and PBR properties. The previous
+ * implementation returned a single shared `baseMaterial` for every mesh,
+ * wiping out all material information and leaving every loaded GLTF as
+ * a uniform cream-coloured blob.
+ */
 const getMaterialForOriginal = (original: Material): MeshStandardNodeMaterial => {
   if (original.name.toLowerCase() === 'glass') {
     return glassMaterial
   }
-  return baseMaterial
+
+  if ((original as { isMeshStandardNodeMaterial?: boolean }).isMeshStandardNodeMaterial) {
+    return original as MeshStandardNodeMaterial
+  }
+
+  const cached = convertedMaterialCache.get(original)
+  if (cached) return cached
+
+  const std = original as MeshStandardMaterial
+
+  const nodeMat = new MeshStandardNodeMaterial()
+  nodeMat.name = std.name
+  nodeMat.color.copy(std.color)
+  if (std.roughness !== undefined) nodeMat.roughness = std.roughness
+  if (std.metalness !== undefined) nodeMat.metalness = std.metalness
+  if (std.emissive) nodeMat.emissive.copy(std.emissive)
+  if (std.emissiveIntensity !== undefined) nodeMat.emissiveIntensity = std.emissiveIntensity
+  nodeMat.opacity = std.opacity
+  nodeMat.transparent = std.transparent
+  nodeMat.alphaTest = std.alphaTest
+  nodeMat.side = std.side
+  nodeMat.vertexColors = std.vertexColors
+  nodeMat.map = std.map
+  nodeMat.normalMap = std.normalMap
+  if (std.normalScale) nodeMat.normalScale.copy(std.normalScale)
+  nodeMat.roughnessMap = std.roughnessMap
+  nodeMat.metalnessMap = std.metalnessMap
+  nodeMat.emissiveMap = std.emissiveMap
+  nodeMat.aoMap = std.aoMap
+  nodeMat.aoMapIntensity = std.aoMapIntensity
+  nodeMat.alphaMap = std.alphaMap
+
+  convertedMaterialCache.set(original, nodeMat)
+  return nodeMat
 }
 
 const BrokenItemFallback = ({ node }: { node: ItemNode }) => {


### PR DESCRIPTION
## Problem

\`getMaterialForOriginal\` in \`ItemRenderer\` returns \`baseMaterial\` (\`#f2f0ed\`, roughness 0.5) for every mesh regardless of its source material. The GLTF's original colors, textures, PBR properties, and per-mesh material variation are all thrown away — every loaded model renders as a uniform cream-coloured shape with no visual distinction between parts.

The intent was to convert regular \`MeshStandardMaterial\` (from GLTFLoader) to \`MeshStandardNodeMaterial\` (required by the WebGPU/TSL pipeline). The implementation just returned a shared constant instead of actually converting the material's properties.

## Fix

Rewrites \`getMaterialForOriginal\` to build a real \`MeshStandardNodeMaterial\` from each original material, copying:

- \`color\`, \`roughness\`, \`metalness\`, \`emissive\`, \`emissiveIntensity\`
- \`opacity\`, \`transparent\`, \`alphaTest\`, \`side\`, \`vertexColors\`
- All texture maps: \`map\`, \`normalMap\`, \`roughnessMap\`, \`metalnessMap\`, \`emissiveMap\`, \`aoMap\`, \`alphaMap\`

Properties are assigned explicitly after construction rather than passed through the constructor — \`Material.setValues\` silently drops certain fields on NodeMaterial subclasses (observed: \`color\` being ignored, producing white output for GLTFs whose material relies solely on \`baseColorFactor\` like Kenney's low-poly kits).

Results are cached per original material via \`WeakMap\`. A double-conversion guard detects materials that have already been replaced with a NodeMaterial on a previous render and returns them as-is.

## Scope

- **One file**: \`packages/viewer/src/components/renderers/item/item-renderer.tsx\`
- **44 insertions, 3 deletions** — the old \`getMaterialForOriginal\` (2 lines) is replaced with a proper converter (~40 lines)
- **No schema changes, no store changes, no new dependencies**
- **Glass special-case preserved**: materials named \`glass\` still get the shared \`glassMaterial\`

## How to test

1. \`bun dev\`, load any scene with \`ItemNode\`s that reference real GLTF models.
2. Items should render with their GLTF's actual colors and textures — wood grain on a cabinet, fabric on a chair, metal on a desk. On \`main\`, every item renders as cream \`#f2f0ed\`.
3. Items with glass materials should still render translucent.
4. \`bun check\`, \`bun check-types\`, \`bun run build\` all clean.

## Checklist

- [x] I've tested this locally with \`bun dev\`
- [x] My code follows the existing code style (\`bun check\` passes on the touched file)
- [x] I've updated relevant documentation (N/A — no docs affected)
- [x] This PR targets the \`main\` branch