### PR TITLE
fix: resolve 8 test failures (stair fixtures, spawn icon, Zod v4 introspection, three-mesh-bvh)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test-preload.ts"]

--- a/packages/core/src/systems/stair/stair-opening-sync.test.ts
+++ b/packages/core/src/systems/stair/stair-opening-sync.test.ts
@@ -78,11 +78,14 @@ describe('syncAutoStairOpenings', () => {
     const building = BuildingNode.parse({ name: 'Building' })
     const ground = LevelNode.parse({ name: 'Ground', level: 0, parentId: building.id })
     const upper = LevelNode.parse({ name: 'Upper', level: 1, parentId: building.id })
+    // Opening must fully contain the computed stair polygon including the 0.15 m
+    // openingOffset expansion. Stair at position [2,0,0.2], width=1, length=2.6
+    // → expanded opening z ∈ [0.05, 2.95]. Use z ∈ [0, 3] with margin.
     const manualOpening: Array<[number, number]> = [
-      [1.2, 0.8],
-      [2.8, 0.8],
-      [2.8, 2.9],
-      [1.2, 2.9],
+      [1.2, 0],
+      [2.8, 0],
+      [2.8, 3],
+      [1.2, 3],
     ]
     const sourceCeiling = CeilingNode.parse({
       name: 'Source Ceiling',
@@ -205,11 +208,12 @@ describe('syncAutoStairOpenings', () => {
     const building = BuildingNode.parse({ name: 'Building' })
     const ground = LevelNode.parse({ name: 'Ground', level: 0, parentId: building.id })
     const upper = LevelNode.parse({ name: 'Upper', level: 1, parentId: building.id })
+    // Must fully contain the computed stair opening (z ∈ [0.05, 2.95] after expansion).
     const manualOpening: Array<[number, number]> = [
-      [1.2, 0.8],
-      [2.8, 0.8],
-      [2.8, 2.9],
-      [1.2, 2.9],
+      [1.2, 0],
+      [2.8, 0],
+      [2.8, 3],
+      [1.2, 3],
     ]
     const staleAutoOpening: Array<[number, number]> = [
       [1.5, 1],

--- a/packages/nodes/src/index.test.ts
+++ b/packages/nodes/src/index.test.ts
@@ -33,8 +33,12 @@ describe('builtinPlugin', () => {
     await loadPlugin(builtinPlugin)
     const unionKinds = new Set(
       AnyNode.options.map((option) => {
-        const typeShape = (option as unknown as { shape: { type: { value: string } } }).shape.type
-        return typeShape.value
+        // nodeType() wraps z.literal(kind) in ZodDefault so nodes can be parsed
+        // without an explicit type field. In Zod v4, ZodDefault has no .value;
+        // unwrap one level via .def.innerType to reach the ZodLiteral.
+        const field = (option as unknown as { shape: { type: any } }).shape.type
+        const literal: { value: string } = field.def?.innerType ?? field
+        return literal.value
       }),
     )
     const registryKinds = new Set(Array.from(nodeRegistry.entries(), ([kind]) => kind))

--- a/packages/nodes/src/spawn/__tests__/parity.test.ts
+++ b/packages/nodes/src/spawn/__tests__/parity.test.ts
@@ -34,9 +34,9 @@ describe('spawn definition', () => {
     expect(parsed.success).toBe(true)
   })
 
-  test('presentation declares an iconify icon for the palette', () => {
+  test('presentation declares a url icon for the palette', () => {
     expect(spawnDefinition.presentation?.label).toBe('Spawn Point')
-    expect(spawnDefinition.presentation?.icon.kind).toBe('iconify')
+    expect(spawnDefinition.presentation?.icon.kind).toBe('url')
     expect(spawnDefinition.presentation?.paletteSection).toBe('structure')
   })
 

--- a/test-preload.ts
+++ b/test-preload.ts
@@ -1,0 +1,19 @@
+import { mock } from 'bun:test'
+
+// three-mesh-bvh@0.9.9's UMD bundle has a class-initialization-order bug:
+// `class ObjectBVH extends threeMeshBvh.BVH` fires before `BVH` is exported.
+// This manifests when three-bvh-csg loads three-mesh-bvh via CJS `require`,
+// which happens transitively when any test imports @pascal-app/viewer (e.g.
+// packages/nodes shelf geometry tests). No test exercises CSG at runtime;
+// the mock prevents the crash without losing coverage.
+mock.module('three-bvh-csg', () => ({
+  ADDITION: 0,
+  SUBTRACTION: 1,
+  REVERSE_SUBTRACTION: 2,
+  Brush: class Brush {},
+  Evaluator: class Evaluator {
+    evaluate() {}
+    dispose() {}
+  },
+  OperationGroup: class OperationGroup {},
+}))


### PR DESCRIPTION
## What does this PR do?

Fixes all 8 test failures that appeared after pulling the latest `main` (shelf v2, IconRef url kind, StairOpeningSystem commits). Four distinct root causes:

**1. `stair-opening-sync` tests (4 failures)**
`manualOpening` fixtures used `z ∈ [0.8, 2.9]` but the computed stair opening expands to `z ∈ [0.05, 2.95]` (`position[2]=0.2` minus `openingOffset=0.15`). `isCoveredByExistingHole` requires full polygon containment, so the auto-hole was not suppressed. Fixtures updated to `z ∈ [0, 3]`.

**2. Spawn parity test (1 failure)**
Commit `6a1d853` (IconRef: add `url` kind) changed all registered icon refs from `{ kind: 'iconify' }` to `{ kind: 'url' }`. Test assertion still expected `'iconify'`. Updated to `'url'`.

**3. `builtinPlugin` discriminator test (1 failure)**
`nodeType()` wraps `z.literal(kind)` in `ZodDefault` so nodes parse without an explicit `type` field. In Zod v4, `ZodDefault` has no `.value` property — the test was written for Zod v3's bare `ZodLiteral`. Fixed introspection to unwrap via `.def?.innerType` before reading `.value`.

**4. `geometry.test.ts` errors (2 errors)**
Shelf v2 added `import … from '@pascal-app/viewer'` to `geometry.ts`. The viewer barrel transitively loads `wall-system` → `three-bvh-csg` → `three-mesh-bvh@0.9.9` as CJS/UMD (because `three-bvh-csg` lacks `exports` conditions). That UMD has a class-initialization-order bug in Bun's test environment. Added `bunfig.toml` + `test-preload.ts` to mock `three-bvh-csg` globally — no test exercises CSG at runtime, so this is safe.

## How to test

1. Pull this branch: `git fetch fork fix/test-failures-after-pull && git checkout fix/test-failures-after-pull`
2. Run `bun test` from the repo root
3. Expect: **662 pass, 0 fail, 0 errors**

## Screenshots / screen recording

N/A — non-visual change (test fixes only).

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch