### PR TITLE
docs: fix editor-v2 stale folder name in apps/editor/README.md

### DIFF
--- a/apps/editor/README.md
+++ b/apps/editor/README.md
@@ -7,7 +7,7 @@ A 3D building editor built with React Three Fiber and WebGPU.
 This is a Turborepo monorepo with three main packages:
 
 ```
-editor-v2/
+editor/
 ├── apps/
 │   └── editor/          # Next.js application (this package)
 ├── packages/


### PR DESCRIPTION
## Summary

The folder tree at the top of `apps/editor/README.md` showed `editor-v2/` as the monorepo root. The repo was renamed to `editor` in the cleanup that moved `editor-v2` into history (see `apps/editor/` itself); this is the last stale reference.

This is the apps/editor README. Community PR #245 (kuishou68) covers the same typo in the root README - the two are complementary, not conflicting.

Fixes #244
