### PR TITLE
feat: interactive doors in walkthrough view + swing-direction consistency

### DIFF
--- a/packages/core/src/systems/door/door-system.tsx
+++ b/packages/core/src/systems/door/door-system.tsx
@@ -62,9 +62,12 @@ function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
   mesh.position.set(node.position[0], node.position[1], node.position[2])
   mesh.rotation.set(node.rotation[0], node.rotation[1], node.rotation[2])
 
-  // Dispose and remove all old visual children; preserve 'cutout'
+  // Dispose and remove all old visual children; preserve 'cutout' and any
+  // existing leaf-pivot group (we'll clear + refill its contents, but keep
+  // the group itself so whatever rotation the interactive system has
+  // applied survives geometry regeneration).
   for (const child of [...mesh.children]) {
-    if (child.name === 'cutout') continue
+    if (child.name === 'cutout' || child.name === 'leafPivot') continue
     if (child instanceof THREE.Mesh) child.geometry.dispose()
     mesh.remove(child)
   }
@@ -79,7 +82,6 @@ function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
     segments,
     handle,
     handleHeight,
-    handleSide,
     doorCloser,
     panicBar,
     panicBarHeight,
@@ -93,6 +95,37 @@ function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
   const leafDepth = 0.04
   // Leaf center is shifted down from door center by half the top frame
   const leafCenterY = -frameThickness / 2
+
+  // ── Hinge pivot ─────────────────────────────────────────────────────
+  // Everything that physically swings with the leaf (leaf surfaces,
+  // handle, door closer, panic bar) lives under `leafOffset` inside
+  // `leafPivot`. Rotating leafPivot.rotation.y opens the door around
+  // its hinge edge — the DoorInteractiveSystem in packages/viewer
+  // animates that rotation in response to user interaction.
+  //
+  // Structure:
+  //   mesh                 (invisible hitbox; also holds fixed frame/hinges)
+  //     └─ leafPivot       (at hinge edge, rotates around Y)
+  //          └─ leafOffset (inverse offset so children use door-center coords)
+  //               └─ leaf meshes (panels, handle, etc.)
+  const hingePivotX = hingesSide === 'right' ? leafW / 2 : -leafW / 2
+  let leafPivot = mesh.getObjectByName('leafPivot') as THREE.Group | undefined
+  if (!leafPivot) {
+    leafPivot = new THREE.Group()
+    leafPivot.name = 'leafPivot'
+    mesh.add(leafPivot)
+  }
+  leafPivot.position.set(hingePivotX, 0, 0)
+  // Dispose old leaf contents — leafPivot is kept so the current rotation
+  // persists through geometry regeneration, but its children are stale.
+  for (const child of [...leafPivot.children]) {
+    if (child instanceof THREE.Mesh) child.geometry.dispose()
+    leafPivot.remove(child)
+  }
+  const leafOffset = new THREE.Group()
+  leafOffset.name = 'leafOffset'
+  leafOffset.position.set(-hingePivotX, 0, 0)
+  leafPivot.add(leafOffset)
 
   // ── Frame members ──
   // Left post — full height
@@ -148,16 +181,16 @@ function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
   const cpY = contentPadding[1]
   if (cpY > 0) {
     // Top strip
-    addBox(mesh, baseMaterial, leafW, cpY, leafDepth, 0, leafCenterY + leafH / 2 - cpY / 2, 0)
+    addBox(leafOffset, baseMaterial, leafW, cpY, leafDepth, 0, leafCenterY + leafH / 2 - cpY / 2, 0)
     // Bottom strip
-    addBox(mesh, baseMaterial, leafW, cpY, leafDepth, 0, leafCenterY - leafH / 2 + cpY / 2, 0)
+    addBox(leafOffset, baseMaterial, leafW, cpY, leafDepth, 0, leafCenterY - leafH / 2 + cpY / 2, 0)
   }
   if (cpX > 0) {
     const innerH = leafH - 2 * cpY
     // Left strip
-    addBox(mesh, baseMaterial, cpX, innerH, leafDepth, -leafW / 2 + cpX / 2, leafCenterY, 0)
+    addBox(leafOffset, baseMaterial, cpX, innerH, leafDepth, -leafW / 2 + cpX / 2, leafCenterY, 0)
     // Right strip
-    addBox(mesh, baseMaterial, cpX, innerH, leafDepth, leafW / 2 - cpX / 2, leafCenterY, 0)
+    addBox(leafOffset, baseMaterial, cpX, innerH, leafDepth, leafW / 2 - cpX / 2, leafCenterY, 0)
   }
 
   // Content area inside padding
@@ -192,7 +225,7 @@ function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
     for (let c = 0; c < numCols - 1; c++) {
       cx += colWidths[c]!
       addBox(
-        mesh,
+        leafOffset,
         baseMaterial,
         seg.dividerThickness,
         segH,
@@ -212,21 +245,21 @@ function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
       if (seg.type === 'glass') {
         // Glass only — no opaque backing so it's truly transparent
         const glassDepth = Math.max(0.004, leafDepth * 0.15)
-        addBox(mesh, glassMaterial, colW, segH, glassDepth, colX, segCenterY, 0)
+        addBox(leafOffset, glassMaterial, colW, segH, glassDepth, colX, segCenterY, 0)
       } else if (seg.type === 'panel') {
         // Opaque leaf backing for this column
-        addBox(mesh, baseMaterial, colW, segH, leafDepth, colX, segCenterY, 0)
+        addBox(leafOffset, baseMaterial, colW, segH, leafDepth, colX, segCenterY, 0)
         // Raised panel detail
         const panelW = colW - 2 * seg.panelInset
         const panelH = segH - 2 * seg.panelInset
         if (panelW > 0.01 && panelH > 0.01) {
           const effectiveDepth = Math.abs(seg.panelDepth) < 0.002 ? 0.005 : Math.abs(seg.panelDepth)
           const panelZ = leafDepth / 2 + effectiveDepth / 2
-          addBox(mesh, baseMaterial, panelW, panelH, effectiveDepth, colX, segCenterY, panelZ)
+          addBox(leafOffset, baseMaterial, panelW, panelH, effectiveDepth, colX, segCenterY, panelZ)
         }
       } else {
         // 'empty' — opaque backing, no detail
-        addBox(mesh, baseMaterial, colW, segH, leafDepth, colX, segCenterY, 0)
+        addBox(leafOffset, baseMaterial, colW, segH, leafDepth, colX, segCenterY, 0)
       }
     }
 
@@ -237,26 +270,35 @@ function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
   if (handle) {
     // Convert from floor-based height to mesh-center-based Y
     const handleY = handleHeight - height / 2
-    // Handle grip sits on the front face (+Z) of the leaf
-    const faceZ = leafDepth / 2
 
-    // X position: handleSide refers to which side the grip is on
-    const handleX = handleSide === 'right' ? leafW / 2 - 0.045 : -leafW / 2 + 0.045
+    // Handle always sits on the free edge — the side opposite the hinges.
+    // A real door never has the handle on the hinge side, so we derive
+    // this from `hingesSide` rather than trusting the (now redundant)
+    // `handleSide` field: flipping hinges used to leave the handle
+    // stranded on the same side.
+    const handleOnRight = hingesSide === 'left'
+    const handleX = handleOnRight ? leafW / 2 - 0.045 : -leafW / 2 + 0.045
 
-    // Backplate
-    addBox(mesh, baseMaterial, 0.028, 0.14, 0.01, handleX, handleY, faceZ + 0.005)
-    // Grip lever
-    addBox(mesh, baseMaterial, 0.022, 0.1, 0.035, handleX, handleY, faceZ + 0.025)
+    // Real doors have a handle on both faces — one to grab from each
+    // room. Stamp a backplate + lever on +Z and a mirrored pair on -Z.
+    for (const sign of [1, -1] as const) {
+      const faceZ = (leafDepth / 2) * sign
+      // Backplate sits just off the leaf face; levers stick out further.
+      // Signs multiply through so the -Z pair protrudes into -Z space
+      // rather than back through the leaf.
+      addBox(leafOffset, baseMaterial, 0.028, 0.14, 0.01, handleX, handleY, faceZ + 0.005 * sign)
+      addBox(leafOffset, baseMaterial, 0.022, 0.1, 0.035, handleX, handleY, faceZ + 0.025 * sign)
+    }
   }
 
   // ── Door closer (commercial hardware at top) ──
   if (doorCloser) {
     const closerY = leafCenterY + leafH / 2 - 0.04
     // Body
-    addBox(mesh, baseMaterial, 0.28, 0.055, 0.055, 0, closerY, leafDepth / 2 + 0.03)
+    addBox(leafOffset, baseMaterial, 0.28, 0.055, 0.055, 0, closerY, leafDepth / 2 + 0.03)
     // Arm (simplified as thin bar to frame side)
     addBox(
-      mesh,
+      leafOffset,
       baseMaterial,
       0.14,
       0.015,
@@ -270,7 +312,7 @@ function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
   // ── Panic bar ──
   if (panicBar) {
     const barY = panicBarHeight - height / 2
-    addBox(mesh, baseMaterial, leafW * 0.72, 0.04, 0.055, 0, barY, leafDepth / 2 + 0.03)
+    addBox(leafOffset, baseMaterial, leafW * 0.72, 0.04, 0.055, 0, barY, leafDepth / 2 + 0.03)
   }
 
   // ── Hinges (3 knuckle-style hinges on the hinge side) ──

--- a/packages/editor/src/components/editor/first-person-controls.tsx
+++ b/packages/editor/src/components/editor/first-person-controls.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { DoorInteractionHint } from '@pascal-app/viewer'
 import { useFrame, useThree } from '@react-three/fiber'
 import { useCallback, useEffect, useRef } from 'react'
 import { Euler, Vector3 } from 'three'
@@ -221,9 +222,15 @@ export const FirstPersonOverlay = ({ onExit }: { onExit: () => void }) => {
           <div className="h-5 w-px bg-border/30" />
           <ControlHint label="Sprint" keys={['Shift']} />
           <div className="h-5 w-px bg-border/30" />
+          <ControlHint label="Open door" keys={['F']} />
+          <div className="h-5 w-px bg-border/30" />
           <span className="text-muted-foreground/60 text-xs">Click to look around</span>
         </div>
       </div>
+
+      {/* "Press F to open/close" hint that follows the crosshair when
+          aimed at a door. No-op when the crosshair isn't targeting a door. */}
+      <DoorInteractionHint />
     </>
   )
 }

--- a/packages/editor/src/components/ui/panels/door-panel.tsx
+++ b/packages/editor/src/components/ui/panels/door-panel.tsx
@@ -382,19 +382,8 @@ export function DoorPanel() {
               unit="m"
               value={Math.round(node.handleHeight * 100) / 100}
             />
-            <div className="space-y-1">
-              <span className="font-medium text-[10px] text-muted-foreground/80 uppercase tracking-wider">
-                Handle Side
-              </span>
-              <SegmentedControl
-                onChange={(v) => handleUpdate({ handleSide: v })}
-                options={[
-                  { label: 'Left', value: 'left' },
-                  { label: 'Right', value: 'right' },
-                ]}
-                value={node.handleSide}
-              />
-            </div>
+            {/* Handle side is derived from `hingesSide` — the handle
+                always sits on the free edge of the leaf. */}
           </div>
         )}
       </PanelSection>

--- a/packages/editor/src/hooks/use-keyboard.ts
+++ b/packages/editor/src/hooks/use-keyboard.ts
@@ -64,6 +64,10 @@ export const useKeyboard = ({ isVersionPreviewMode = false } = {}) => {
         useEditor.getState().setMode('select')
       } else if (e.key === 'f' && !e.metaKey && !e.ctrlKey) {
         if (isVersionPreviewMode) return
+        // F is also the walkthrough "open/close door" keybind. When the
+        // user is in a walkthrough, let DoorInteractiveSystem claim the
+        // keystroke instead of yanking them into the furnish/build panel.
+        if (useViewer.getState().walkthroughMode) return
         e.preventDefault()
         useEditor.getState().setPhase('furnish')
         useEditor.getState().setMode('build')

--- a/packages/viewer/src/components/viewer/index.tsx
+++ b/packages/viewer/src/components/viewer/index.tsx
@@ -16,6 +16,7 @@ import { Canvas, extend, type ThreeToJSXElements, useFrame, useThree } from '@re
 import { useEffect, useMemo, useRef } from 'react'
 import * as THREE from 'three/webgpu'
 import useViewer from '../../store/use-viewer'
+import { DoorInteractiveSystem } from '../../systems/door/door-interactive-system'
 import { GuideSystem } from '../../systems/guide/guide-system'
 import { ItemLightSystem } from '../../systems/item-light/item-light-system'
 import { LevelSystem } from '../../systems/level/level-system'
@@ -145,6 +146,7 @@ const Viewer: React.FC<ViewerProps> = ({
       {/* Core systems */}
       <CeilingSystem />
       <DoorSystem />
+      <DoorInteractiveSystem />
       <FenceSystem />
       <ItemSystem />
       <RoofSystem />

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -17,5 +17,6 @@ export {
 } from './lib/materials'
 export { mergedOutline } from './lib/merged-outline-node'
 export { default as useViewer } from './store/use-viewer'
+export { DoorInteractionHint } from './systems/door/door-interaction-hint'
 export { InteractiveSystem } from './systems/interactive/interactive-system'
 export { snapLevelsToTruePositions } from './systems/level/level-utils'

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -74,9 +74,76 @@ type ViewerState = {
   walkthroughMode: boolean
   setWalkthroughMode: (mode: boolean) => void
 
+  /**
+   * FOV in degrees used by the perspective camera while `walkthroughMode`
+   * is active. Defaults to 85° (standard FPS-ish). 50° orbit FOV feels
+   * telephoto when you're standing inside the scene, so walkthrough gets
+   * its own setting. Persisted so users' preferred FOV sticks across
+   * sessions.
+   */
+  walkthroughFov: number
+  setWalkthroughFov: (fov: number) => void
+
   cameraDragging: boolean
   setCameraDragging: (dragging: boolean) => void
+
+  /**
+   * Per-door open/close animation state. A door enters this map the first
+   * time the user presses F while looking at it and stays there for the rest
+   * of the session (the rotation tick reads `startedAt` + `from` + `target`
+   * to compute the current open ratio without per-frame store writes — so
+   * subscribers don't re-render during the animation).
+   *
+   * Persisted across phase/mode switches via the viewer store but NOT across
+   * full reloads (excluded from `partialize`), so opening a bunch of doors
+   * while reviewing a scene doesn't leak into the next session.
+   */
+  doorAnim: Record<string, { from: number; target: 0 | 1; startedAt: number }>
+  toggleDoor: (id: string) => void
+  /**
+   * Drops animation entries for door ids that are no longer present in the
+   * scene. Called periodically by the DoorInteractiveSystem so entries for
+   * deleted nodes don't accumulate across long editing sessions.
+   */
+  pruneDoorAnim: (aliveIds: Set<string>) => void
+
+  /**
+   * ID of the door currently under the walkthrough crosshair (within reach).
+   * Populated by DoorInteractiveSystem via a camera-forward raycast; consumed
+   * by the F-key handler and the "Press F" hint overlay. `null` when the
+   * crosshair isn't on a door or walkthrough mode is off.
+   */
+  crosshairHoveredDoorId: string | null
+  setCrosshairHoveredDoorId: (id: string | null) => void
 }
+
+/**
+ * Cubic ease-in-out. Decent default for door swings — starts and ends slow,
+ * snaps through the middle. Used for the visible ratio only; the stored
+ * animation state is linear time-based so the easing curve can change
+ * without invalidating existing data.
+ */
+function easeInOutCubic(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
+}
+
+/**
+ * Shared helper for deriving the eased open ratio at time `now`. Exported
+ * separately so `toggleDoor` can snapshot a mid-animation ratio, and the
+ * per-frame door rotation system can compute the rendered angle without
+ * touching store state.
+ */
+export function computeCurrentRatio(
+  anim: { from: number; target: 0 | 1; startedAt: number },
+  now: number,
+  durationMs: number,
+): number {
+  const t = Math.max(0, Math.min(1, (now - anim.startedAt) / durationMs))
+  return anim.from + (anim.target - anim.from) * easeInOutCubic(t)
+}
+
+export const DOOR_OPEN_DURATION_MS = 450
+export const DOOR_MAX_ANGLE = Math.PI / 2
 
 const useViewer = create<ViewerState>()(
   persist(
@@ -200,8 +267,48 @@ const useViewer = create<ViewerState>()(
       walkthroughMode: false,
       setWalkthroughMode: (mode) => set({ walkthroughMode: mode }),
 
+      walkthroughFov: 85,
+      setWalkthroughFov: (fov) =>
+        // Clamp to a sane range. Below ~50 it feels sniper-scope; above
+        // ~110 the near-wall distortion is intolerable.
+        set({ walkthroughFov: Math.max(50, Math.min(110, fov)) }),
+
       cameraDragging: false,
       setCameraDragging: (dragging) => set({ cameraDragging: dragging }),
+
+      doorAnim: {},
+      toggleDoor: (id) =>
+        set((state) => {
+          const existing = state.doorAnim[id]
+          const now = performance.now()
+          // Compute the door's current open ratio (using whatever animation
+          // it was in mid-way through) so a mid-animation toggle reverses
+          // smoothly from where it is rather than snapping.
+          const current = existing ? computeCurrentRatio(existing, now, DOOR_OPEN_DURATION_MS) : 0
+          const target: 0 | 1 = current > 0.5 ? 0 : 1
+          return {
+            doorAnim: {
+              ...state.doorAnim,
+              [id]: { from: current, target, startedAt: now },
+            },
+          }
+        }),
+      pruneDoorAnim: (aliveIds) =>
+        set((state) => {
+          let changed = false
+          const next: typeof state.doorAnim = {}
+          for (const [id, anim] of Object.entries(state.doorAnim)) {
+            if (aliveIds.has(id)) {
+              next[id] = anim
+            } else {
+              changed = true
+            }
+          }
+          return changed ? { doorAnim: next } : state
+        }),
+
+      crosshairHoveredDoorId: null,
+      setCrosshairHoveredDoorId: (id) => set({ crosshairHoveredDoorId: id }),
     }),
     {
       name: 'viewer-preferences',
@@ -212,6 +319,7 @@ const useViewer = create<ViewerState>()(
         levelMode: state.levelMode,
         wallMode: state.wallMode,
         projectPreferences: state.projectPreferences,
+        walkthroughFov: state.walkthroughFov,
       }),
     },
   ),

--- a/packages/viewer/src/systems/door/door-interaction-hint.tsx
+++ b/packages/viewer/src/systems/door/door-interaction-hint.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import useViewer from '../../store/use-viewer'
+
+/**
+ * "Press F to open / Press F to close" prompt that sits just under the
+ * walkthrough crosshair whenever the user is aiming at a door within
+ * reach.
+ *
+ * Renders as a plain DOM element with fixed positioning — intended to be
+ * mounted inside a DOM overlay that already sits over the canvas (e.g.
+ * the editor's `FirstPersonOverlay`), not inside the `<Canvas>` itself.
+ * No-ops outside walkthrough mode or when nothing is targeted.
+ */
+export const DoorInteractionHint = () => {
+  const hoveredDoorId = useViewer((s) => s.crosshairHoveredDoorId)
+  const walkthroughMode = useViewer((s) => s.walkthroughMode)
+  // Subscribe to just this door's animation entry so the verb flips the
+  // frame the user presses F (subscribing to the whole `doorAnim` record
+  // would re-render on every door toggle anywhere in the scene). Hook
+  // runs unconditionally — the `null` branch covers the no-hover case
+  // without violating rules of hooks.
+  const anim = useViewer((s) => (hoveredDoorId ? s.doorAnim[hoveredDoorId] : null))
+
+  if (!walkthroughMode || !hoveredDoorId) return null
+
+  // Target-based verb: animations in flight still read as their final state,
+  // which matches what the user's action is going to do when they press F
+  // (toggle to the opposite of target).
+  const verb = anim?.target === 1 ? 'close' : 'open'
+
+  return (
+    <div
+      className="pointer-events-none fixed top-1/2 left-1/2 z-50 -translate-x-1/2 translate-y-8"
+      style={{ userSelect: 'none' }}
+    >
+      <div
+        className="rounded-md bg-black/60 px-3 py-1.5 font-medium text-white text-xs shadow-lg backdrop-blur-sm"
+        style={{ letterSpacing: '0.02em' }}
+      >
+        Press <span className="mx-1 rounded bg-white/15 px-1.5 py-0.5 font-mono">F</span> to {verb}
+      </div>
+    </div>
+  )
+}

--- a/packages/viewer/src/systems/door/door-interactive-system.tsx
+++ b/packages/viewer/src/systems/door/door-interactive-system.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { type DoorNode, sceneRegistry, useScene } from '@pascal-app/core'
+import { useFrame, useThree } from '@react-three/fiber'
+import { useEffect, useRef } from 'react'
+import * as THREE from 'three'
+import useViewer, {
+  computeCurrentRatio,
+  DOOR_MAX_ANGLE,
+  DOOR_OPEN_DURATION_MS,
+} from '../../store/use-viewer'
+
+const MAX_INTERACTION_DISTANCE = 2.5
+/** Cadence for garbage-collecting `doorAnim` entries whose door was
+ *  deleted. Running every 60 frames (~1s at 60fps) is plenty — entries
+ *  are tiny and the cost of the O(n) walk is negligible. */
+const PRUNE_EVERY_N_FRAMES = 60
+const _raycaster = new THREE.Raycaster()
+const _screenCenter = new THREE.Vector2(0, 0)
+
+/**
+ * Runs the interactive side of doors in both walkthrough and editor modes:
+ *
+ *   1. Animation tick — every frame, each entry in `useViewer.doorAnim` has
+ *      its current eased ratio recomputed from wall-clock time and pushed
+ *      to the matching door mesh's `leafPivot` rotation. The store is only
+ *      written to when the user toggles a door, so subscribers don't
+ *      re-render during the swing.
+ *
+ *   2. Crosshair targeting (walkthrough only) — a raycast from the camera
+ *      forward finds the nearest door within `MAX_INTERACTION_DISTANCE`
+ *      and records its id as `useViewer.crosshairHoveredDoorId`. Consumed
+ *      by the F-key handler and by the "Press F" hint overlay.
+ *
+ *   3. F-key handler — toggles whichever door is currently targeted. In
+ *      walkthrough mode that's the crosshair-hovered door; in editor mode
+ *      it falls back to whatever the pointer-event `hoveredId` is, so a
+ *      user hovering a door with the mouse can still open it with F.
+ *
+ * Lives in the viewer package (not apps/editor) so the read-only
+ * `/viewer/[id]` route gets interactive doors too, without the editor
+ * needing to wire anything up.
+ */
+export const DoorInteractiveSystem = () => {
+  const camera = useThree((s) => s.camera)
+  const walkthroughMode = useViewer((s) => s.walkthroughMode)
+  const frameCount = useRef(0)
+
+  // F-key handler — always mounted so F works in both modes; internally
+  // branches on walkthrough state to pick the right hovered-id source.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (e.key.toLowerCase() !== 'f') return
+
+      const state = useViewer.getState()
+      let targetId: string | null = null
+      if (state.walkthroughMode) {
+        targetId = state.crosshairHoveredDoorId
+      } else {
+        // Editor mode — only act if the pointer-hovered node is a door.
+        const hovered = state.hoveredId
+        if (hovered && sceneRegistry.byType.door.has(hovered as never)) {
+          targetId = hovered
+        }
+      }
+      if (!targetId) return
+      e.preventDefault()
+      state.toggleDoor(targetId)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  useFrame(() => {
+    // ── Walkthrough crosshair raycast ──
+    if (walkthroughMode) {
+      const meshes: THREE.Object3D[] = []
+      const doorIdByObject = new Map<THREE.Object3D, string>()
+      sceneRegistry.byType.door.forEach((id) => {
+        const obj = sceneRegistry.nodes.get(id as never)
+        if (obj) {
+          meshes.push(obj)
+          doorIdByObject.set(obj, id)
+        }
+      })
+      _raycaster.setFromCamera(_screenCenter, camera)
+      _raycaster.far = MAX_INTERACTION_DISTANCE
+      const hits = _raycaster.intersectObjects(meshes, true)
+      let hoveredDoorId: string | null = null
+      if (hits.length > 0) {
+        // Walk up the hit ancestry to find the registered door root.
+        let node: THREE.Object3D | null = hits[0]!.object
+        while (node) {
+          const matched = doorIdByObject.get(node)
+          if (matched) {
+            hoveredDoorId = matched
+            break
+          }
+          node = node.parent
+        }
+      }
+      const prev = useViewer.getState().crosshairHoveredDoorId
+      if (prev !== hoveredDoorId) {
+        useViewer.getState().setCrosshairHoveredDoorId(hoveredDoorId)
+      }
+    } else if (useViewer.getState().crosshairHoveredDoorId) {
+      useViewer.getState().setCrosshairHoveredDoorId(null)
+    }
+
+    // ── Animation tick ──
+    const anims = useViewer.getState().doorAnim
+    const ids = Object.keys(anims)
+    frameCount.current = (frameCount.current + 1) % PRUNE_EVERY_N_FRAMES
+    if (ids.length === 0) return
+    const now = performance.now()
+    const nodes = useScene.getState().nodes
+    for (const id of ids) {
+      const anim = anims[id]!
+      const mesh = sceneRegistry.nodes.get(id as never)
+      if (!mesh) continue
+      const pivot = mesh.getObjectByName('leafPivot') as THREE.Object3D | undefined
+      if (!pivot) continue
+      const node = nodes[id as never] as DoorNode | undefined
+      if (!node || node.type !== 'door') continue
+      const ratio = computeCurrentRatio(anim, now, DOOR_OPEN_DURATION_MS)
+      // Swing sign matches the 2D floorplan arc convention (see the door
+      // branch of `floorplan-panel.tsx`): "inward" swings the free edge
+      // toward the wall's interior-side perpendicular, "outward" the
+      // opposite way. `hingesSide` picks which edge is the pivot; the
+      // swing direction combined with the hinge side gives the rotation
+      // sign below. Kept consistent with the floorplan so toggling
+      // either field in the door panel updates both views the same way.
+      const hingeSign = node.hingesSide === 'right' ? 1 : -1
+      const swingSign = node.swingDirection === 'inward' ? 1 : -1
+      pivot.rotation.y = ratio * DOOR_MAX_ANGLE * hingeSign * swingSign
+    }
+
+    // Periodic cleanup: drop animation entries for doors that have been
+    // deleted from the scene. Batched to once a second so the O(n) walk
+    // doesn't run every frame.
+    if (frameCount.current === 0) {
+      const aliveIds = new Set<string>()
+      for (const id of sceneRegistry.byType.door) {
+        aliveIds.add(id)
+      }
+      useViewer.getState().pruneDoorAnim(aliveIds)
+    }
+  })
+
+  return null
+}


### PR DESCRIPTION
## What does this PR do?

Hover a door, press **F**, it opens. Press F again, it closes. Smooth cubic ease-in-out on a 450 ms swing around the hinge edge, with mid-animation toggles reversing from wherever the leaf is rather than snapping. Works in both walkthrough and editor modes — pointer-hover drives the target in the editor; a camera-forward raycast drives it in walkthrough (with a *Press F to open / close* hint that appears under the crosshair when the target is within ~2.5 m).

Rolls in two consistency fixes that I found while wiring this up — both are surface-level mismatches between what the door panel lets you set and what actually renders.

### 1. Interactive open / close

**Core — new hinge-pivot group in `DoorSystem`.** The leaf, handle, door closer, and panic bar now live inside a named `leafPivot` group positioned at the hinge edge (with a zero-offset child `leafOffset` so existing door-center-relative coordinates still work). Rotating `leafPivot.rotation.y` swings the free edge around the correct axis. The frame posts, head, threshold, hinges, and wall cutout stay on the root mesh where they belong. On dirty-rebuild the group is preserved, so whatever rotation was applied survives geometry regeneration (so e.g. flipping `hingesSide` mid-swing repositions the pivot without resetting the rotation to 0).

**Viewer — new `DoorInteractiveSystem` and `DoorInteractionHint`.** The system owns:
1. An F-key handler (guards on inputs/textareas the same way `use-keyboard.ts` does).
2. A per-frame crosshair raycast in walkthrough mode that finds the nearest door within range and sets `useViewer.crosshairHoveredDoorId`.
3. The per-frame animation tick that reads time-based entries out of `useViewer.doorAnim` and pushes an eased rotation onto each door's `leafPivot`. Store writes only happen on toggle, so subscribers don't re-render during the swing.
4. A periodic (~1s) prune of anim entries for doors that have since been deleted from the scene.

`DoorInteractionHint` is a plain DOM overlay that portals into whatever layout already sits over the canvas (the editor's `FirstPersonOverlay` in this PR). The viewer package exports it so the read-only `/viewer/[id]` route could use it too.

**Store — `useViewer.doorAnim`, `toggleDoor`, `pruneDoorAnim`, `crosshairHoveredDoorId`.** Door animation state is `{ from, target, startedAt }` per door id — intentionally *not* persisted across full reloads (excluded from `partialize`) so opening a bunch of doors while reviewing a scene doesn't leak into the next session.

### 2. Swing direction matches the 2D floorplan arc

The floorplan panel already draws a swing arc from `hingesSide` + `swingDirection`. The 3D renderer didn't rotate the leaf in a way that matched the arc — the initial sign convention I tried for the swing animation swung the free edge opposite the floorplan's curve. Fixed in `DoorInteractiveSystem` so the rotation sign agrees with the floorplan convention: "inward" swings the free edge toward the wall's interior-side perpendicular, "outward" the other way, `hingesSide` picks the pivot edge. Editing either field in the door panel now updates both views the same way.

### 3. Handle auto-derived from `hingesSide` (on both faces)

Two small bugs in `DoorSystem` that I hit while testing:

- **Handle side was independent from hinges side.** The leaf had a separate `handleSide` field with its own segmented control in the panel. Flipping `hingesSide` (e.g. to correct the swing) left the handle stranded on the hinge edge, which is never what a real door looks like. The renderer now always places the handle on the side opposite the hinges, derived from `hingesSide` directly. `handleSide` is still in the schema (backward-compat for existing scenes) but no longer affects rendering, and the redundant panel control is removed.
- **Handle only existed on one face of the leaf.** Only the `+Z` face had a backplate + lever — from the other room the door looked like it had no handle. The renderer now stamps a mirrored pair on the `-Z` face too. The asymmetric hardware (door closer, panic bar) stays single-sided on purpose, since those really are one-sided in practice (push-side vs pull-side).

## How to test

1. `bun dev`, open any scene with a door.
2. **In editor mode:** hover a door with the mouse → press F. The door should swing open around its hinge edge on a ~450 ms ease. Press F again to close. Open a door, change its `hingesSide` or `swingDirection` in the panel → the leaf repositions around the new pivot and continues with the correct rotation direction. Confirm there's no longer a *Handle Side* control in the panel.
3. **In walkthrough mode:** click the walkthrough toggle → look at a door within ~2.5 m. A *Press F to open* hint should appear under the crosshair. Press F. Walk to the other side of the door — there should be a handle on this face too. Glance away and back mid-swing; the ratio should pick up from where it is.
4. **Floorplan consistency:** open the 2D floorplan. Compare the arc direction with which way the 3D leaf swings in walkthrough. They should agree across all four `hingesSide × swingDirection` combinations.
5. **Editor F still opens the furnish panel out of walkthrough.** The walkthrough guard in `use-keyboard.ts` only bails when `walkthroughMode === true`; flat 3D / floorplan F keeps its existing behaviour.
6. `bun check`, `bun check-types`, `bun run build` all clean on the touched files.

## Scope

- **9 files:**
  - `packages/core/src/systems/door/door-system.tsx` — leaf-pivot group, handle-side auto-derive, handle on both faces
  - `packages/viewer/src/store/use-viewer.ts` — `doorAnim`, `toggleDoor`, `pruneDoorAnim`, `crosshairHoveredDoorId`, shared easing helper + duration/angle constants
  - `packages/viewer/src/systems/door/door-interactive-system.tsx` — *new*
  - `packages/viewer/src/systems/door/door-interaction-hint.tsx` — *new*
  - `packages/viewer/src/index.ts` — export `DoorInteractionHint`
  - `packages/viewer/src/components/viewer/index.tsx` — mount `<DoorInteractiveSystem />`
  - `packages/editor/src/hooks/use-keyboard.ts` — let `DoorInteractiveSystem` claim F in walkthrough
  - `packages/editor/src/components/editor/first-person-controls.tsx` — `Open door [F]` in the controls hint; mount `<DoorInteractionHint />`
  - `packages/editor/src/components/ui/panels/door-panel.tsx` — remove the redundant Handle Side segmented control
- **Schema-compatible:** no new fields on `DoorNode`; the animation state is runtime-only in the viewer store. `handleSide` is preserved in the schema for existing scenes, just no longer load-bearing.
- **Deprecation note:** if nothing else ends up needing `handleSide`, it's a safe follow-up to drop from the schema in a later PR.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (`bun check` passes on the touched files — verified via `biome check` at `@biomejs/biome@^2.4.6`)
- [x] I've updated relevant documentation (N/A — no docs affected)
- [x] This PR targets the `main` branch