### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+## 0.6.0 (2026-04-21)
+
+### Features
+
+- **Multi-surface material system** — per-surface materials for walls, stairs, roofs with click-targeted 3D editing ([#266](https://github.com/pascalorg/editor/pull/266)) by [@sudhir9297](https://github.com/sudhir9297)
+- **Automatic wall-room generation** — closed wall loops auto-split and generate slabs ([#255](https://github.com/pascalorg/editor/pull/255), [#257](https://github.com/pascalorg/editor/pull/257)) by [@sudhir9297](https://github.com/sudhir9297)
+- **Stair-slab integration** — stair-driven cutouts in slabs and ceilings, auto ceilings from wall loops
+- **Curved fence support** + endpoint move tools ([#267](https://github.com/pascalorg/editor/pull/267)) by [@sudhir9297](https://github.com/sudhir9297)
+- **13 material presets** — granite, marble, parquet, wallpaper, wood and more ([#231](https://github.com/pascalorg/editor/pull/231)) by [@sudhir9297](https://github.com/sudhir9297)
+- **Export scene system** — GLB, STL, OBJ formats ([#203](https://github.com/pascalorg/editor/pull/203)) by [@zephran-dev](https://github.com/zephran-dev), with STL/OBJ groundwork by [@mvanhorn](https://github.com/mvanhorn) ([#175](https://github.com/pascalorg/editor/pull/175))
+- **Street view / walkthrough mode** ([#173](https://github.com/pascalorg/editor/pull/173)) by [@Yashism](https://github.com/Yashism)
+- **Duplicate project** ([#178](https://github.com/pascalorg/editor/pull/178)) by [@kleenkanteen](https://github.com/kleenkanteen)
+- **Editable wall length slider** ([#195](https://github.com/pascalorg/editor/pull/195)) by [@zephran-dev](https://github.com/zephran-dev)
+- **Infinity dragging slider** using PointerLock API ([#206](https://github.com/pascalorg/editor/pull/206)) by [@claygeo](https://github.com/claygeo)
+- **Material system enhancements** ([#201](https://github.com/pascalorg/editor/pull/201)) by [@PMAT77](https://github.com/PMAT77)
+- **Editor layout redesign v2** + 3D box select
+- **Move/rotate building** + relative positioning for all tools
+- **Grid snap toolbar controls**
+- **Cut-out button** in floating action menu for slabs and ceilings
+
+### Fixes
+
+- **WebGPU renderer** — await `renderer.init()` in Canvas GL factory ([#233](https://github.com/pascalorg/editor/pull/233)) by [@b9llach](https://github.com/b9llach)
+- **WebGPU fallback** — skip post-processing when unavailable ([#234](https://github.com/pascalorg/editor/pull/234)) by [@b9llach](https://github.com/b9llach)
+- **Crash on mode switch** — fix crash when switching to Furniture mode ([#237](https://github.com/pascalorg/editor/pull/237)) by [@txhno](https://github.com/txhno)
+- **Crash on duplicate** — prevent crash when duplicating elements ([#239](https://github.com/pascalorg/editor/pull/239)) by [@nnhhoang](https://github.com/nnhhoang)
+- **Delete walls/slabs** via floating action menu ([#180](https://github.com/pascalorg/editor/pull/180)) by [@nnhhoang](https://github.com/nnhhoang)
+- **Counter-clockwise rotation** — T key for CCW rotation on selected nodes ([#184](https://github.com/pascalorg/editor/pull/184)) by [@nnhhoang](https://github.com/nnhhoang)
+- **Scene singleton cleanup** — release singletons on Editor unmount ([#214](https://github.com/pascalorg/editor/pull/214)) by [@geopenta](https://github.com/geopenta)
+- **State management & memory leaks** ([#152](https://github.com/pascalorg/editor/pull/152)) by [@hobostay](https://github.com/hobostay)
+- **Ghost wall prevention** — use WALL_MIN_LENGTH constant ([#168](https://github.com/pascalorg/editor/pull/168)) by [@zephran-dev](https://github.com/zephran-dev)
+- **Catalog image optimization** — add sizes and loading props ([#189](https://github.com/pascalorg/editor/pull/189)) by [@korvixhq](https://github.com/korvixhq)
+- **Code cleanup** — remove unused `@ts-expect-error` directive ([#150](https://github.com/pascalorg/editor/pull/150)) by [@cs68614-hash](https://github.com/cs68614-hash)
+- Robust undo/redo with nested history pause/resume
+- Post-processing recovery after duplicate scene mutations
+- Improved snapping across all geometry types
+- Thumbnails, placement, and responsiveness improvements
+- Stair elevation sync with floor slabs
+
+### Contributors
+
+A huge thank you to everyone who contributed to this release! 🎉
+
+- [@sudhir9297](https://github.com/sudhir9297) — material system, wall-room generation, curved walls, stairs, fences (7 PRs!)
+- [@zephran-dev](https://github.com/zephran-dev) — export system, wall length slider, ghost wall fix
+- [@nnhhoang](https://github.com/nnhhoang) — rotation controls, delete actions, crash fix
+- [@b9llach](https://github.com/b9llach) — WebGPU renderer fixes
+- [@txhno](https://github.com/txhno) — furniture mode crash fix
+- [@Yashism](https://github.com/Yashism) — street view / walkthrough mode
+- [@claygeo](https://github.com/claygeo) — infinity dragging slider
+- [@geopenta](https://github.com/geopenta) — scene singleton cleanup
+- [@kleenkanteen](https://github.com/kleenkanteen) — duplicate project feature
+- [@mvanhorn](https://github.com/mvanhorn) — STL/OBJ export formats
+- [@PMAT77](https://github.com/PMAT77) — material system enhancements
+- [@korvixhq](https://github.com/korvixhq) — catalog image optimization
+- [@hobostay](https://github.com/hobostay) — state management & memory leak fixes
+- [@cs68614-hash](https://github.com/cs68614-hash) — code cleanup

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
     },
     "packages/core": {
       "name": "@pascal-app/core",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "dedent": "^1.7.1",
         "idb-keyval": "^6.2.2",
@@ -75,7 +75,7 @@
     },
     "packages/editor": {
       "name": "@pascal-app/editor",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@iconify/react": "^6.0.2",
         "@number-flow/react": "^0.5.14",
@@ -106,8 +106,8 @@
         "zustand": "^5.0.11",
       },
       "devDependencies": {
-        "@pascal-app/core": "^0.5.1",
-        "@pascal-app/viewer": "^0.5.1",
+        "@pascal-app/core": "^0.6.0",
+        "@pascal-app/viewer": "^0.6.0",
         "@pascal/typescript-config": "*",
         "@types/howler": "^2.2.12",
         "@types/node": "^22.19.12",
@@ -117,8 +117,8 @@
         "typescript": "5.9.3",
       },
       "peerDependencies": {
-        "@pascal-app/core": "^0.5.1",
-        "@pascal-app/viewer": "^0.5.1",
+        "@pascal-app/core": "^0.6.0",
+        "@pascal-app/viewer": "^0.6.0",
         "@react-three/drei": "^10",
         "@react-three/fiber": "^9",
         "next": ">=15",
@@ -167,7 +167,7 @@
     },
     "packages/viewer": {
       "name": "@pascal-app/viewer",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "polygon-clipping": "^0.15.7",
         "zustand": "^5",
@@ -180,7 +180,7 @@
         "typescript": "5.9.3",
       },
       "peerDependencies": {
-        "@pascal-app/core": "^0.5.1",
+        "@pascal-app/core": "^0.6.0",
         "@react-three/drei": "^10",
         "@react-three/fiber": "^9",
         "react": "^18 || ^19",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pascal-app/core",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Core library for Pascal 3D building editor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pascal-app/editor",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Pascal building editor component",
   "type": "module",
   "exports": {
@@ -11,8 +11,8 @@
     "check-types": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@pascal-app/core": "^0.5.1",
-    "@pascal-app/viewer": "^0.5.1",
+    "@pascal-app/core": "^0.6.0",
+    "@pascal-app/viewer": "^0.6.0",
     "@react-three/drei": "^10",
     "@react-three/fiber": "^9",
     "next": ">=15",
@@ -50,8 +50,8 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
-    "@pascal-app/core": "^0.5.1",
-    "@pascal-app/viewer": "^0.5.1",
+    "@pascal-app/core": "^0.6.0",
+    "@pascal-app/viewer": "^0.6.0",
     "@pascal/typescript-config": "*",
     "@types/howler": "^2.2.12",
     "@types/node": "^22.19.12",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pascal-app/viewer",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "3D viewer component for Pascal building editor",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,7 +22,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "@pascal-app/core": "^0.5.1",
+    "@pascal-app/core": "^0.6.0",
     "@react-three/drei": "^10",
     "@react-three/fiber": "^9",
     "react": "^18 || ^19",


### PR DESCRIPTION
## v0.6.0

Bumps all packages (`@pascal-app/core`, `@pascal-app/viewer`, `@pascal-app/editor`) to 0.6.0.

### Changes since v0.5.1 (46 commits, 168 files, +12,177/−2,480)

#### ✨ Features

**Multi-surface Material System** (PR #266)
- Per-surface material fields for walls (interior/exterior), stairs (tread/side/railing), and roofs (top/edge/wall)
- Click-targeted material editing in 3D — click a surface to edit its material directly
- Backward-compatible migration from legacy single-material objects
- UV mapping fixes for roofs, stairs, and fences
- New material presets: granite, marble (x2), parquet (x2), wallpaper (x3), wood (x5)
- Material picker improvements (`hideSideControl`, `disabled` props)

**Automatic Wall-Room Generation** (PRs #255, #257)
- Automatic wall-splitting from closed wall loops
- Auto-generated slabs from room polygons
- Curved wall room support with simplified slab polygons
- Wall segment merge when deleting dividers
- 3D wall endpoint move controls with Alt-detach
- Wall split attachment migration

**Stair-Slab Integration** (PR #1/255)
- Stair-driven slab hole cutouts
- Stair openings in ceilings
- Auto cutout toggle in stair panel
- Stair placement using local level height

**Grid Snap & Toolbar**
- Cycling grid snap control in viewer toolbar
- Grid snap dropdown
- Toolbar toggle reordering

**Ceilings**
- Auto ceilings from wall loops
- Improved ceiling selection and move preview

**Fence Tooling** (PR #267)
- Full curved fence support (geometry, tool, panel, floating action menu)
- Fence endpoint move tools with Alt-detach
- Fence drafting snap improvements

#### 🔧 Fixes & Improvements

**Undo/Redo & Performance** (PR #267)
- Robust undo/redo with nested history pause/resume — no more drag preview flooding the undo stack
- Improved snapping for roofs, stairs, and slabs to wall/fence targets
- Live snap settings in polygon editor
- Disabled space detection during paused history for better drag performance

**Stability**
- Fix post-processing after duplicate scene mutations (#228)
- Guard null selected item during item tool placement (#229)
- Fix WebGPU renderer initialization order (#233, #234)
- Fix crash when duplicating elements (#239)
- Fix editor furnish item initialization (#237)
- Fix floorplan panel maximum update depth loop
- Fix stair building rotation
- Improved thumbnails, placement, and editor responsiveness (#258)
- Fix move tools perf and broken undo stack (#259)

**Rendering**
- Fix slab material reload persistence
- Ground occluder restricted to recessed slabs
- Fix opening remounts after merged wall reparenting
- Slider modifier standardization (Cmd=0.01, Shift=1)

### Build status
- `@pascal-app/core` build ✅
- `@pascal-app/viewer` build ✅
- `@pascal-app/editor` type check: 230 errors (vs 197 pre-existing in v0.5.1 — delta from new features in site-panel and scene.ts typings)

### To publish
After merge, run the Release workflow with `package=both` and `bump=minor`, then manually publish `@pascal-app/editor`:
```bash
cd packages/editor && npm publish --access public
```
