### PR TITLE
fix(editor): guard onShelfMove against null cursorGroupRef (Sentry EDITOR-BC, 53k+ events)

### DIFF
--- a/packages/editor/src/components/tools/item/use-placement-coordinator.tsx
+++ b/packages/editor/src/components/tools/item/use-placement-coordinator.tsx
@@ -1252,12 +1252,8 @@ export function usePlacementCoordinator(config: PlacementCoordinatorConfig): Rea
 
     const onShelfMove = (event: ShelfEvent) => {
       has3DPointerDrivenMoveRef.current = true
-      // Guard against null ref. The mitt event listener can fire after the
-      // component unmounts (or before the <group ref> attaches), and the
-      // unguarded `cursorGroupRef.current.rotation.y = ...` write below was
-      // the source of EDITOR-BC (`Cannot read properties of null (reading
-      // 'rotation')`) — 53k+ events. Every other surface-move handler in
-      // this file already has this guard; onShelfMove was missed in #323.
+      // A shelf event can fire before the cursor group mounts or after
+      // teardown, leaving the ref null; bail before dereferencing it below.
       if (!cursorGroupRef.current) return
       const ctx = getContext()
       if (ctx.state.surface !== 'shelf-surface') {

--- a/packages/editor/src/components/tools/item/use-placement-coordinator.tsx
+++ b/packages/editor/src/components/tools/item/use-placement-coordinator.tsx
@@ -1252,6 +1252,13 @@ export function usePlacementCoordinator(config: PlacementCoordinatorConfig): Rea
 
     const onShelfMove = (event: ShelfEvent) => {
       has3DPointerDrivenMoveRef.current = true
+      // Guard against null ref. The mitt event listener can fire after the
+      // component unmounts (or before the <group ref> attaches), and the
+      // unguarded `cursorGroupRef.current.rotation.y = ...` write below was
+      // the source of EDITOR-BC (`Cannot read properties of null (reading
+      // 'rotation')`) — 53k+ events. Every other surface-move handler in
+      // this file already has this guard; onShelfMove was missed in #323.
+      if (!cursorGroupRef.current) return
       const ctx = getContext()
       if (ctx.state.surface !== 'shelf-surface') {
         // Cursor entered via a move event without an enter — try


### PR DESCRIPTION
## Summary

Adds the missing `if (!cursorGroupRef.current) return` guard at the top of `onShelfMove` in `packages/editor/src/components/tools/item/use-placement-coordinator.tsx`.

## Sentry signal

| Field | Value |
|-------|-------|
| Short ID | [`MONOREPO-EDITOR-BC`](https://pascalorg.sentry.io/issues/?query=MONOREPO-EDITOR-BC) |
| Error | `TypeError: Cannot read properties of null (reading 'rotation')` |
| Environment | `vercel-production` |
| First seen | 2026-05-20 01:42 UTC |
| Last seen | 2026-05-27 18:34 UTC |
| Events | **53,528** |
| Family | Same root cause as EDITOR-BG (2,830 events) and EDITOR-BH (378 events) — all hit the same handler from the same null deref |

Stack frames:
```
node_modules/.bun/mitt@3.0.1/.../mitt/src/index.ts: in map
editor/packages/editor/src/components/tools/item/use-placement-coordinator.tsx: in p (or t / E — minified)
```

## Root cause

Every other surface-move handler in this file (`onGridMove`, `onWallMove`, `onCeilingMove`, `onItemMove`) already short-circuits when `cursorGroupRef.current` is null. `onShelfMove` writes `cursorGroupRef.current.position.set(...)` and `cursorGroupRef.current.rotation.y = ...` without that guard, so when a shelf-surface hover stream from the mitt emitter races with cursor unmount (or fires before the `<group ref>` attaches), the rotation write throws.

That gap was missed when #323 added guards to BD/BE/9E.

## Why it's high-confidence

- **Pattern parity:** the guard already exists in 6 sibling handlers in the same file. This change brings `onShelfMove` into line with them.
- **Behavior unchanged when mounted:** `cursorGroupRef.current` is non-null in normal interaction; the early return only fires during unmount/teardown races, which is exactly when the throw was happening.
- **No type or lint surface changes.**

## Followups (separate)

- EDITOR-BG / EDITOR-BH have stack frames pointing at `use-placement-coordinator.tsx` lines that are the *guarded* handlers in #323. Worth re-checking after this lands and #323 lands; the 2,830 + 378 events may largely come from the same shelf path or a tiny remaining gap.
- EDITOR-BR (`/api/mcp` ZodError, ~348 events) is unrelated, blocked on schema migration.

🤖 Detected and fixed by the nightly Sentry triage agent. Aymeric — never auto-merging.