### PR TITLE
fix(nodes): coalesce node.children to [] in renderers (Sentry EDITOR-C0)

### DIFF
--- a/packages/nodes/src/building/renderer.tsx
+++ b/packages/nodes/src/building/renderer.tsx
@@ -18,7 +18,7 @@ export const BuildingRenderer = ({ node }: { node: BuildingNode }) => {
       rotation={[node.rotation[0], node.rotation[1], node.rotation[2]]}
       {...handlers}
     >
-      {node.children.map((childId) => (
+      {(node.children ?? []).map((childId) => (
         <NodeRenderer key={childId} nodeId={childId} />
       ))}
     </group>

--- a/packages/nodes/src/ceiling/renderer.tsx
+++ b/packages/nodes/src/ceiling/renderer.tsx
@@ -117,7 +117,7 @@ export const CeilingRenderer = ({ node }: { node: CeilingNode }) => {
         scale={0}
         visible={false}
       />
-      {node.children.map((childId) => (
+      {(node.children ?? []).map((childId) => (
         <NodeRenderer key={childId} nodeId={childId} />
       ))}
     </mesh>

--- a/packages/nodes/src/site/renderer.tsx
+++ b/packages/nodes/src/site/renderer.tsx
@@ -139,7 +139,7 @@ export const SiteRenderer = ({ node }: { node: SiteNode }) => {
   return (
     <group ref={ref} {...handlers}>
       {/* Render children (buildings and items) */}
-      {node.children.map((childId) => (
+      {(node.children ?? []).map((childId) => (
         <NodeRenderer key={childId} nodeId={childId as AnyNodeId} />
       ))}
 

--- a/packages/nodes/src/wall/renderer.tsx
+++ b/packages/nodes/src/wall/renderer.tsx
@@ -78,7 +78,7 @@ const WallRenderer = ({ node }: { node: WallNode }) => {
         {...handlers}
       />
 
-      {node.children.map((childId) => (
+      {(node.children ?? []).map((childId) => (
         <NodeRenderer key={`${node.id}:${childId}`} nodeId={childId} />
       ))}
     </mesh>


### PR DESCRIPTION
## Summary

`CeilingRenderer` crashes in production with:

```
TypeError: Cannot read properties of undefined (reading 'map')
```

…because `node.children` is `undefined` for ceiling nodes loaded from older serialized data that predates the `children` field. Same shape can affect other container renderers.

`packages/nodes/src/roof/renderer.tsx` already uses `node.children ?? []` for exactly this reason. This PR applies the same guard to the remaining renderers that iterate `node.children` directly.

## Affected renderers

- `packages/nodes/src/ceiling/renderer.tsx` (the one that triggered Sentry EDITOR-C0)
- `packages/nodes/src/wall/renderer.tsx`
- `packages/nodes/src/site/renderer.tsx`
- `packages/nodes/src/building/renderer.tsx`

`roof/renderer.tsx` already had the guard — left untouched.

## Change

One-liner per file:

```diff
- {node.children.map((childId) => (
+ {(node.children ?? []).map((childId) => (
```

No behaviour change for properly-shaped nodes; only prevents the crash on legacy/partial node data.

## Sentry

- https://pascalorg.sentry.io/issues/7502667501/ (`MONOREPO-EDITOR-C0`)