### PR TITLE
fix: restore fence tool handlers dropped by null-guard commit

### DIFF
--- a/packages/nodes/src/fence/tool.tsx
+++ b/packages/nodes/src/fence/tool.tsx
@@ -510,6 +510,26 @@ export const FenceTool: React.FC = () => {
         startingPoint.current.set(nextStart[0], event.localPosition[1], nextStart[1])
         endingPoint.current.copy(startingPoint.current)
         cursorRef.current?.position.copy(startingPoint.current)
+        previewRef.current.visible = false
+        buildingState.current = 1
+        setDraftMeasurement(null)
+      }
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') shiftPressed.current = true
+    }
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') shiftPressed.current = false
+    }
+
+    const onCancel = () => {
+      if (buildingState.current === 1) {
+        markToolCancelConsumed()
+        stopDrafting()
+      }
+    }
 
     emitter.on('grid:move', onGridMove)
     emitter.on('grid:click', onGridClick)


### PR DESCRIPTION
## Summary

[`251af2c`](https://github.com/pascalorg/editor/commit/251af2c) ("fix: add null guards for cursorRef in fence and wall tool click handlers", merged in [#315](https://github.com/pascalorg/editor/pull/315) / portforward of pr-309) added a `?.` on `cursorRef.current` in `onGridClick`, but the same commit accidentally deleted:

- the closing braces of the `else` branch and `onGridClick` itself, leaving the function syntactically unterminated, and
- the trailing reset block (`previewRef.current.visible = false`, `buildingState.current = 1`, `setDraftMeasurement(null)`), and
- the `onKeyDown` / `onKeyUp` / `onCancel` handler definitions — which are still referenced at the `emitter.on(...)` / `emitter.off(...)` sites below.

This left `main` failing to build:

```
src/fence/tool.tsx(527,4): error TS1128: Declaration or statement expected.
src/fence/tool.tsx(527,12): error TS1005: ';' expected.
…
src/fence/tool.tsx(518,31): error TS2552: Cannot find name 'onCancel'.
src/fence/tool.tsx(519,40): error TS2552: Cannot find name 'onKeyDown'.
src/fence/tool.tsx(520,38): error TS2552: Cannot find name 'onKeyUp'.
```

Restores the deleted block verbatim from the prior state (5bd2f51), keeping the intended `cursorRef.current?.` optional-chaining null guard.

## Test plan

- [x] `bun typecheck` (passes)
- [x] `bun run build` (passes — both editor packages and downstream community app)
- [ ] Smoke-test fence tool in the editor: place a fence, continue placing successive segments, press Esc to cancel, hold Shift for angle snap

🤖 Generated with [Claude Code](https://claude.com/claude-code)