### PR TITLE
fix(editor): guard door segments and columnRatios against undefined

### DIFF
--- a/packages/core/src/store/use-scene.ts
+++ b/packages/core/src/store/use-scene.ts
@@ -6,6 +6,7 @@ import { create, type StoreApi, type UseBoundStore } from 'zustand'
 import { BuildingNode } from '../schema'
 import type { Collection, CollectionId } from '../schema/collections'
 import { generateCollectionId } from '../schema/collections'
+import { DoorNode as DoorNodeSchema } from '../schema/nodes/door'
 import { LevelNode } from '../schema/nodes/level'
 import {
   getPitchFromActiveRoofHeight,
@@ -104,6 +105,11 @@ function normalizeStairSegmentNode(node: Record<string, unknown>) {
 
   const parsed = StairSegmentNodeSchema.safeParse(sanitized)
   return parsed.success ? parsed.data : null
+}
+
+function normalizeDoorNode(node: Record<string, unknown>) {
+  const parsed = DoorNodeSchema.safeParse(node)
+  return parsed.success ? { ...node, ...parsed.data } : null
 }
 
 function migrateWallSurfaceMaterials(node: Record<string, any>) {
@@ -362,6 +368,13 @@ function migrateNodes(nodes: Record<string, any>): Record<string, AnyNode> {
             : 0
         // 40° matches the RoofSegmentNode schema default.
         patchedNodes[id] = { ...rest, pitch: derived > 0 ? derived : 40 }
+      }
+    }
+
+    if (node.type === 'door') {
+      const normalized = normalizeDoorNode(node)
+      if (normalized) {
+        patchedNodes[id] = normalized
       }
     }
 

--- a/packages/viewer/src/systems/door/door-system.tsx
+++ b/packages/viewer/src/systems/door/door-system.tsx
@@ -2,6 +2,7 @@ import {
   type AnyNodeId,
   clampDoorOperationState,
   type DoorNode,
+  DoorNode as DoorNodeSchema,
   getDoorRenderOpenAmount,
   getEffectiveNode,
   sceneRegistry,
@@ -25,6 +26,20 @@ const defaultRevealMaterial = new THREE.MeshBasicMaterial({ color: '#7f766c' })
 let baseMaterial = getBaseMaterial()
 let revealMaterial: THREE.Material = defaultRevealMaterial
 let glassMaterial: THREE.Material = defaultGlassMaterial
+
+const DOOR_RENDER_DEFAULTS = DoorNodeSchema.parse({ id: 'door_render_default' })
+
+// Legacy/unparsed door nodes can miss schema-defaulted fields (segments,
+// columnRatios, dividerThickness, …) and crash the geometry build. Re-apply the
+// Zod defaults; if the node is structurally invalid (e.g. a segment missing a
+// required field) drop the bad segments, then fall back to defaults entirely.
+function normalizeDoorNodeForRender(node: DoorNode): DoorNode {
+  const parsed = DoorNodeSchema.safeParse(node)
+  if (parsed.success) return parsed.data
+  const retry = DoorNodeSchema.safeParse({ ...node, segments: undefined })
+  if (retry.success) return retry.data
+  return { ...DOOR_RENDER_DEFAULTS, id: node.id, parentId: node.parentId }
+}
 
 export const DoorSystem = () => {
   const dirtyNodes = useScene((state) => state.dirtyNodes)
@@ -1903,7 +1918,9 @@ function getEffectiveOpeningShape(node: DoorNode): DoorNode['openingShape'] {
     : (node.openingShape ?? 'rectangle')
 }
 
-function updateDoorMesh(node: DoorNode, mesh: THREE.Mesh) {
+function updateDoorMesh(rawNode: DoorNode, mesh: THREE.Mesh) {
+  const node = normalizeDoorNodeForRender(rawNode)
+
   // Root mesh is an invisible hitbox; all visuals live in child meshes
   mesh.geometry.dispose()
   mesh.geometry = new THREE.BoxGeometry(node.width, node.height, node.frameDepth)


### PR DESCRIPTION
## Problem

Sentry issue **EDITOR-AM** — TypeError: `Cannot read properties of undefined (reading 'length')` in `door-system.tsx` (487 events) AND escalating issue `Cannot read properties of undefined (reading 'some')` (1.8k events).

In `door-system.tsx`, the code accesses `segments.some` and `seg.columnRatios.length` without null guards. Legacy door nodes in the database may lack these fields because they were added later to the Zod schema with a default value. When the viewer loads these nodes directly from the DB, the fields are `undefined`.

## Fix
- Added defensive fallback: `segments ?? []` for all array iterations.
- Added defensive fallback: `seg.columnRatios ?? [1]` (matches Zod default).
- Added defensive fallback: `seg.dividerThickness ?? 0.03` (matches Zod default).