### PR TITLE
core: pause/resume primitive for wall-driven auto slab+ceiling sync

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,7 +56,10 @@ export {
   type AutoSlabSyncPlan,
   detectSpacesForLevel,
   initSpaceDetectionSync,
+  isSpaceDetectionPaused,
+  pauseSpaceDetection,
   planAutoSlabsForLevel,
+  resumeSpaceDetection,
   type Space,
   wallTouchesOthers,
 } from './lib/space-detection'

--- a/packages/core/src/lib/space-detection-pause.test.ts
+++ b/packages/core/src/lib/space-detection-pause.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  isSpaceDetectionPaused,
+  pauseSpaceDetection,
+  resumeSpaceDetection,
+} from './space-detection'
+
+// The pause flag is module-level (matching the existing pauseSceneHistory
+// refcount in store/history-control.ts). Reset it before/after each test so
+// leftover depth from one case can't bleed into another.
+function drain() {
+  for (let i = 0; i < 64 && isSpaceDetectionPaused(); i += 1) {
+    resumeSpaceDetection()
+  }
+}
+
+beforeEach(drain)
+afterEach(drain)
+
+describe('space-detection pause primitive', () => {
+  test('defaults to not paused', () => {
+    expect(isSpaceDetectionPaused()).toBe(false)
+  })
+
+  test('pauseSpaceDetection flips the flag, resumeSpaceDetection clears it', () => {
+    pauseSpaceDetection()
+    expect(isSpaceDetectionPaused()).toBe(true)
+    resumeSpaceDetection()
+    expect(isSpaceDetectionPaused()).toBe(false)
+  })
+
+  test('refcount — pause depth survives mismatched resumes from a second source', () => {
+    pauseSpaceDetection()
+    pauseSpaceDetection()
+    expect(isSpaceDetectionPaused()).toBe(true)
+
+    resumeSpaceDetection()
+    expect(isSpaceDetectionPaused()).toBe(true)
+
+    resumeSpaceDetection()
+    expect(isSpaceDetectionPaused()).toBe(false)
+  })
+
+  test('resume is a no-op when not currently paused', () => {
+    expect(isSpaceDetectionPaused()).toBe(false)
+    resumeSpaceDetection()
+    resumeSpaceDetection()
+    expect(isSpaceDetectionPaused()).toBe(false)
+
+    pauseSpaceDetection()
+    expect(isSpaceDetectionPaused()).toBe(true)
+    resumeSpaceDetection()
+    expect(isSpaceDetectionPaused()).toBe(false)
+  })
+})

--- a/packages/core/src/lib/space-detection.ts
+++ b/packages/core/src/lib/space-detection.ts
@@ -884,6 +884,29 @@ function runSpaceDetection(
   editorStore.getState().setSpaces(nextSpaces)
 }
 
+// Refcount of outstanding pause requests, matching the pauseSceneHistory
+// pattern. The community editor flips this off while the AI is actively
+// mutating the scene so the wall-driven auto slab/ceiling sync doesn't race
+// `create_room`'s explicit slabs/ceilings (see plan
+// `ai-pause-space-detection`).
+let spaceDetectionPauseDepth = 0
+
+/** Pause the wall-driven auto slab/ceiling sync. Refcounted — pair with `resumeSpaceDetection`. */
+export function pauseSpaceDetection(): void {
+  spaceDetectionPauseDepth += 1
+}
+
+/** Resume the wall-driven auto slab/ceiling sync. No-op if not currently paused. */
+export function resumeSpaceDetection(): void {
+  if (spaceDetectionPauseDepth === 0) return
+  spaceDetectionPauseDepth -= 1
+}
+
+/** True iff the wall-driven auto slab/ceiling sync is currently paused. */
+export function isSpaceDetectionPaused(): boolean {
+  return spaceDetectionPauseDepth > 0
+}
+
 export function initSpaceDetectionSync(sceneStore: any, editorStore: any): () => void {
   const previousSnapshots = new Map<string, string>()
   let isProcessing = false
@@ -907,6 +930,17 @@ export function initSpaceDetectionSync(sceneStore: any, editorStore: any): () =>
     const currentSnapshots = new Map<string, string>()
     for (const [levelId, walls] of wallsByLevel.entries()) {
       currentSnapshots.set(levelId, levelWallSnapshot(walls))
+    }
+
+    // Paused: roll the snapshot forward so we don't backfill (and re-duplicate)
+    // every paused change once detection resumes. Whatever the AI built while
+    // paused becomes the new baseline; only future changes will reconcile.
+    if (spaceDetectionPauseDepth > 0) {
+      previousSnapshots.clear()
+      for (const [levelId, snapshot] of currentSnapshots.entries()) {
+        previousSnapshots.set(levelId, snapshot)
+      }
+      return
     }
 
     const levelsToUpdate = new Set<string>()


### PR DESCRIPTION
## What does this PR do?

`initSpaceDetectionSync` in `packages/core/src/lib/space-detection.ts` subscribes to every scene mutation and auto-derives slabs/ceilings from wall topology. When a host app drives explicit slab/ceiling creation (e.g. the community editor's AI `create_room` flow, which builds zone → slab → ceiling → walls in sequence), the auto-sync races those nodes and the polygon-signature de-dupe in `syncAuto*ForLevel` is fragile enough that duplicate `autoFromWalls: true` nodes leak through.

This adds a refcount primitive, mirroring `pauseSceneHistory` in `store/history-control.ts`:

- `pauseSpaceDetection()` / `resumeSpaceDetection()` / `isSpaceDetectionPaused()` — exported from `@pascal-app/core`.
- The subscriber early-outs while the depth is non-zero, **and** rolls `previousSnapshots` forward so resume does NOT backfill paused-period changes (otherwise duplicates just shift in time).

No behavior change for callers that don't touch the new functions. The community editor wires this up via `useAISession` in a follow-up commit on `pascalorg/private-editor`.

## How to test

1. From a fresh checkout of this branch: `cd packages/core && bun run build && bun test src/lib/space-detection-pause.test.ts` — the 4 new unit cases for the refcount should pass.
2. Confirm nothing else regressed in `packages/core`: `bun test` from the core package root. The pre-existing `syncAutoStairOpenings` failures in `src/systems/stair/stair-opening-sync.test.ts` (visible on `main`) are unchanged by this branch.
3. Smoke-import in a consuming app: `import { pauseSpaceDetection, resumeSpaceDetection, isSpaceDetectionPaused } from '@pascal-app/core'` — types resolve, runtime calls toggle the depth as expected.

## Screenshots / screen recording

N/A — non-visual change (new exports + subscriber gating; no rendering or UI affected).

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run \`bun check\` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the \`main\` branch