### PR TITLE
ifc-converter: pass test script with no tests yet

### DIFF
--- a/packages/ifc-converter/package.json
+++ b/packages/ifc-converter/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc --build",
     "dev": "tsc --build --watch",
-    "test": "bun test",
+    "test": "bun test --pass-with-no-tests",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

`@pascal-app/ifc-converter` has no test files yet, so its `test` script (`bun test`) exits with code 1 (`No tests found!`) and fails the monorepo `turbo test` task in CI.

## Fix

Add `--pass-with-no-tests` to the package's `test` script. The task stays green until real tests land, at which point they run normally — matching the intent of sibling packages (`core`, `nodes`, `mcp`) that run `bun test` with existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)