### PR TITLE
fix(mcp): templates use string IDs for SiteNode.children

### DIFF
--- a/packages/mcp/src/templates/empty-studio.ts
+++ b/packages/mcp/src/templates/empty-studio.ts
@@ -238,16 +238,6 @@ function buildTemplate(): SceneGraph {
     nodes[node.id as AnyNodeId] = node
   }
 
-  // SiteNode.children is a discriminatedUnion of BuildingNode/ItemNode objects
-  // (not string ids) — so the site must embed the full building node. The
-  // rest of the tree uses string ids per the BaseNode/LevelNode/WallNode
-  // schemas. We mutate the flat-dict copy of the site here so the nested
-  // representation round-trips through AnyNode.safeParse.
-  const siteInDict = nodes['site_empty' as AnyNodeId] as unknown as {
-    children: unknown[]
-  }
-  siteInDict.children = [nodes['building_empty' as AnyNodeId]]
-
   return {
     nodes,
     rootNodeIds: ['site_empty'] as AnyNodeId[],

--- a/packages/mcp/src/templates/garden-house.ts
+++ b/packages/mcp/src/templates/garden-house.ts
@@ -263,10 +263,6 @@ function buildTemplate(): SceneGraph {
     ],
   } as unknown as AnyNode
 
-  // SiteNode.children is a discriminatedUnion of BuildingNode/ItemNode objects
-  // (not string ids) per the schema — embed the full building node here.
-  ;(nodes.site_garden as unknown as { children: unknown[] }).children = [nodes.building_garden!]
-
   return {
     nodes: nodes as Record<AnyNodeId, AnyNode>,
     rootNodeIds: ['site_garden'] as AnyNodeId[],

--- a/packages/mcp/src/templates/two-bedroom.ts
+++ b/packages/mcp/src/templates/two-bedroom.ts
@@ -291,10 +291,6 @@ function buildTemplate(): SceneGraph {
     ],
   } as unknown as AnyNode
 
-  // SiteNode.children is a discriminatedUnion of BuildingNode/ItemNode objects
-  // (not string ids) per the schema — embed the full building node here.
-  ;(nodes.site_2br as unknown as { children: unknown[] }).children = [nodes.building_2br!]
-
   return {
     nodes: nodes as Record<AnyNodeId, AnyNode>,
     rootNodeIds: ['site_2br'] as AnyNodeId[],


### PR DESCRIPTION
## What does this PR do?

Follow-up to #325. PR #320 changed `SiteNode.children` from embedded `BuildingNode | ItemNode` objects to flat `string[]` IDs. #325 updated the runtime call sites (`rehydrate-site-children.ts`, `generate-variants.ts`, `nodes/site/renderer.tsx`) but missed the three scene templates in `packages/mcp/src/templates/`, which still mutated the site node's `children` array to embed full building objects after building the flat dict.

This caused `AnyNode.safeParse` to fail for `site_empty`, `site_2br`, and `site_garden` when running `bun test --cwd packages/mcp` (part of `.github/workflows/mcp-ci.yml`):

```
✗ scene templates > empty-studio template nodes all pass AnyNode.safeParse
✗ scene templates > two-bedroom template nodes all pass AnyNode.safeParse
✗ scene templates > garden-house template nodes all pass AnyNode.safeParse

error: ... failed AnyNode.safeParse at children.0: Invalid input: expected string, received object
```

Each template already initialises `site.children` with the correct string id (e.g. `['building_empty']`); the obsolete mutation blocks just need to be removed.

## How to test

1. `bun test --cwd packages/mcp` — confirm all 281 tests pass (previously 3 failing).
2. Open the editor, load any of the three templates (empty-studio, two-bedroom, garden-house) — confirm the scene loads and the site/building/level hierarchy renders correctly.

## Screenshots / screen recording

N/A — non-visual fix (schema alignment in template data).

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch