### PR TITLE
feat: add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+node_modules
+**/node_modules
+**/.next
+**/.turbo
+**/dist
+.env
+.env.local
+.env*.local
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.0-alpine
+WORKDIR /app
+
+COPY . .
+RUN bun install --frozen-lockfile
+RUN touch apps/editor/.env.local
+RUN ./node_modules/.bin/turbo run build --filter=editor
+
+EXPOSE 3000
+WORKDIR /app/apps/editor
+CMD ["bun", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,25 @@
-FROM oven/bun:1.3.0-alpine
+# Matches `packageManager` in package.json and the version CI installs — a skew
+# here is what makes `--frozen-lockfile` fail inside the image but not locally.
+FROM oven/bun:1.3.14-alpine
 WORKDIR /app
+
+# `next build` runs under `node`, and this image's `node` is a shim that re-execs
+# bun (/usr/local/bun-node-fallback-bin/node). Next 16's build crashes it — a
+# segfault on 1.3.14, a turbopack CommonJS wrapper error on 1.3.0 — on both arm64
+# and amd64. CI does not hit this because GitHub runners have a real node.
+RUN apk add --no-cache nodejs
 
 COPY . .
 RUN bun install --frozen-lockfile
-RUN touch apps/editor/.env.local
 RUN ./node_modules/.bin/turbo run build --filter=editor
 
+# Saved scenes live in SQLite under PASCAL_DATA_DIR; owned by the runtime user so
+# the store can create the database on first write.
+RUN mkdir -p /data && chown -R bun:bun /data /app
+ENV PASCAL_DATA_DIR=/data
+VOLUME /data
+
+USER bun
 EXPOSE 3000
 WORKDIR /app/apps/editor
 CMD ["bun", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  editor:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,18 @@ services:
   editor:
     build: .
     ports:
+      # Keep the container port at 3000. `/scenes` fetches its own API through a
+      # base URL that only `NEXT_PUBLIC_APP_URL` can override, and Next inlines
+      # that at build time — so a remapped host port 500s the page.
       - "3000:3000"
     environment:
       NODE_ENV: production
+      # Scene database location. Without the volume below, every saved project is
+      # discarded when the container is recreated.
+      PASCAL_DATA_DIR: /data
+    volumes:
+      - pascal-data:/data
     restart: unless-stopped
+
+volumes:
+  pascal-data:


### PR DESCRIPTION
## Summary

- Adds a `Dockerfile` using `oven/bun:1.3.0-alpine` that installs dependencies, builds all workspace packages via Turbo, and serves the Next.js app
- Adds a `docker-compose.yml` for a one-command start (`docker compose up --build`)
- Adds `.dockerignore` to exclude `node_modules`, build artifacts, and local env files from the build context

## Usage

```bash
docker compose up --build
```

The editor will be available at `http://localhost:3000`.

Optional env vars (e.g. `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`) can be passed under the `environment` key in `docker-compose.yml` — the editor works without them.

## Test plan

- [x] `docker compose up --build` completes without errors
- [x] Editor loads at `http://localhost:3000`
- [x] Create/edit a building, confirm 3D viewport works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and ops-only changes; no application auth or business logic modified, though build/runtime assumptions (Bun version, port 3000, data volume) affect how the editor is deployed.
> 
> **Overview**
> Adds **containerized deployment** for the Next.js editor so it can be built and run with `docker compose up --build`.
> 
> The **Dockerfile** uses `oven/bun:1.3.14-alpine`, installs deps with `bun install --frozen-lockfile`, builds only the editor via Turbo, and runs as the `bun` user from `apps/editor`. It installs **Alpine `nodejs`** so `next build` uses a real Node binary (the Bun image’s `node` shim breaks Next 16). Scene SQLite data is directed to **`PASCAL_DATA_DIR=/data`** with a declared volume and permissions for the runtime user.
> 
> **`.dockerignore`** keeps `.git`, `node_modules`, Next/Turbo outputs, env files, and logs out of the build context. **`docker-compose.yml`** maps **host port 3000 to container 3000** (documented constraint for `/scenes` and `NEXT_PUBLIC_APP_URL` build-time inlining), sets production env and **`pascal-data`** volume on `/data`, and uses `restart: unless-stopped`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d7266b38d6d12dfb88a9556b7509efd2aac24a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->