### PR TITLE
ifc-converter: drop test script until tests exist

### DIFF
--- a/packages/ifc-converter/package.json
+++ b/packages/ifc-converter/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsc --build",
     "dev": "tsc --build --watch",
-    "test": "bun test --pass-with-no-tests",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

`@pascal-app/ifc-converter` has no test files yet, so `bun test` exits 1 (`No tests found!`) and fails the monorepo `turbo test` task in CI.

The previous attempt (#327) added `--pass-with-no-tests`, but the **bun 1.3.0 pinned in CI doesn't honor that flag** — it still prints `No tests found!` and exits 1. (The flag works on newer bun, which masked the issue locally.)

## Fix

Remove the `test` script entirely, matching the convention used by `@pascal-app/viewer` (which has no `test` script). Turbo skips the `test` task for packages that don't define one. The script comes back when real tests land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)