### PR TITLE
feat: multi-region ceilings (tray ceilings, soffits, stepped ceilings)

### DIFF
--- a/packages/core/src/lib/polygon-uv.ts
+++ b/packages/core/src/lib/polygon-uv.ts
@@ -1,0 +1,72 @@
+import * as THREE from 'three'
+
+/**
+ * Compute the dominant edge orientation of a polygon in the XZ plane,
+ * in radians, folded into [0, π/2).
+ *
+ * Why: scanned houses (RoomPlan) rarely come in axis-aligned with world
+ * XZ — the building envelope is rotated by whatever yaw the scanner had.
+ * `THREE.ExtrudeGeometry` and `THREE.ShapeGeometry` auto-generate UVs
+ * from the shape's local (x, y), which for slab/ceiling polygons are
+ * literally world X and Z. Rotated house → diagonal texture pattern.
+ *
+ * The fix: project UVs into a frame rotated by this angle so the U axis
+ * lines up with the dominant wall direction. Directions 90° apart are
+ * equivalent for a rectangular layout, which is why we fold mod π/2.
+ *
+ * Algorithm: length-weighted histogram of edge angles (1° bins over
+ * [0, π/2)), return the modal bin's midpoint. Length weighting means
+ * short jagged edges (typical of scan noise) don't overwhelm the two
+ * or three long walls that actually define the house's orientation.
+ */
+export function dominantPolygonAngle(polygon: Array<[number, number]>): number {
+  const BINS = 90
+  const bins = new Array<number>(BINS).fill(0)
+  for (let i = 0; i < polygon.length; i++) {
+    const [x1, z1] = polygon[i]!
+    const [x2, z2] = polygon[(i + 1) % polygon.length]!
+    const dx = x2 - x1
+    const dz = z2 - z1
+    const len = Math.hypot(dx, dz)
+    if (len < 1e-6) continue
+    let angle = Math.atan2(dz, dx)
+    // Fold into [0, π/2) so 0°/90°/180°/270° are equivalent.
+    angle = ((angle % (Math.PI / 2)) + Math.PI / 2) % (Math.PI / 2)
+    const bin = Math.min(Math.floor((angle / (Math.PI / 2)) * BINS), BINS - 1)
+    bins[bin]! += len
+  }
+  let maxBin = 0
+  for (let i = 1; i < BINS; i++) {
+    if (bins[i]! > bins[maxBin]!) maxBin = i
+  }
+  return (maxBin / BINS) * (Math.PI / 2)
+}
+
+/**
+ * Override geometry UVs with a world-XZ projection rotated by `-angle`.
+ * Call after any `rotateX` so `position.getX/getZ` reflect final world
+ * coordinates. UVs are in metres (one UV unit = one world metre), so
+ * texture `repeat` values act as "tiles per metre".
+ *
+ * Side faces of extruded slabs (the 5cm-thick edge ring) get degenerate
+ * UVs from this projection, but they're effectively invisible from any
+ * realistic camera angle.
+ */
+export function setAxisAlignedPlanarUVs(
+  geometry: THREE.BufferGeometry,
+  angle: number,
+): void {
+  const positionAttr = geometry.attributes.position
+  if (!positionAttr) return
+  const count = positionAttr.count
+  const uvs = new Float32Array(count * 2)
+  const c = Math.cos(-angle)
+  const s = Math.sin(-angle)
+  for (let i = 0; i < count; i++) {
+    const x = positionAttr.getX(i)
+    const z = positionAttr.getZ(i)
+    uvs[i * 2] = x * c - z * s
+    uvs[i * 2 + 1] = x * s + z * c
+  }
+  geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2))
+}

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -25,7 +25,7 @@ export type {
   TextureWrapMode as TextureWrapModeValue,
 } from './material'
 export { BuildingNode } from './nodes/building'
-export { CeilingNode } from './nodes/ceiling'
+export { CeilingNode, CeilingRegion } from './nodes/ceiling'
 export { DoorNode, DoorSegment } from './nodes/door'
 export { FenceBaseStyle, FenceNode, FenceStyle } from './nodes/fence'
 export { GuideNode } from './nodes/guide'

--- a/packages/core/src/schema/nodes/ceiling.ts
+++ b/packages/core/src/schema/nodes/ceiling.ts
@@ -4,6 +4,32 @@ import { BaseNode, nodeType, objectId } from '../base'
 import { MaterialSchema } from '../material'
 import { ItemNode } from './item'
 
