### PR TITLE
fix(viewer): kick render on focus and visibility resume

### DIFF
--- a/packages/viewer/src/components/viewer/frame-limiter.tsx
+++ b/packages/viewer/src/components/viewer/frame-limiter.tsx
@@ -28,10 +28,31 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     set({ frameloop: 'never' })
     raf = requestAnimationFrame(tick)
 
+    // Browsers throttle requestAnimationFrame when the tab is hidden, the
+    // window is unfocused, or the system marks the tab as occluded. With
+    // frameloop="never" rAF is the only render driver, so when it stalls the
+    // canvas freezes — Linux Firefox/Chrome and Zen show this as the viewer
+    // "turning off" between cursor interactions. Force one synchronous
+    // advance whenever the page resumes so the next visible frame matches the
+    // current scene state.
+    function kick() {
+      i += 1 / 1000
+      advance(i)
+    }
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible') kick()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('focus', kick)
+    window.addEventListener('pageshow', kick)
+
     return () => {
       if (raf) {
         cancelAnimationFrame(raf)
       }
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('focus', kick)
+      window.removeEventListener('pageshow', kick)
       set({ frameloop: initFrameloop })
     }
   }, [fps, advance, set, initFrameloop])


### PR DESCRIPTION
## What does this PR do?

`frameloop="never"` makes FrameLimiter's `requestAnimationFrame` loop the only render driver. Browsers throttle rAF when the tab is hidden, the window is unfocused, or the system marks the tab as occluded. When that happens `advance()` stops firing and the canvas stays whatever was last in the swap chain (blank on first paint, or the previous frame on subsequent freezes).

This adds three event listeners alongside the existing rAF loop. `visibilitychange` (transitioning to `visible`), window `focus`, and `pageshow` each call `advance()` synchronously so the next visible frame matches the current scene state without waiting for rAF to resume.

The fix is contained to `packages/viewer/src/components/viewer/frame-limiter.tsx` (+21/-0). No new imports. No layer-boundary changes.

Fixes #275
Closes #196

## Why prior fixes don't cover this

- #228 rebuilds the post-processing pipeline on duplicate-scene mutations
- #234 short-circuits the pipeline when `navigator.gpu` is undefined
- #284 caches the WebGPU renderer per canvas to avoid Canvas-remount races

None of those address rAF throttling. Once the throttle hits, every render path stalls because `useFrame` only runs when `advance()` is called.

## How to test

1. `bun install && bun dev`, open the editor in Chrome or Firefox.
2. Click the Pascal tab into focus. The viewer renders.
3. Switch to a different tab for 5 seconds, then switch back to Pascal.

Without the fix, the viewer can stay frozen (blank or stale) until you move the mouse over the canvas. With the fix, the viewer renders the current scene immediately on tab return.

A second reproducer: open Pascal in a focused tab, drag another window over Pascal so it occludes the canvas, then move that window away. Some Linux WMs (and Zen on Windows) trigger the same rAF throttle that this fix recovers from.

## Screenshots / screen recording

Before/after recorded locally on macOS Chrome 147 in the chrome MCP harness, which holds `document.visibilityState === 'hidden'` so the throttle path fires reliably. Frame 1 is the broken state on reload (blank canvas, faded toolbar). The click triggers a `focus` event, the new handler calls `advance()`, the scene renders.

![fix-275-before-after](https://github.com/mvanhorn/editor/releases/download/pr-291-evidence/fix-275-after.gif)

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (`bun check` passes)
- [x] I've updated relevant documentation (if applicable) - n/a, the inline comment in `frame-limiter.tsx` documents the rationale
- [x] This PR targets the `main` branch