### PR TITLE
Mark elevator-opening-system as client

### DIFF
--- a/packages/core/src/systems/elevator/elevator-opening-system.tsx
+++ b/packages/core/src/systems/elevator/elevator-opening-system.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useRef } from 'react'
 import type { AnyNode } from '../../schema'
 import useScene from '../../store/use-scene'


### PR DESCRIPTION
## Summary

- `packages/core/src/systems/elevator/elevator-opening-system.tsx` imports `useEffect`/`useRef` from React, which Next.js RSC builds treat as client-only. Adding `"use client"` lets consumers that build with Next (e.g. private-editor's community app) compile the package.
- Other core systems use `useFrame` from `@react-three/fiber` and slip past RSC checks; this is the only `.tsx` system that needs the directive today.

Found while building private-editor against the just-merged elevator submodule bump:

```
./editor/packages/core/dist/systems/elevator/elevator-opening-system.js
You're importing a module that depends on useEffect into a React Server Component module.
```

## Test plan

- [ ] `bun run build` on a Next consumer (private-editor community) no longer fails on this file
- [ ] Editor app standalone still runs fine (the directive is a no-op outside Next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)