### PR TITLE
fix(ifc-converter): broken Contributions GitHub URL

### DIFF
--- a/apps/ifc-converter/app/page.tsx
+++ b/apps/ifc-converter/app/page.tsx
@@ -16,7 +16,7 @@ export default function HomePage() {
           elements, default-height walls, skipped items.{' '}
           <a
             className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700"
-            href="https://github.com/pascalorg/editor/apps/ifc-converter"
+            href="https://github.com/pascalorg/editor/tree/main/apps/ifc-converter"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/apps/ifc-converter/next-env.d.ts
+++ b/apps/ifc-converter/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import './.next/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
The IFC converter's alpha banner pointed at
`github.com/pascalorg/editor/apps/ifc-converter`, which 404s — the canonical
path includes `/tree/main/`.

The same URL is reused by the new IFC importer surface in
`pascalorg/private-editor`'s community app, so keeping them consistent matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)