### PR TITLE
Add a minimal Bun devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "Pascal Editor",
+  "image": "oven/bun:1.3.0",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "postCreateCommand": "bun install",
+  "forwardPorts": [3002]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ bun install
 bun dev
 ```
 
-The editor will be running at **http://localhost:3000**. That's it!
+The editor will be running at **http://localhost:3002**. That's it!
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ bun dev
 # 1. Build @pascal-app/core and @pascal-app/viewer
 # 2. Start watching both packages for changes
 # 3. Start the Next.js editor dev server
-# Open http://localhost:3000
+# Open http://localhost:3002
 ```
 
 **Important:** Always run `bun dev` from the root directory to ensure the package watchers are running. This enables hot reload when you edit files in `packages/core/src/` or `packages/viewer/src/`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -11,7 +11,7 @@ bun install
 bun dev
 ```
 
-The editor will be running at **http://localhost:3000**.
+The editor will be running at **http://localhost:3002**.
 
 ## Environment Variables (optional)
 
@@ -24,7 +24,7 @@ cp .env.example .env
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` | No | Enables address search in the editor |
-| `PORT` | No | Dev server port (default: 3000) |
+| `PORT` | No | Dev server port (default: 3002) |
 
 The editor works fully without any environment variables.
 

--- a/apps/editor/README.md
+++ b/apps/editor/README.md
@@ -345,7 +345,7 @@ pnpm install
 # Run development server
 pnpm dev
 
-# Open http://localhost:3000
+# Open http://localhost:3002
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add a minimal `.devcontainer` config so the repo can be opened and run in Bun without extra setup
- Forward the editor port used by the app and install dependencies on container creation
- Update the local dev docs to match the actual dev server port

## Why
This makes onboarding easier and gives contributors a repeatable local environment with less machine-specific setup.