### PR TITLE
feat(wall-tool): add Ctrl key to bypass grid snap for arbitrary wall lengths

### DIFF
--- a/packages/editor/src/components/tools/wall/wall-drafting.ts
+++ b/packages/editor/src/components/tools/wall/wall-drafting.ts
@@ -99,10 +99,18 @@ export function snapWallDraftPoint(args: {
   walls: WallNode[]
   start?: WallPlanPoint
   angleSnap?: boolean
+  freeSnap?: boolean
   ignoreWallIds?: string[]
 }): WallPlanPoint {
-  const { point, walls, start, angleSnap = false, ignoreWallIds } = args
-  const basePoint = start && angleSnap ? snapPointTo45Degrees(start, point) : snapPointToGrid(point)
+  const { point, walls, start, angleSnap = false, freeSnap = false, ignoreWallIds } = args
+  let basePoint: WallPlanPoint
+  if (freeSnap) {
+    basePoint = point
+  } else if (start && angleSnap) {
+    basePoint = snapPointTo45Degrees(start, point)
+  } else {
+    basePoint = snapPointToGrid(point)
+  }
 
   return (
     findWallSnapTarget(basePoint, walls, {

--- a/packages/editor/src/components/tools/wall/wall-tool.tsx
+++ b/packages/editor/src/components/tools/wall/wall-tool.tsx
@@ -73,6 +73,7 @@ export const WallTool: React.FC = () => {
   const endingPoint = useRef(new Vector3(0, 0, 0))
   const buildingState = useRef(0)
   const shiftPressed = useRef(false)
+  const ctrlPressed = useRef(false)
 
   useEffect(() => {
     let gridPosition: WallPlanPoint = [0, 0]
@@ -86,7 +87,7 @@ export const WallTool: React.FC = () => {
       const walls = getCurrentLevelWalls()
       // event.localPosition is building-local — consistent with stored wall start/end
       const localPoint: WallPlanPoint = [event.localPosition[0], event.localPosition[2]]
-      gridPosition = snapWallDraftPoint({ point: localPoint, walls })
+      gridPosition = snapWallDraftPoint({ point: localPoint, walls, freeSnap: shiftPressed.current })
 
       if (buildingState.current === 1) {
         const snappedLocal = snapWallDraftPoint({
@@ -94,6 +95,7 @@ export const WallTool: React.FC = () => {
           walls,
           start: [startingPoint.current.x, startingPoint.current.z],
           angleSnap: !shiftPressed.current,
+          freeSnap: ctrlPressed.current,
         })
         endingPoint.current.set(snappedLocal[0], event.localPosition[1], snappedLocal[1])
         cursorRef.current.position.copy(endingPoint.current)
@@ -120,7 +122,7 @@ export const WallTool: React.FC = () => {
       const localClick: WallPlanPoint = [event.localPosition[0], event.localPosition[2]]
 
       if (buildingState.current === 0) {
-        const snappedStart = snapWallDraftPoint({ point: localClick, walls })
+        const snappedStart = snapWallDraftPoint({ point: localClick, walls, freeSnap: shiftPressed.current })
         gridPosition = snappedStart
         startingPoint.current.set(snappedStart[0], event.localPosition[1], snappedStart[1])
         endingPoint.current.copy(startingPoint.current)
@@ -132,6 +134,7 @@ export const WallTool: React.FC = () => {
           walls,
           start: [startingPoint.current.x, startingPoint.current.z],
           angleSnap: !shiftPressed.current,
+          freeSnap: ctrlPressed.current,
         })
         const dx = snappedEnd[0] - startingPoint.current.x
         const dz = snappedEnd[1] - startingPoint.current.z
@@ -144,15 +147,13 @@ export const WallTool: React.FC = () => {
     }
 
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Shift') {
-        shiftPressed.current = true
-      }
+      if (e.key === 'Shift') shiftPressed.current = true
+      if (e.key === 'Control') ctrlPressed.current = true
     }
 
     const onKeyUp = (e: KeyboardEvent) => {
-      if (e.key === 'Shift') {
-        shiftPressed.current = false
-      }
+      if (e.key === 'Shift') shiftPressed.current = false
+      if (e.key === 'Control') ctrlPressed.current = false
     }
 
     const onCancel = () => {


### PR DESCRIPTION
Closes #242

## Summary

- Adds `Ctrl` modifier key to the wall drawing tool that disables the 0.5m grid snap, allowing walls at any length (e.g. 1.70m, 2.35m)
- `Shift` continues to work as before — disabling angle snapping for non-45° walls
- Wall-join snapping (connecting to existing wall endpoints) still works in both free modes
- The two modifiers are fully independent and can be combined

## Modifier key behaviour

| Keys | Grid snap | Angle snap |
|------|-----------|------------|
| *(none)* | 0.5m grid | 45° |
| **Shift** | 0.5m grid | free |
| **Ctrl** | free | 45° |
| **Shift + Ctrl** | free | free |

## Test plan

- [ ] Draw a wall without any modifier — snaps to 0.5m increments and 45° angles as before
- [ ] Hold **Shift** while drawing — angle is free, grid snap still active
- [ ] Hold **Ctrl** while drawing — can produce walls like 1.70m, 2.35m, etc.
- [ ] Hold **Shift + Ctrl** — fully free movement
- [ ] Verify wall-join snap (connecting to existing wall endpoints) still works with Ctrl held