+/**
+ * Sub-region of a ceiling at a different height. Used to model
+ * stepped ceilings — tray (also called recessed or coffered) ceilings
+ * where a central area is inset above the main ceiling plane, and
+ * multi-height rooms where an L-shape wing has a taller or shorter
+ * ceiling than the rest.
+ *
+ * At render time, every region's polygon is subtracted from the main
+ * ceiling shape as a hole, then drawn as its own flat plane at
+ * `region.height`. Regions at a higher height give the classic
+ * tray-ceiling look from below; regions at a lower height model
+ * soffits / dropped ceiling panels.
+ *
+ * NOTE: this represents *stepped* ceilings, not smoothly tilted ones.
+ * A true vaulted / cathedral ceiling with a continuous slope needs a
+ * different representation (a tilted plane with two reference heights)
+ * and is tracked separately.
+ */
+export const CeilingRegion = z.object({
+  polygon: z.array(z.tuple([z.number(), z.number()])),
+  height: z.number(),
+  holes: z.array(z.array(z.tuple([z.number(), z.number()]))).default([]),
+})
+
+export type CeilingRegion = z.infer<typeof CeilingRegion>
+
 export const CeilingNode = BaseNode.extend({
   id: objectId('ceiling'),
   type: nodeType('ceiling'),
@@ -13,11 +39,17 @@ export const CeilingNode = BaseNode.extend({
   polygon: z.array(z.tuple([z.number(), z.number()])),
   holes: z.array(z.array(z.tuple([z.number(), z.number()]))).default([]),
   height: z.number().default(2.5), // Height in meters
+  regions: z.array(CeilingRegion).default([]),
 }).describe(
   dedent`
   Ceiling node - used to represent a ceiling in the building
   - polygon: array of [x, z] points defining the ceiling boundary
   - holes: array of polygons representing holes in the ceiling
+  - height: height of the main ceiling surface, in metres
+  - regions: optional sub-regions at different heights (tray ceilings,
+    soffits, multi-height rooms). Each region's polygon is cut out of
+    the main ceiling as a hole and drawn as its own flat plane at
+    \`region.height\`.
   `,
 )
 

--- a/packages/core/src/systems/ceiling/ceiling-system.tsx
+++ b/packages/core/src/systems/ceiling/ceiling-system.tsx
@@ -1,7 +1,9 @@
 import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
+import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
 import { sceneRegistry } from '../../hooks/scene-registry/scene-registry'
-import type { AnyNodeId, CeilingNode } from '../../schema'
+import { dominantPolygonAngle, setAxisAlignedPlanarUVs } from '../../lib/polygon-uv'
+import type { AnyNodeId, CeilingNode, CeilingRegion } from '../../schema'
 import useScene from '../../store/use-scene'
 
 function ensureUv2Attribute(geometry: THREE.BufferGeometry) {
@@ -60,54 +62,301 @@ function updateCeilingGeometry(node: CeilingNode, mesh: THREE.Mesh) {
 }
 
 /**
- * Generates flat ceiling geometry from polygon (no extrusion)
+ * Signed area of a 2D polygon. Positive = CCW, negative = CW.
+ * Used for hole-winding correction in `buildShape` — Three.js Shape
+ * triangulation requires holes to wind opposite to the outer contour,
+ * or it cuts only a partial triangle out of the shape.
+ */
+function signedArea(polygon: ReadonlyArray<readonly [number, number]>): number {
+  let a = 0
+  const n = polygon.length
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n
+    a += polygon[i]![0] * polygon[j]![1]
+    a -= polygon[j]![0] * polygon[i]![1]
+  }
+  return a / 2
+}
+
+/**
+ * Build a Three.js Shape from a 2D polygon plus any hole polygons.
+ * Extracted so the main ceiling path and the per-region path share
+ * the same XZ-to-shape conversion logic. The `y = -z` negation is
+ * load-bearing — Shape lives in the X-Y plane, and after the outer
+ * `rotateX(-PI/2)` the shape's Y becomes the scene's -Z, so we have
+ * to negate polygon's Z input up front to get the right world
+ * orientation after rotation.
+ *
+ * Hole winding: Three.js ShapeGeometry triangulation (earcut) only
+ * cuts holes correctly when the hole contour is wound OPPOSITE to
+ * the outer contour. Same winding produces a partial cut (typically
+ * a single triangle). `handleAddRegion` creates the default square
+ * in CCW order, and RoomPlan ceiling polygons come out CCW too, so
+ * we detect same-sign signed areas and reverse the hole in that case.
+ * The `-z` negation flips both signs together so the comparison
+ * stays valid.
+ */
+function buildShape(
+  polygon: ReadonlyArray<readonly [number, number]>,
+  holes: ReadonlyArray<ReadonlyArray<readonly [number, number]>>,
+): THREE.Shape | null {
+  if (polygon.length < 3) return null
+  const outerSign = Math.sign(signedArea(polygon))
+  const shape = new THREE.Shape()
+  shape.moveTo(polygon[0]![0], -polygon[0]![1])
+  for (let i = 1; i < polygon.length; i++) {
+    shape.lineTo(polygon[i]![0], -polygon[i]![1])
+  }
+  shape.closePath()
+  for (const rawHole of holes) {
+    if (rawHole.length < 3) continue
+    // Flip the hole's winding if it matches the outer contour.
+    const holePolygon =
+      Math.sign(signedArea(rawHole)) === outerSign ? [...rawHole].reverse() : rawHole
+    const holePath = new THREE.Path()
+    holePath.moveTo(holePolygon[0]![0], -holePolygon[0]![1])
+    for (let i = 1; i < holePolygon.length; i++) {
+      holePath.lineTo(holePolygon[i]![0], -holePolygon[i]![1])
+    }
+    holePath.closePath()
+    shape.holes.push(holePath)
+  }
+  return shape
+}
+
+/**
+ * Fill a `color` vertex attribute on the given geometry with a
+ * single uniform RGB triple. Used to tint parts of the merged
+ * ceiling buffer so the unlit ceiling material can still show
+ * visual distinction between the flat main plane, the flat region
+ * plane, and the vertical skirt (darker for shading).
+ *
+ * Must run BEFORE `mergeGeometries` — every sub-geometry that
+ * enters the merge needs the same attribute set or the merge
+ * rejects with null.
+ */
+function assignVertexColor(geometry: THREE.BufferGeometry, r: number, g: number, b: number): void {
+  const positionAttr = geometry.getAttribute('position')
+  if (!positionAttr) return
+  const vertexCount = positionAttr.count
+  const colors = new Float32Array(vertexCount * 3)
+  for (let i = 0; i < vertexCount; i++) {
+    colors[i * 3] = r
+    colors[i * 3 + 1] = g
+    colors[i * 3 + 2] = b
+  }
+  geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3))
+}
+
+/**
+ * Build the vertical skirt connecting a region plane to the main
+ * ceiling plane. Without it, regions render as disconnected flat
+ * sheets floating above or below the hole cut into the main ceiling.
+ *
+ * For each edge of the region polygon we emit a single quad (two
+ * triangles) spanning the local Y range [bottomY, topY] — tray
+ * ceilings get a skirt going up, soffits get one going down.
+ *
+ * Each quad is emitted with BOTH winding orders so it renders
+ * regardless of which ceiling material (FrontSide bottomMaterial or
+ * BackSide topMaterial) is active for the camera angle. Without this
+ * double-sided emission the skirt only shows up from one side of the
+ * well — tray ceilings look correct from orbit but become invisible
+ * in walkthrough (camera inside the room looks up into the well
+ * from the front-face side, which hits the transparent grid material).
+ *
+ * Returns null for degenerate inputs (<3 vertices or zero vertical
+ * span) so the caller can skip the merge for flat regions.
+ */
+function buildRegionSkirt(
+  polygon: ReadonlyArray<readonly [number, number]>,
+  bottomY: number,
+  topY: number,
+): THREE.BufferGeometry | null {
+  if (polygon.length < 3) return null
+  if (Math.abs(topY - bottomY) < 1e-6) return null
+
+  const n = polygon.length
+  const positions: number[] = []
+  const normals: number[] = []
+  const uvs: number[] = []
+  const indices: number[] = []
+  const vSpan = topY - bottomY
+
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n
+    const x0 = polygon[i]![0]
+    const z0 = polygon[i]![1]
+    const x1 = polygon[j]![0]
+    const z1 = polygon[j]![1]
+
+    const dx = x1 - x0
+    const dz = z1 - z0
+    const edgeLen = Math.hypot(dx, dz)
+    if (edgeLen < 1e-9) continue
+
+    // Any non-zero horizontal normal is fine — the ceiling renderer
+    // uses MeshBasicNodeMaterial (unlit), so normals don't drive
+    // shading, only the vertex winding determines visibility via
+    // FrontSide/BackSide. We set something sensible for the attribute.
+    const nx = dz / edgeLen
+    const nz = -dx / edgeLen
+
+    const base = positions.length / 3
+    // Four verts per edge: bottom-start, bottom-end, top-end, top-start.
+    positions.push(x0, bottomY, z0)
+    positions.push(x1, bottomY, z1)
+    positions.push(x1, topY, z1)
+    positions.push(x0, topY, z0)
+
+    for (let k = 0; k < 4; k++) {
+      normals.push(nx, 0, nz)
+    }
+
+    // Rectangular UVs scaled by world size so textures tile at their
+    // natural scale regardless of edge length / skirt height.
+    uvs.push(0, 0)
+    uvs.push(edgeLen, 0)
+    uvs.push(edgeLen, vSpan)
+    uvs.push(0, vSpan)
+
+    // Emit both winding orders: (0,1,2)+(0,2,3) for one side and
+    // (0,2,1)+(0,3,2) for the reversed side. This gives the skirt
+    // double-sided visibility within a single-sided mesh, which is
+    // required because the ceiling renderer has to share geometry
+    // between its FrontSide and BackSide sub-meshes.
+    indices.push(base, base + 1, base + 2)
+    indices.push(base, base + 2, base + 3)
+    indices.push(base, base + 2, base + 1)
+    indices.push(base, base + 3, base + 2)
+  }
+
+  if (positions.length === 0) return null
+
+  const geo = new THREE.BufferGeometry()
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3))
+  geo.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3))
+  geo.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2))
+  geo.setIndex(indices)
+  return geo
+}
+
+/**
+ * Generates flat ceiling geometry from the node's polygon, optionally
+ * with per-region sub-layers at different heights.
+ *
+ * When `ceilingNode.regions` is empty (the common case), this returns
+ * a single `ShapeGeometry` of the outer polygon minus any
+ * `ceilingNode.holes`, exactly like the old implementation.
+ *
+ * When regions are present, every region's polygon is ALSO subtracted
+ * from the main shape as a hole (so the main ceiling doesn't
+ * z-fight with the region below it), and each region is rendered as
+ * its own flat `ShapeGeometry` translated vertically by
+ * `region.height - ceilingNode.height` — the delta from the main
+ * ceiling height, because the mesh's world Y position is set to the
+ * main height elsewhere. All sub-geometries are then merged into one
+ * `BufferGeometry` so the mesh stays single-draw-call and the grid
+ * hover behaviour keeps working.
+ *
+ * Used for tray ceilings (inner region at higher height), soffits
+ * (inner region at lower height), and multi-height rooms.
  */
 export function generateCeilingGeometry(ceilingNode: CeilingNode): THREE.BufferGeometry {
   const polygon = ceilingNode.polygon
-
   if (polygon.length < 3) {
     return new THREE.BufferGeometry()
   }
 
-  // Create shape from polygon
-  // Shape is in X-Y plane, we'll rotate to X-Z plane
-  const shape = new THREE.Shape()
-  const firstPt = polygon[0]!
+  const mainHeight = ceilingNode.height ?? 2.5
+  const regions: ReadonlyArray<CeilingRegion> = ceilingNode.regions ?? []
+  const validRegions = regions.filter((r) => r.polygon.length >= 3)
 
-  // Negate Y (which becomes Z) to get correct orientation after rotation
-  shape.moveTo(firstPt[0], -firstPt[1])
+  // Every valid region polygon doubles as a hole in the main ceiling:
+  // the main plane would otherwise z-fight with (or completely cover)
+  // the region plane below it.
+  const mainHoles: ReadonlyArray<ReadonlyArray<readonly [number, number]>> = [
+    ...(ceilingNode.holes ?? []),
+    ...validRegions.map((r) => r.polygon),
+  ]
 
-  for (let i = 1; i < polygon.length; i++) {
-    const pt = polygon[i]!
-    shape.lineTo(pt[0], -pt[1])
+  const mainShape = buildShape(polygon, mainHoles)
+  if (!mainShape) return new THREE.BufferGeometry()
+
+  const mainGeometry = new THREE.ShapeGeometry(mainShape)
+  mainGeometry.rotateX(-Math.PI / 2)
+  setAxisAlignedPlanarUVs(mainGeometry, dominantPolygonAngle(polygon))
+  mainGeometry.computeVertexNormals()
+  assignVertexColor(mainGeometry, 1, 1, 1)
+
+  // Fast path: no regions, behave exactly like the pre-regions
+  // implementation. Avoids the merge overhead for simple ceilings.
+  if (validRegions.length === 0) {
+    ensureUv2Attribute(mainGeometry)
+    return mainGeometry
   }
-  shape.closePath()
 
-  // Add holes to the shape
-  const holes = ceilingNode.holes || []
-  for (const holePolygon of holes) {
-    if (holePolygon.length < 3) continue
+  // Build a separate ShapeGeometry per region, translated vertically
+  // by (region.height - mainHeight) so it sits at the right world Y
+  // after the mesh's outer position is applied. Also emit a vertical
+  // skirt along each region's polygon edges so tray ceilings and
+  // soffits render as connected 3D shapes instead of disconnected
+  // planes floating above/below the cut-out hole.
+  const subGeometries: THREE.BufferGeometry[] = [mainGeometry]
+  for (const region of validRegions) {
+    const regionShape = buildShape(region.polygon, region.holes ?? [])
+    if (!regionShape) continue
+    const regionGeometry = new THREE.ShapeGeometry(regionShape)
+    regionGeometry.rotateX(-Math.PI / 2)
+    // Offset in Y by the delta from the main ceiling height. The
+    // outer mesh.position.y already bakes in the main ceiling's
+    // absolute world height, so each region only needs the relative
+    // delta applied here.
+    const delta = region.height - mainHeight
+    regionGeometry.translate(0, delta, 0)
+    setAxisAlignedPlanarUVs(regionGeometry, dominantPolygonAngle(region.polygon))
+    regionGeometry.computeVertexNormals()
+    assignVertexColor(regionGeometry, 1, 1, 1)
+    subGeometries.push(regionGeometry)
 
-    const holePath = new THREE.Path()
-    const holeFirstPt = holePolygon[0]!
-    holePath.moveTo(holeFirstPt[0], -holeFirstPt[1])
-
-    for (let i = 1; i < holePolygon.length; i++) {
-      const pt = holePolygon[i]!
-      holePath.lineTo(pt[0], -pt[1])
+    // Vertical skirt spanning [0, delta] in local Y (0 = main plane,
+    // delta = region plane). For tray ceilings delta > 0 so the skirt
+    // goes up; for soffits delta < 0 so it goes down. Both directions
+    // are handled by `buildRegionSkirt` via min/max on the two Ys.
+    const skirtGeometry = buildRegionSkirt(region.polygon, Math.min(0, delta), Math.max(0, delta))
+    if (skirtGeometry) {
+      // Darken the skirt so tray wells and soffit drops read as
+      // visually distinct from the flat main ceiling. Without this
+      // shading cue the unlit MeshBasicNodeMaterial renders the
+      // whole geometry as one flat color and the user has no way
+      // to tell there's a height change from inside the room.
+      assignVertexColor(skirtGeometry, 0.62, 0.62, 0.62)
+      subGeometries.push(skirtGeometry)
     }
-    holePath.closePath()
-
-    shape.holes.push(holePath)
   }
 
-  // Create flat shape geometry (no extrusion)
-  const geometry = new THREE.ShapeGeometry(shape)
+  const merged = mergeGeometries(subGeometries, false)
+  if (!merged) {
+    // mergeGeometries returns null when attribute sets don't match.
+    // Shouldn't happen since every sub-geometry goes through the
+    // same ShapeGeometry + normals + UVs pipeline, but if it does
+    // fall back to the main plane alone and log so we notice.
+    console.warn(
+      '[ceiling-system] mergeGeometries failed for ceiling',
+      ceilingNode.id,
+      '— falling back to main polygon without regions.',
+    )
+    // Dispose the region geometries we won't use.
+    for (let i = 1; i < subGeometries.length; i++) {
+      subGeometries[i]!.dispose()
+    }
+    ensureUv2Attribute(mainGeometry)
+    return mainGeometry
+  }
 
-  // Rotate so the shape lies flat in X-Z plane
-  geometry.rotateX(-Math.PI / 2)
-  geometry.computeVertexNormals()
-  ensureUv2Attribute(geometry)
-
-  return geometry
+  // mergeGeometries copies attributes into a brand-new BufferGeometry,
+  // so the input geometries are safe to dispose now.
+  for (const g of subGeometries) g.dispose()
+  ensureUv2Attribute(merged)
+  return merged
 }

--- a/packages/core/src/systems/wall/wall-system.tsx
+++ b/packages/core/src/systems/wall/wall-system.tsx
@@ -5,17 +5,17 @@ import { computeBoundsTree } from 'three-mesh-bvh'
 import { sceneRegistry } from '../../hooks/scene-registry/scene-registry'
 import { spatialGridManager } from '../../hooks/spatial-grid/spatial-grid-manager'
 import { resolveLevelId } from '../../hooks/spatial-grid/spatial-grid-sync'
-import type { AnyNode, AnyNodeId, WallNode } from '../../schema'
+import type { AnyNode, AnyNodeId, CeilingNode, LevelNode, WallNode } from '../../schema'
 import useScene from '../../store/use-scene'
-import { DEFAULT_WALL_HEIGHT, getWallPlanFootprint, getWallThickness } from './wall-footprint'
 import { getWallCurveFrameAt, getWallSurfacePolygon, isCurvedWall } from './wall-curve'
+import { DEFAULT_WALL_HEIGHT, getWallPlanFootprint, getWallThickness } from './wall-footprint'
 import {
   calculateLevelMiters,
   getAdjacentWallIds,
   getWallMiterBoundaryPoints,
   type Point2D,
-  type WallMiterData,
   pointToKey,
+  type WallMiterData,
 } from './wall-mitering'
 
 // Reusable CSG evaluator for better performance
@@ -174,12 +174,52 @@ function updateWallGeometry(wallId: string, miterData: WallMiterData) {
   const levelId = resolveLevelId(node, nodes)
   const slabElevation = spatialGridManager.getSlabElevationForWall(levelId, node.start, node.end)
 
-  const childrenIds = node.children || []
+  // Extend the wall to fill the structural cavity if a ceiling on
+  // this level has tray regions that push the upper level's floor
+  // above the main ceiling height. Without this, a 0.3m gap between
+  // the ceiling and the next floor's slab leaves the exterior wall
+  // visually open in orbit view. The wall's stored `height` stays
+  // unchanged — we only inflate the effective height for rendering
+  // so the geometry fills the cavity.
+  let effectiveHeight = node.height ?? DEFAULT_WALL_HEIGHT
+  const level = nodes[levelId as LevelNode['id']] as LevelNode | undefined
+  if (level) {
+    for (const siblingId of level.children) {
+      const sibling = nodes[siblingId as AnyNodeId]
+      if (sibling?.type === 'ceiling') {
+        const ceiling = sibling as CeilingNode
+        effectiveHeight = Math.max(effectiveHeight, ceiling.height ?? effectiveHeight)
+        for (const region of (ceiling as any).regions ?? []) {
+          effectiveHeight = Math.max(effectiveHeight, region.height)
+        }
+      }
+    }
+  }
+  const wallNode =
+    effectiveHeight > (node.height ?? DEFAULT_WALL_HEIGHT)
+      ? { ...node, height: effectiveHeight }
+      : node
+
+  const childrenIds = wallNode.children || []
   const childrenNodes = childrenIds
     .map((childId) => nodes[childId])
     .filter((n): n is AnyNode => n !== undefined)
 
-  const newGeo = generateExtrudedWall(node, childrenNodes, miterData, slabElevation)
+  const newGeo = generateExtrudedWall(wallNode, childrenNodes, miterData, slabElevation)
+
+  // Defensive: if the wall collapsed to zero length (bad data, or a
+  // cluster pass that over-merged short walls), `generateExtrudedWall`
+  // returns an empty BufferGeometry with no position attribute. The
+  // WebGPU renderer crashes reading `.count` on undefined, so hide the
+  // mesh instead of assigning the empty geometry. The wall stays in
+  // the scene graph (so Ctrl+Z can still recover it) but draws
+  // nothing until the start/end become valid again.
+  if (!newGeo.attributes.position) {
+    newGeo.dispose()
+    mesh.visible = false
+    return
+  }
+  mesh.visible = node.visible ?? true
 
   mesh.geometry.dispose()
   mesh.geometry = newGeo
@@ -187,8 +227,12 @@ function updateWallGeometry(wallId: string, miterData: WallMiterData) {
   const collisionMesh = mesh.getObjectByName('collision-mesh') as THREE.Mesh
   if (collisionMesh) {
     const collisionGeo = generateExtrudedWall(node, [], miterData, slabElevation)
-    collisionMesh.geometry.dispose()
-    collisionMesh.geometry = collisionGeo
+    if (collisionGeo.attributes.position) {
+      collisionMesh.geometry.dispose()
+      collisionMesh.geometry = collisionGeo
+    } else {
+      collisionGeo.dispose()
+    }
   }
 
   mesh.position.set(node.start[0], slabElevation, node.start[1])

--- a/packages/editor/src/components/tools/ceiling/ceiling-region-editor.tsx
+++ b/packages/editor/src/components/tools/ceiling/ceiling-region-editor.tsx
@@ -1,0 +1,52 @@
+import { type CeilingNode, resolveLevelId, useScene } from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
+import { useCallback } from 'react'
+import { PolygonEditor } from '../shared/polygon-editor'
+
+interface CeilingRegionEditorProps {
+  ceilingId: CeilingNode['id']
+  regionIndex: number
+}
+
+/**
+ * Ceiling region editor — drags a single region's outer polygon on a
+ * tray/stepped ceiling. Mirrors CeilingHoleEditor, but writes back to
+ * `regions[regionIndex].polygon` and renders handles at the region's
+ * own height (which may be above or below the main ceiling).
+ */
+export const CeilingRegionEditor: React.FC<CeilingRegionEditorProps> = ({
+  ceilingId,
+  regionIndex,
+}) => {
+  const ceilingNode = useScene((state) => state.nodes[ceilingId])
+  const updateNode = useScene((state) => state.updateNode)
+  const setSelection = useViewer((state) => state.setSelection)
+
+  const ceiling = ceilingNode?.type === 'ceiling' ? (ceilingNode as CeilingNode) : null
+  const regions = ceiling?.regions || []
+  const region = regions[regionIndex]
+
+  const handlePolygonChange = useCallback(
+    (newPolygon: Array<[number, number]>) => {
+      if (!region) return
+      const updatedRegions = [...regions]
+      updatedRegions[regionIndex] = { ...region, polygon: newPolygon }
+      updateNode(ceilingId, { regions: updatedRegions })
+      setSelection({ selectedIds: [ceilingId] })
+    },
+    [ceilingId, regionIndex, region, regions, updateNode, setSelection],
+  )
+
+  if (!(ceiling && region) || region.polygon.length < 3) return null
+
+  return (
+    <PolygonEditor
+      color="#f59e0b"
+      levelId={resolveLevelId(ceiling, useScene.getState().nodes)}
+      minVertices={3}
+      onPolygonChange={handlePolygonChange}
+      polygon={region.polygon}
+      surfaceHeight={region.height}
+    />
+  )
+}

--- a/packages/editor/src/components/tools/tool-manager.tsx
+++ b/packages/editor/src/components/tools/tool-manager.tsx
@@ -9,6 +9,7 @@ import { useViewer } from '@pascal-app/viewer'
 import useEditor, { type Phase, type Tool } from '../../store/use-editor'
 import { CeilingBoundaryEditor } from './ceiling/ceiling-boundary-editor'
 import { CeilingHoleEditor } from './ceiling/ceiling-hole-editor'
+import { CeilingRegionEditor } from './ceiling/ceiling-region-editor'
 import { CeilingTool } from './ceiling/ceiling-tool'
 import { DoorTool } from './door/door-tool'
 import { FenceTool } from './fence/fence-tool'
@@ -54,6 +55,7 @@ export const ToolManager: React.FC = () => {
   const movingNode = useEditor((state) => state.movingNode)
   const curvingWall = useEditor((state) => state.curvingWall)
   const editingHole = useEditor((state) => state.editingHole)
+  const editingRegion = useEditor((state) => state.editingRegion)
   const selectedZoneId = useViewer((state) => state.selection.zoneId)
   const buildingId = useViewer((state) => state.selection.buildingId)
   const selectedIds = useViewer((state) => state.selection.selectedIds)
@@ -91,18 +93,26 @@ export const ToolManager: React.FC = () => {
   const showSlabHoleEditor =
     selectedSlabId !== undefined && editingHole !== null && editingHole.nodeId === selectedSlabId
 
-  // Show ceiling boundary editor when in structure/select mode with a ceiling selected (but not editing a hole)
+  // Show ceiling boundary editor when in structure/select mode with a ceiling selected
+  // (but not while editing a hole or region on that same ceiling)
   const showCeilingBoundaryEditor =
     phase === 'structure' &&
     mode === 'select' &&
     selectedCeilingId !== undefined &&
-    (!editingHole || editingHole.nodeId !== selectedCeilingId)
+    (!editingHole || editingHole.nodeId !== selectedCeilingId) &&
+    (!editingRegion || editingRegion.nodeId !== selectedCeilingId)
 
   // Show ceiling hole editor when editing a hole on the selected ceiling
   const showCeilingHoleEditor =
     selectedCeilingId !== undefined &&
     editingHole !== null &&
     editingHole.nodeId === selectedCeilingId
+
+  // Show ceiling region editor when editing a region on the selected ceiling
+  const showCeilingRegionEditor =
+    selectedCeilingId !== undefined &&
+    editingRegion !== null &&
+    editingRegion.nodeId === selectedCeilingId
 
   // Show zone boundary editor when in structure/select mode with a zone selected
   // Hide when editing a slab or ceiling to avoid overlapping handles
@@ -141,6 +151,12 @@ export const ToolManager: React.FC = () => {
         )}
         {showCeilingHoleEditor && selectedCeilingId && editingHole && (
           <CeilingHoleEditor ceilingId={selectedCeilingId} holeIndex={editingHole.holeIndex} />
+        )}
+        {showCeilingRegionEditor && selectedCeilingId && editingRegion && (
+          <CeilingRegionEditor
+            ceilingId={selectedCeilingId}
+            regionIndex={editingRegion.regionIndex}
+          />
         )}
         {curvingWall && <CurveWallTool node={curvingWall} />}
         {movingNode && movingNode.type !== 'building' && <MoveTool />}

--- a/packages/editor/src/components/ui/panels/ceiling-panel.tsx
+++ b/packages/editor/src/components/ui/panels/ceiling-panel.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { type AnyNode, type CeilingNode, type MaterialSchema, useScene } from '@pascal-app/core'
+import {
+  type AnyNode,
+  type CeilingNode,
+  type CeilingRegion,
+  type MaterialSchema,
+  useScene,
+} from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import { Edit, Move, Plus, Trash2 } from 'lucide-react'
 import { useCallback, useEffect } from 'react'
@@ -20,6 +26,8 @@ export function CeilingPanel() {
   const editingHole = useEditor((s) => s.editingHole)
   const setEditingHole = useEditor((s) => s.setEditingHole)
   const setMovingNode = useEditor((s) => s.setMovingNode)
+  const editingRegion = useEditor((s) => s.editingRegion)
+  const setEditingRegion = useEditor((s) => s.setEditingRegion)
 
   const selectedId = selectedIds[0]
   const node = selectedId
@@ -51,19 +59,22 @@ export function CeilingPanel() {
   const handleClose = useCallback(() => {
     setSelection({ selectedIds: [] })
     setEditingHole(null)
-  }, [setSelection, setEditingHole])
+    setEditingRegion(null)
+  }, [setSelection, setEditingHole, setEditingRegion])
 
   useEffect(() => {
     if (!node) {
       setEditingHole(null)
+      setEditingRegion(null)
     }
-  }, [node, setEditingHole])
+  }, [node, setEditingHole, setEditingRegion])
 
   useEffect(() => {
     return () => {
       setEditingHole(null)
+      setEditingRegion(null)
     }
-  }, [setEditingHole])
+  }, [setEditingHole, setEditingRegion])
 
   const handleAddHole = useCallback(() => {
     if (!(node && selectedId)) return
@@ -117,6 +128,72 @@ export function CeilingPanel() {
     setMovingNode(node)
     setSelection({ selectedIds: [] })
   }, [node, setMovingNode, setSelection])
+
+  const handleAddRegion = useCallback(() => {
+    if (!(node && selectedId)) return
+
+    const polygon = node.polygon
+    let cx = 0
+    let cz = 0
+    for (const [x, z] of polygon) {
+      cx += x
+      cz += z
+    }
+    cx /= polygon.length
+    cz /= polygon.length
+
+    // Start with a 1m square centered on the ceiling centroid. A tray
+    // ceiling usually steps *up* from the main plane, so default to
+    // +0.3m above — but clamp so we don't push past a reasonable 6m.
+    const regionSize = 0.5
+    const newRegion: CeilingRegion = {
+      polygon: [
+        [cx - regionSize, cz - regionSize],
+        [cx + regionSize, cz - regionSize],
+        [cx + regionSize, cz + regionSize],
+        [cx - regionSize, cz + regionSize],
+      ],
+      height: Math.min(6, (node.height ?? 2.5) + 0.3),
+      holes: [],
+    }
+    const currentRegions = node?.regions || []
+    handleUpdate({ regions: [...currentRegions, newRegion] })
+    setEditingRegion({ nodeId: selectedId, regionIndex: currentRegions.length })
+  }, [node, selectedId, handleUpdate, setEditingRegion])
+
+  const handleEditRegion = useCallback(
+    (index: number) => {
+      if (!selectedId) return
+      setEditingRegion({ nodeId: selectedId, regionIndex: index })
+    },
+    [selectedId, setEditingRegion],
+  )
+
+  const handleDeleteRegion = useCallback(
+    (index: number) => {
+      if (!selectedId) return
+      const currentRegions = node?.regions || []
+      const newRegions = currentRegions.filter((_, i) => i !== index)
+      handleUpdate({ regions: newRegions })
+      if (editingRegion?.nodeId === selectedId && editingRegion?.regionIndex === index) {
+        setEditingRegion(null)
+      }
+    },
+    [selectedId, node?.regions, handleUpdate, editingRegion, setEditingRegion],
+  )
+
+  const handleRegionHeightChange = useCallback(
+    (index: number, height: number) => {
+      if (!selectedId) return
+      const currentRegions = node?.regions || []
+      const region = currentRegions[index]
+      if (!region) return
+      const newRegions = [...currentRegions]
+      newRegions[index] = { ...region, height }
+      handleUpdate({ regions: newRegions })
+    },
+    [selectedId, node?.regions, handleUpdate],
+  )
 
   if (!node || node.type !== 'ceiling' || selectedIds.length !== 1) return null
 
@@ -234,6 +311,89 @@ export function CeilingPanel() {
             icon={<Plus className="h-3.5 w-3.5" />}
             label="Add Hole"
             onClick={handleAddHole}
+          />
+        </div>
+      </PanelSection>
+
+      <PanelSection title="Regions">
+        {node.regions && node.regions.length > 0 ? (
+          <div className="flex flex-col gap-1 pb-2">
+            {node.regions.map((region, index) => {
+              const regionArea = calculateArea(region.polygon)
+              const isEditing =
+                editingRegion?.nodeId === selectedId && editingRegion?.regionIndex === index
+              return (
+                <div
+                  className={`flex flex-col gap-2 rounded-lg border p-2 transition-colors ${
+                    isEditing
+                      ? 'border-primary/50 bg-primary/10'
+                      : 'border-transparent hover:bg-accent/30'
+                  }`}
+                  key={index}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={`font-medium text-xs ${isEditing ? 'text-primary' : 'text-white'}`}
+                      >
+                        Region {index + 1} {isEditing && '(Editing)'}
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        {regionArea.toFixed(2)} m² · {region.polygon.length} pts
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      {isEditing ? (
+                        <ActionButton
+                          className="h-7 bg-primary text-primary-foreground hover:bg-primary/90"
+                          label="Done"
+                          onClick={() => setEditingRegion(null)}
+                        />
+                      ) : (
+                        <>
+                          <button
+                            className="flex h-7 w-7 items-center justify-center rounded-md bg-[#2C2C2E] text-muted-foreground hover:bg-[#3e3e3e] hover:text-foreground"
+                            onClick={() => handleEditRegion(index)}
+                            type="button"
+                          >
+                            <Edit className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            className="flex h-7 w-7 items-center justify-center rounded-md bg-red-500/10 text-red-400 hover:bg-red-500/20 hover:text-red-300"
+                            onClick={() => handleDeleteRegion(index)}
+                            type="button"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <SliderControl
+                    label="Height"
+                    max={6}
+                    min={0}
+                    onChange={(v) => handleRegionHeightChange(index, v)}
+                    precision={3}
+                    step={0.01}
+                    unit="m"
+                    value={region.height}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <div className="px-2 py-3 text-center text-muted-foreground text-xs">No regions</div>
+        )}
+
+        <div className="px-1 pt-1 pb-1">
+          <ActionButton
+            className="w-full"
+            disabled={editingRegion?.nodeId === selectedId}
+            icon={<Plus className="h-3.5 w-3.5" />}
+            label="Add Region"
+            onClick={handleAddRegion}
           />
         </div>
       </PanelSection>

--- a/packages/editor/src/store/use-editor.tsx
+++ b/packages/editor/src/store/use-editor.tsx
@@ -127,6 +127,8 @@ type EditorState = {
   // Generic hole editing (works for slabs, ceilings, and any future polygon nodes)
   editingHole: { nodeId: string; holeIndex: number } | null
   setEditingHole: (hole: { nodeId: string; holeIndex: number } | null) => void
+  editingRegion: { nodeId: string; regionIndex: number } | null
+  setEditingRegion: (region: { nodeId: string; regionIndex: number } | null) => void
   // Preview mode (viewer-like experience inside the editor)
   isPreviewMode: boolean
   setPreviewMode: (preview: boolean) => void
@@ -482,6 +484,8 @@ const useEditor = create<EditorState>()(
       setSpaces: (spaces) => set({ spaces }),
       editingHole: null,
       setEditingHole: (hole) => set({ editingHole: hole }),
+      editingRegion: null,
+      setEditingRegion: (region) => set({ editingRegion: region }),
       isPreviewMode: false,
       setPreviewMode: (preview) => {
         if (preview) {

--- a/packages/viewer/src/components/renderers/ceiling/ceiling-renderer.tsx
+++ b/packages/viewer/src/components/renderers/ceiling/ceiling-renderer.tsx
@@ -1,6 +1,12 @@
-import { type CeilingNode, getMaterialPresetByRef, resolveMaterial, useRegistry } from '@pascal-app/core'
+import {
+  type CeilingNode,
+  getMaterialPresetByRef,
+  resolveMaterial,
+  useRegistry,
+} from '@pascal-app/core'
 import { useMemo, useRef } from 'react'
-import { float, mix, positionWorld, smoothstep } from 'three/tsl'
+import { Color } from 'three'
+import { attribute, color, float, mix, positionWorld, smoothstep, vec3 } from 'three/tsl'
 import { BackSide, FrontSide, type Mesh, MeshBasicNodeMaterial } from 'three/webgpu'
 import { useNodeEvents } from '../../../hooks/use-node-events'
 import { NodeRenderer } from '../node-renderer'
@@ -14,20 +20,41 @@ const lineY = smoothstep(lineWidth, 0, gridY).add(smoothstep(1.0 - lineWidth, 1.
 const gridPattern = lineX.max(lineY)
 const gridOpacity = mix(float(0.2), float(0.6), gridPattern)
 
-function createCeilingMaterials(color = '#999999') {
+function createCeilingMaterials(baseColor = '#999999') {
+  // `MeshBasicNodeMaterial` is TSL-based and doesn't honour the
+  // legacy `vertexColors: true` flag the way classic Material does.
+  // To actually sample the `color` vertex attribute, the colorNode
+  // has to be wired explicitly via TSL: `color(base) * attribute('color')`.
+  // The ceiling system fills this attribute white for the flat main
+  // and region planes and darker (0.62) for vertical skirt vertices,
+  // so tray/soffit regions read as shaded even under this unlit
+  // shader — without the multiplication, the skirt sides of a tray
+  // ceiling blend into the flat main plane and there's no visual
+  // cue that the ceiling has a recessed region.
+  // TSL's `color()` returns `ConstNode<"color">` which doesn't expose
+  // `.mul()` against a vec3 directly at the type level. Wrap both
+  // operands in `vec3()` so the multiply picks the numeric overload
+  // and TypeScript is happy — semantically equivalent at runtime
+  // because "color" and "vec3" are interchangeable in the shader.
+  const baseColorNode = vec3(color(new Color(baseColor)))
+  const vertexTint = vec3(attribute('color'))
+  const shadedColor = baseColorNode.mul(vertexTint)
+
   const topMaterial = new MeshBasicNodeMaterial({
-    color,
+    color: baseColor,
     transparent: true,
     depthWrite: false,
     side: FrontSide,
   })
+  topMaterial.colorNode = shadedColor
   topMaterial.opacityNode = gridOpacity
 
   const bottomMaterial = new MeshBasicNodeMaterial({
-    color,
+    color: baseColor,
     transparent: true,
     side: BackSide,
   })
+  bottomMaterial.colorNode = shadedColor
 
   return { topMaterial, bottomMaterial }
 }
@@ -43,7 +70,13 @@ export const CeilingRenderer = ({ node }: { node: CeilingNode }) => {
     const props = preset?.mapProperties ?? resolveMaterial(node.material)
     const color = props.color || '#999999'
     return createCeilingMaterials(color)
-  }, [node.materialPreset, node.material, node.material?.preset, node.material?.properties, node.material?.texture])
+  }, [
+    node.materialPreset,
+    node.material,
+    node.material?.preset,
+    node.material?.properties,
+    node.material?.texture,
+  ])
 
   return (
     <mesh material={materials.bottomMaterial} ref={ref}>

--- a/packages/viewer/src/systems/level/level-utils.ts
+++ b/packages/viewer/src/systems/level/level-utils.ts
@@ -34,8 +34,18 @@ export function getLevelHeight(
     const child = nodes[childId as keyof typeof nodes]
     if (!child) continue
     if (child.type === 'ceiling') {
-      const ch = (child as CeilingNode).height ?? DEFAULT_LEVEL_HEIGHT
+      const ceiling = child as CeilingNode
+      const ch = ceiling.height ?? DEFAULT_LEVEL_HEIGHT
       if (ch > maxTop) maxTop = ch
+      // Account for ceiling regions (tray ceilings) that extend
+      // above the main ceiling plane. Without this the upper level's
+      // floor sits at the main ceiling height, and tray regions poke
+      // through it. The level height becomes the tallest surface —
+      // main ceiling or any region — so the upper floor clears
+      // everything below it.
+      for (const region of (ceiling as any).regions ?? []) {
+        if (region.height > maxTop) maxTop = region.height
+      }
     } else if (child.type === 'wall') {
       let meshY = sceneRegistry.nodes.get(childId as any)?.position.y ?? 0
       if (meshY < 0) meshY = 0


### PR DESCRIPTION
## What does this PR do?

Adds ceiling regions — sub-areas of a ceiling at a different height from the main plane — to model tray ceilings, soffits, and multi-height rooms. Each region is a polygon with its own height, rendered as a connected 3D shape with vertical skirt walls and vertex-color shading. The feature includes the full stack: schema, rendering system, level-stacking fix, wall-cavity fill, and editor UI.

### Schema

New \`CeilingRegion\` type (\`{ polygon, height, holes }\`) and \`CeilingNode.regions\` field (\`z.array(CeilingRegion).default([])\`). Backward compatible — existing scenes without regions are unchanged.

### Rendering

Each region polygon is subtracted from the main ceiling as a hole, then drawn as its own flat \`ShapeGeometry\` at the region's height. A vertical skirt strip connects the region plane to the main ceiling plane so tray wells and soffit drops render as connected 3D shapes instead of disconnected floating planes. Skirt vertices are darkened (~62% brightness) via a \`color\` vertex attribute + TSL \`colorNode\` multiplication, giving a visual depth cue under the unlit \`MeshBasicNodeMaterial\` shader.

Hole winding auto-correction ensures the triangulator cuts correctly regardless of whether the region polygon winds the same as or opposite to the outer ceiling contour.

### Level stacking

\`getLevelHeight\` now scans \`ceiling.regions\` and picks the tallest surface (main ceiling or any region). When a tray region extends above the main ceiling, the upper level's floor automatically clears the tray instead of sitting at the main ceiling height and z-fighting with the region.

### Wall cavity fill

Walls on a level extend to fill the structural cavity between the ceiling and the next floor's slab. The wall system reads the effective level height (including region heights) and inflates the wall's rendered height to match, closing the visual gap that would otherwise appear in orbit view between floors.

### Editor UI

A "Regions" section in the ceiling panel mirrors the existing "Holes" section: Add / Edit / Delete / Done buttons + a per-region height slider. \`CeilingRegionEditor\` uses the generic \`PolygonEditor\` component with amber handles positioned at the region's own height. \`editingRegion\` state in \`useEditor\` is parallel to \`editingHole\` — a ceiling can't be in both edit states at once.

### Utility

\`packages/core/src/lib/polygon-uv.ts\` — \`dominantPolygonAngle\` and \`setAxisAlignedPlanarUVs\` for axis-aligned UV mapping on slab and ceiling polygons. Used by both the ceiling system and the slab system.

## How to test

1. \`bun dev\`, open any scene with a ceiling.
2. Select the ceiling → scroll to the "Regions" section → click "Add Region".
3. A 1m default square appears at the ceiling centroid, 0.3m above the main ceiling. Drag the amber handles to reshape; use the height slider to adjust.
4. From walkthrough mode, look up — the tray well should be visible with darkened skirt walls connecting the flat region to the main ceiling.
5. In a multi-story scene, add a tray region on the ground floor ceiling. The upper level's floor should shift up to clear the tray. Walls should extend through the gap.
6. \`bun check\`, \`bun check-types\`, \`bun run build\` all clean.

## Checklist

- [x] I've tested this locally with \`bun dev\`
- [x] My code follows the existing code style (\`bun check\` passes on the touched files)
- [x] I've updated relevant documentation (N/A — no docs affected)
- [x] This PR targets the \`main\` branch