### PR TITLE
docs(mcp): document plan↔world coordinate convention

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -247,16 +247,29 @@ There is no sign flip. The editor builds plan geometry as
 the owning `level`'s elevation (its `level` field, in metres) plus the
 element's own height; slabs additionally carry an absolute `elevation`.
 
-**Heads-up when you compute coordinates outside the editor.** Because the plan
-is the X–Z plane, the second coordinate is **depth**, not a screen-"up" axis.
-If you generate geometry from a source that assumes *"Y = north, viewed from
-the top"* — a land survey with bearings from North, a north-up site plan, or
-most 2-D plotting libraries — the result can arrive **mirrored** relative to
-that source when viewed top-down. Pascal's own 2-D and 3-D tools are
-internally consistent, so this only affects geometry authored programmatically.
-Decide your axis mapping explicitly and verify orientation against a known
-reference (e.g. a scaled guide image) before trusting it; reflect across the
-appropriate axis if it comes in flipped.
+**Heads-up when you compute coordinates outside the editor.** Pascal's
+viewports apply their own rotations on top of the world axes: the 2-D plan
+panel wraps its content in a 90° rotation (see `FLOORPLAN_VIEW_ROTATION_DEG`
+in `packages/editor/src/components/editor/floorplan-panel.tsx`), and the 3-D
+"top-down" snap defaults to a ~45° offset between world and screen axes when
+you snap to it from the iso default position. So a layout authored as if
+*"Y = north, viewed top-down"* — common in land surveys, north-up site plans,
+and 2-D plotting libraries — will arrive **rotated** relative to its source
+when viewed in Pascal (and possibly further reflected, depending on which
+viewport and camera state you're in). The editor's own 2-D and 3-D tools are
+internally consistent with their stored coordinates, so this only affects
+geometry authored programmatically. To verify orientation before trusting
+externally-computed coordinates, place a scaled guide image at known anchor
+points and check alignment; apply whatever rotation (or reflection) your
+authoring side needs to match.
+
+A worked demonstration of all of this — axis-aligned baseline, the rotated
+30° example below, and a paired "page-intent vs world-result" L for the
+external-coordinate gotcha — lives in
+[`examples/coordinate-conventions-demo.md`](./examples/coordinate-conventions-demo.md)
+and [`examples/coordinate-conventions-demo.json`](./examples/coordinate-conventions-demo.json).
+Load the JSON with `pascal-mcp --scene examples/coordinate-conventions-demo.json`
+or import it through any host configured for the package.
 
 **Example — a 6 × 4 m slab rotated 30° about its first corner** (not
 axis-aligned, so the mapping is actually exercised):

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -227,6 +227,55 @@ console.log(scene)
 See [`examples/embed-in-agent.ts`](./examples/embed-in-agent.ts) for a
 compilable version.
 
+## Coordinate conventions
+
+Pascal is a **right-handed** scene where **X and Z form the ground plane and Y
+is up**. Lengths are in **metres**; rotations are **radians**, stored as Euler
+`[x, y, z]` tuples.
+
+**Plan → world.** Every 2-D point you pass is a ground-plane coordinate
+`[x, z]` — this includes `wall.start` / `wall.end` and the `polygon` / `holes`
+arrays of `slab`, `zone`, and `ceiling`. It maps to world space as:
+
+```
+[x, z]  →  (x, y, z)      // the 2nd component is world Z (depth), not "up"
+```
+
+There is no sign flip. The editor builds plan geometry as
+`new Vector3(point[0], y, point[1])` (see
+`packages/nodes/src/{wall,slab,ceiling}/tool.tsx`). The vertical `y` comes from
+the owning `level`'s elevation (its `level` field, in metres) plus the
+element's own height; slabs additionally carry an absolute `elevation`.
+
+**Heads-up when you compute coordinates outside the editor.** Because the plan
+is the X–Z plane, the second coordinate is **depth**, not a screen-"up" axis.
+If you generate geometry from a source that assumes *"Y = north, viewed from
+the top"* — a land survey with bearings from North, a north-up site plan, or
+most 2-D plotting libraries — the result can arrive **mirrored** relative to
+that source when viewed top-down. Pascal's own 2-D and 3-D tools are
+internally consistent, so this only affects geometry authored programmatically.
+Decide your axis mapping explicitly and verify orientation against a known
+reference (e.g. a scaled guide image) before trusting it; reflect across the
+appropriate axis if it comes in flipped.
+
+**Example — a 6 × 4 m slab rotated 30° about its first corner** (not
+axis-aligned, so the mapping is actually exercised):
+
+```json
+{
+  "op": "create",
+  "parentId": "<levelId>",
+  "node": {
+    "type": "slab",
+    "elevation": 0.0,
+    "polygon": [[0, 0], [5.196, 3.0], [3.196, 6.464], [-2.0, 3.464]]
+  }
+}
+```
+
+This lands flat on the ground (Y = 0), 6 m along a heading 30° off the +X axis
+and 4 m along its perpendicular — i.e. occupying world (x, z) directly.
+
 ## Tools
 
 All tools validate their inputs and outputs with Zod. Mutation tools are

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -233,26 +233,28 @@ Pascal is a **right-handed** scene where **X and Z form the ground plane and Y
 is up**. Lengths are in **metres**; rotations are **radians**, stored as Euler
 `[x, y, z]` tuples.
 
-**Plan → world.** Every 2-D point you pass is a ground-plane coordinate
+**Plan → world.** Every 2-D point you pass is a level/building-local
+ground-plane coordinate
 `[x, z]` — this includes `wall.start` / `wall.end` and the `polygon` / `holes`
-arrays of `slab`, `zone`, and `ceiling`. It maps to world space as:
+arrays of `slab`, `zone`, and `ceiling`. With the default identity building
+transform, it appears in world space as:
 
 ```
 [x, z]  →  (x, y, z)      // the 2nd component is world Z (depth), not "up"
 ```
 
-There is no sign flip. The editor builds plan geometry as
-`new Vector3(point[0], y, point[1])` (see
-`packages/nodes/src/{wall,slab,ceiling}/tool.tsx`). The vertical `y` comes from
-the owning `level`'s elevation (its `level` field, in metres) plus the
-element's own height; slabs additionally carry an absolute `elevation`.
+There is no sign flip in the stored convention: tooling consumes the second
+component as world Z directly. The vertical `y` starts from the owning level's
+stacked height as computed by the level system from accumulated level heights,
+plus the element's own height; slabs additionally carry an absolute
+`elevation`.
 
 **Heads-up when you compute coordinates outside the editor.** Pascal's
 viewports apply their own rotations on top of the world axes: the 2-D plan
-panel wraps its content in a 90° rotation (see `FLOORPLAN_VIEW_ROTATION_DEG`
-in `packages/editor/src/components/editor/floorplan-panel.tsx`), and the 3-D
-"top-down" snap defaults to a ~45° offset between world and screen axes when
-you snap to it from the iso default position. So a layout authored as if
+panel wraps its content in a 90° rotation (`FLOORPLAN_VIEW_ROTATION_DEG`), and
+the 3-D "top-down" snap preserves the camera's current azimuth, so when invoked
+from the iso default position, world and screen axes are offset by ~45° until
+you orbit to an axis-aligned view. So a layout authored as if
 *"Y = north, viewed top-down"* — common in land surveys, north-up site plans,
 and 2-D plotting libraries — will arrive **rotated** relative to its source
 when viewed in Pascal (and possibly further reflected, depending on which
@@ -268,11 +270,12 @@ A worked demonstration of all of this — axis-aligned baseline, the rotated
 external-coordinate gotcha — lives in
 [`examples/coordinate-conventions-demo.md`](./examples/coordinate-conventions-demo.md)
 and [`examples/coordinate-conventions-demo.json`](./examples/coordinate-conventions-demo.json).
-Load the JSON with `pascal-mcp --scene examples/coordinate-conventions-demo.json`
-or import it through any host configured for the package.
+Load the JSON with
+`pascal-mcp --stdio --scene examples/coordinate-conventions-demo.json`.
 
-**Example — a 6 × 4 m slab rotated 30° about its first corner** (not
-axis-aligned, so the mapping is actually exercised):
+**Example — a 6 × 4 m slab rotated 30° about its first corner** (coordinates
+rounded to 3 dp; sides ≈ 6 m / 4 m; not axis-aligned, so the mapping is
+actually exercised):
 
 ```json
 {
@@ -286,8 +289,13 @@ axis-aligned, so the mapping is actually exercised):
 }
 ```
 
-This lands flat on the ground (Y = 0), 6 m along a heading 30° off the +X axis
-and 4 m along its perpendicular — i.e. occupying world (x, z) directly.
+This lands flat on the ground (Y = 0), about 6 m along a heading 30° off the +X
+axis and 4 m along its perpendicular — i.e. occupying world (x, z) directly.
+
+One separate gotcha: wall-attached coordinates are wall-local, not plan
+coordinates. Stored door/window `position[0]`, and `place_item` `position[0]`
+when the target is a wall, are metres along the wall; wall-attached rotations
+are wall-local too.
 
 ## Tools
 

--- a/packages/mcp/examples/coordinate-conventions-demo.json
+++ b/packages/mcp/examples/coordinate-conventions-demo.json
@@ -1,0 +1,2124 @@
+{
+  "nodes": {
+    "slab_demo_a": {
+      "id": "slab_demo_a",
+      "name": "DEMO A -- 6x4 m axis-aligned (baseline)",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          18,
+          0
+        ],
+        [
+          24,
+          0
+        ],
+        [
+          24,
+          4
+        ],
+        [
+          18,
+          4
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_demo_b": {
+      "id": "slab_demo_b",
+      "name": "DEMO B -- 6x4 m rotated 30 deg from +X (verbatim)",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          18,
+          10
+        ],
+        [
+          23.195999999999998,
+          13
+        ],
+        [
+          21.196,
+          16.464
+        ],
+        [
+          16,
+          13.464
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_origin": {
+      "id": "slab_origin",
+      "name": "Origin",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          -0.3,
+          -0.3
+        ],
+        [
+          0.3,
+          -0.3
+        ],
+        [
+          0.3,
+          0.3
+        ],
+        [
+          -0.3,
+          0.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "site_conv_demo": {
+      "id": "site_conv_demo",
+      "name": "Coords conv demo site",
+      "type": "site",
+      "object": "node",
+      "polygon": {
+        "type": "polygon",
+        "points": [
+          [
+            -6,
+            -12
+          ],
+          [
+            44,
+            -12
+          ],
+          [
+            44,
+            40
+          ],
+          [
+            -6,
+            40
+          ]
+        ]
+      },
+      "visible": true,
+      "children": [
+        "building_conv_demo"
+      ],
+      "metadata": {},
+      "parentId": null
+    },
+    "level_conv_demo": {
+      "id": "level_conv_demo",
+      "name": "Coords conv demo ground level",
+      "type": "level",
+      "level": 0,
+      "object": "node",
+      "visible": true,
+      "children": [
+        "slab_axis_x_bar",
+        "slab_axis_x_tip",
+        "slab_axis_z_bar",
+        "slab_axis_z_tip",
+        "slab_axis_neg_x",
+        "slab_axis_neg_z",
+        "slab_origin",
+        "zone_lbl_compass_a",
+        "zone_lbl_compass_b",
+        "zone_lbl_axis_x",
+        "zone_lbl_axis_z",
+        "zone_lbl_axis_neg_x",
+        "zone_lbl_axis_neg_z",
+        "zone_lbl_origin",
+        "zone_lbl_caveat_1",
+        "zone_lbl_caveat_2",
+        "zone_lbl_caveat_3",
+        "zone_lbl_caveat_4",
+        "slab_demo_a",
+        "zone_lbl_a_title",
+        "zone_lbl_a_long",
+        "zone_lbl_a_short",
+        "zone_lbl_a_origin",
+        "zone_lbl_a_baseline",
+        "slab_demo_b",
+        "zone_lbl_b_title_1",
+        "zone_lbl_b_title_2",
+        "zone_lbl_b_verified_1",
+        "zone_lbl_b_verified_2",
+        "zone_lbl_b_verified_3",
+        "zone_lbl_b_origin",
+        "slab_demo_c_page",
+        "slab_demo_c_page_ax_x",
+        "slab_demo_c_page_ax_y",
+        "zone_lbl_c_p_title",
+        "zone_lbl_c_p_axx",
+        "zone_lbl_c_p_axy",
+        "zone_lbl_c_p_stem",
+        "zone_lbl_c_p_foot",
+        "zone_lbl_c_arrow",
+        "slab_demo_c_world",
+        "zone_lbl_c_w_title",
+        "zone_lbl_c_w_stem",
+        "zone_lbl_c_w_foot",
+        "zone_lbl_c_w_screen_1",
+        "zone_lbl_c_w_screen_2",
+        "slab_demo_d_page",
+        "slab_demo_d_page_ax_x",
+        "slab_demo_d_page_ax_y",
+        "zone_lbl_d_p_title_1",
+        "zone_lbl_d_p_title_2",
+        "zone_lbl_d_p_axx",
+        "zone_lbl_d_p_axy",
+        "zone_lbl_d_p_hope",
+        "zone_lbl_d_arrow",
+        "slab_demo_d_world",
+        "zone_lbl_d_w_title",
+        "zone_lbl_d_w_note_1",
+        "zone_lbl_d_w_note_2",
+        "zone_lbl_d_w_note_3",
+        "zone_lbl_d_w_note_4",
+        "zone_lbl_d_w_note_5",
+        "zone_takeaway_band",
+        "zone_lbl_take_1",
+        "zone_lbl_take_2",
+        "zone_lbl_take_3",
+        "zone_lbl_take_4",
+        "zone_lbl_take_5"
+      ],
+      "metadata": {
+        "label": "Coords conv demo"
+      },
+      "parentId": "building_conv_demo"
+    },
+    "slab_axis_neg_x": {
+      "id": "slab_axis_neg_x",
+      "name": "-X stub",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          -2.5,
+          -0.06
+        ],
+        [
+          0,
+          -0.06
+        ],
+        [
+          0,
+          0.06
+        ],
+        [
+          -2.5,
+          0.06
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_axis_neg_z": {
+      "id": "slab_axis_neg_z",
+      "name": "-Z stub",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          -0.06,
+          -2.5
+        ],
+        [
+          0.06,
+          -2.5
+        ],
+        [
+          0.06,
+          0
+        ],
+        [
+          -0.06,
+          0
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_axis_x_bar": {
+      "id": "slab_axis_x_bar",
+      "name": "+X axis bar",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          0,
+          -0.06
+        ],
+        [
+          12,
+          -0.06
+        ],
+        [
+          12,
+          0.06
+        ],
+        [
+          0,
+          0.06
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_axis_x_tip": {
+      "id": "slab_axis_x_tip",
+      "name": "+X tip",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          12,
+          -0.4
+        ],
+        [
+          12.9,
+          0
+        ],
+        [
+          12,
+          0.4
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_axis_z_bar": {
+      "id": "slab_axis_z_bar",
+      "name": "+Z axis bar",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          -0.06,
+          0
+        ],
+        [
+          0.06,
+          0
+        ],
+        [
+          0.06,
+          12
+        ],
+        [
+          -0.06,
+          12
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_axis_z_tip": {
+      "id": "slab_axis_z_tip",
+      "name": "+Z tip",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          -0.4,
+          12
+        ],
+        [
+          0.4,
+          12
+        ],
+        [
+          0,
+          12.9
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "zone_lbl_a_long": {
+      "id": "zone_lbl_a_long",
+      "name": "Long edge: 6 m along world +X",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          20.7,
+          1.3
+        ],
+        [
+          21.3,
+          1.3
+        ],
+        [
+          21.3,
+          1.9000000000000001
+        ],
+        [
+          20.7,
+          1.9000000000000001
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_axis_x": {
+      "id": "zone_lbl_axis_x",
+      "name": "+X axis = plan first component (12 m long)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          13.299999999999999,
+          -1.3
+        ],
+        [
+          13.9,
+          -1.3
+        ],
+        [
+          13.9,
+          -0.7
+        ],
+        [
+          13.299999999999999,
+          -0.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_axis_z": {
+      "id": "zone_lbl_axis_z",
+      "name": "+Z axis = plan second component (12 m long)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          -1.3,
+          13.299999999999999
+        ],
+        [
+          -0.7,
+          13.299999999999999
+        ],
+        [
+          -0.7,
+          13.9
+        ],
+        [
+          -1.3,
+          13.9
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_origin": {
+      "id": "zone_lbl_origin",
+      "name": "Origin (0, 0) -- all demo coords are world space, metres",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          1.2,
+          1.2
+        ],
+        [
+          1.8,
+          1.2
+        ],
+        [
+          1.8,
+          1.8
+        ],
+        [
+          1.2,
+          1.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_take_1": {
+      "id": "zone_lbl_take_1",
+      "name": "TAKEAWAY (1/5): [x,z] -> world (x, 0, z) exactly, no sign flip",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          2.7,
+          32.7
+        ],
+        [
+          3.3,
+          32.7
+        ],
+        [
+          3.3,
+          33.3
+        ],
+        [
+          2.7,
+          33.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_take_2": {
+      "id": "zone_lbl_take_2",
+      "name": "(2/5): Demo B verified: 6x4 m, 30 deg, AB perp AD",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          2.7,
+          33.5
+        ],
+        [
+          3.3,
+          33.5
+        ],
+        [
+          3.3,
+          34.099999999999994
+        ],
+        [
+          2.7,
+          34.099999999999994
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_take_3": {
+      "id": "zone_lbl_take_3",
+      "name": "(3/5): On-screen orientation is viewport-dependent",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          2.7,
+          34.300000000000004
+        ],
+        [
+          3.3,
+          34.300000000000004
+        ],
+        [
+          3.3,
+          34.9
+        ],
+        [
+          2.7,
+          34.9
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_take_4": {
+      "id": "zone_lbl_take_4",
+      "name": "(4/5): 2D plan rotates +90 deg; 3D top-down ~45 deg offset",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          2.7,
+          35.1
+        ],
+        [
+          3.3,
+          35.1
+        ],
+        [
+          3.3,
+          35.699999999999996
+        ],
+        [
+          2.7,
+          35.699999999999996
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_take_5": {
+      "id": "zone_lbl_take_5",
+      "name": "(5/5): Verify with a scaled guide image at known anchors",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          21.7,
+          32.7
+        ],
+        [
+          22.3,
+          32.7
+        ],
+        [
+          22.3,
+          33.3
+        ],
+        [
+          21.7,
+          33.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "slab_demo_c_page": {
+      "id": "slab_demo_c_page",
+      "name": "DEMO C -- PAGE INTENT (1/2 scale)",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          0,
+          22
+        ],
+        [
+          2,
+          22
+        ],
+        [
+          2,
+          22.5
+        ],
+        [
+          0.5,
+          22.5
+        ],
+        [
+          0.5,
+          24.5
+        ],
+        [
+          0,
+          24.5
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_demo_d_page": {
+      "id": "slab_demo_d_page",
+      "name": "DEMO D -- PAGE INTENT (z reflected, 1/2 scale)",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          22,
+          24.5
+        ],
+        [
+          24,
+          24.5
+        ],
+        [
+          24,
+          24
+        ],
+        [
+          22.5,
+          24
+        ],
+        [
+          22.5,
+          22
+        ],
+        [
+          22,
+          22
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "zone_lbl_a_short": {
+      "id": "zone_lbl_a_short",
+      "name": "Short edge: 4 m along world +Z",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          24.5,
+          1.7
+        ],
+        [
+          25.1,
+          1.7
+        ],
+        [
+          25.1,
+          2.3
+        ],
+        [
+          24.5,
+          2.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_a_title": {
+      "id": "zone_lbl_a_title",
+      "name": "DEMO A -- axis-aligned 6x4 m rectangle",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          20.7,
+          -1.3
+        ],
+        [
+          21.3,
+          -1.3
+        ],
+        [
+          21.3,
+          -0.7
+        ],
+        [
+          20.7,
+          -0.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_arrow": {
+      "id": "zone_lbl_c_arrow",
+      "name": "pasted [x,z] UNCORRECTED -->",
+      "type": "zone",
+      "color": "#ffe9c2",
+      "object": "node",
+      "polygon": [
+        [
+          6.2,
+          24.2
+        ],
+        [
+          6.8,
+          24.2
+        ],
+        [
+          6.8,
+          24.8
+        ],
+        [
+          6.2,
+          24.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_p_axx": {
+      "id": "zone_lbl_c_p_axx",
+      "name": "page +x = author's 'east'",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          2.1,
+          21.5
+        ],
+        [
+          2.6999999999999997,
+          21.5
+        ],
+        [
+          2.6999999999999997,
+          22.1
+        ],
+        [
+          2.1,
+          22.1
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_p_axy": {
+      "id": "zone_lbl_c_p_axy",
+      "name": "page +y = author's 'north'",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          -0.7,
+          24.099999999999998
+        ],
+        [
+          -0.10000000000000003,
+          24.099999999999998
+        ],
+        [
+          -0.10000000000000003,
+          24.7
+        ],
+        [
+          -0.7,
+          24.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_arrow": {
+      "id": "zone_lbl_d_arrow",
+      "name": "pasted as [x,z] -->",
+      "type": "zone",
+      "color": "#ffe9c2",
+      "object": "node",
+      "polygon": [
+        [
+          28.2,
+          24.2
+        ],
+        [
+          28.8,
+          24.2
+        ],
+        [
+          28.8,
+          24.8
+        ],
+        [
+          28.2,
+          24.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_p_axx": {
+      "id": "zone_lbl_d_p_axx",
+      "name": "page +x",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          24.099999999999998,
+          21.5
+        ],
+        [
+          24.7,
+          21.5
+        ],
+        [
+          24.7,
+          22.1
+        ],
+        [
+          24.099999999999998,
+          22.1
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_p_axy": {
+      "id": "zone_lbl_d_p_axy",
+      "name": "page +y",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          21.3,
+          24.099999999999998
+        ],
+        [
+          21.900000000000002,
+          24.099999999999998
+        ],
+        [
+          21.900000000000002,
+          24.7
+        ],
+        [
+          21.3,
+          24.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "slab_demo_c_world": {
+      "id": "slab_demo_c_world",
+      "name": "DEMO C -- WORLD RESULT (uncorrected)",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          10,
+          22
+        ],
+        [
+          14,
+          22
+        ],
+        [
+          14,
+          23
+        ],
+        [
+          11,
+          23
+        ],
+        [
+          11,
+          27
+        ],
+        [
+          10,
+          27
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_demo_d_world": {
+      "id": "slab_demo_d_world",
+      "name": "DEMO D -- WORLD RESULT (mirror image of Demo C)",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          32,
+          27
+        ],
+        [
+          36,
+          27
+        ],
+        [
+          36,
+          26
+        ],
+        [
+          33,
+          26
+        ],
+        [
+          33,
+          22
+        ],
+        [
+          32,
+          22
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "zone_lbl_a_origin": {
+      "id": "zone_lbl_a_origin",
+      "name": "First corner at world (18, 0)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          18.2,
+          0.2
+        ],
+        [
+          18.8,
+          0.2
+        ],
+        [
+          18.8,
+          0.8
+        ],
+        [
+          18.2,
+          0.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_b_origin": {
+      "id": "zone_lbl_b_origin",
+      "name": "First vertex (18, 10) -- canonical [[0,0],[5.196,3],...] + offset",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          18.2,
+          10.2
+        ],
+        [
+          18.8,
+          10.2
+        ],
+        [
+          18.8,
+          10.8
+        ],
+        [
+          18.2,
+          10.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_p_foot": {
+      "id": "zone_lbl_c_p_foot",
+      "name": "foot: 4 m along page +x",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          1.2,
+          21.2
+        ],
+        [
+          1.8,
+          21.2
+        ],
+        [
+          1.8,
+          21.8
+        ],
+        [
+          1.2,
+          21.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_p_stem": {
+      "id": "zone_lbl_c_p_stem",
+      "name": "stem: 5 m along page +y",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          -1.1,
+          23.099999999999998
+        ],
+        [
+          -0.5,
+          23.099999999999998
+        ],
+        [
+          -0.5,
+          23.7
+        ],
+        [
+          -1.1,
+          23.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_w_foot": {
+      "id": "zone_lbl_c_w_foot",
+      "name": "foot along world +X (was author's east)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          12.2,
+          22.2
+        ],
+        [
+          12.8,
+          22.2
+        ],
+        [
+          12.8,
+          22.8
+        ],
+        [
+          12.2,
+          22.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_w_stem": {
+      "id": "zone_lbl_c_w_stem",
+      "name": "stem along world +Z (was author's north)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          10.2,
+          24.2
+        ],
+        [
+          10.8,
+          24.2
+        ],
+        [
+          10.8,
+          24.8
+        ],
+        [
+          10.2,
+          24.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_caveat_1": {
+      "id": "zone_lbl_caveat_1",
+      "name": "Viewports may rotate world axes on screen",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          4.7,
+          -6.3
+        ],
+        [
+          5.3,
+          -6.3
+        ],
+        [
+          5.3,
+          -5.7
+        ],
+        [
+          4.7,
+          -5.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_caveat_2": {
+      "id": "zone_lbl_caveat_2",
+      "name": "2D plan panel applies +90 deg rotation",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          4.7,
+          -7.3
+        ],
+        [
+          5.3,
+          -7.3
+        ],
+        [
+          5.3,
+          -6.7
+        ],
+        [
+          4.7,
+          -6.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_caveat_3": {
+      "id": "zone_lbl_caveat_3",
+      "name": "3D 'top-down' camera defaults to ~45 deg offset",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          4.7,
+          -8.3
+        ],
+        [
+          5.3,
+          -8.3
+        ],
+        [
+          5.3,
+          -7.7
+        ],
+        [
+          4.7,
+          -7.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_caveat_4": {
+      "id": "zone_lbl_caveat_4",
+      "name": "World axes themselves are stable; only display rotates",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          4.7,
+          -9.3
+        ],
+        [
+          5.3,
+          -9.3
+        ],
+        [
+          5.3,
+          -8.7
+        ],
+        [
+          4.7,
+          -8.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_p_hope": {
+      "id": "zone_lbl_d_p_hope",
+      "name": "Hope: 'reflecting z will un-mirror the result'",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          22.7,
+          25.2
+        ],
+        [
+          23.3,
+          25.2
+        ],
+        [
+          23.3,
+          25.8
+        ],
+        [
+          22.7,
+          25.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "building_conv_demo": {
+      "id": "building_conv_demo",
+      "name": "Demo bld",
+      "type": "building",
+      "object": "node",
+      "visible": true,
+      "children": [
+        "level_conv_demo"
+      ],
+      "metadata": {},
+      "parentId": "site_conv_demo",
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "rotation": [
+        0,
+        0,
+        0
+      ]
+    },
+    "zone_lbl_b_title_1": {
+      "id": "zone_lbl_b_title_1",
+      "name": "DEMO B -- 6x4 m rectangle",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          21.7,
+          8.2
+        ],
+        [
+          22.3,
+          8.2
+        ],
+        [
+          22.3,
+          8.8
+        ],
+        [
+          21.7,
+          8.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_b_title_2": {
+      "id": "zone_lbl_b_title_2",
+      "name": "Rotated 30 deg CCW from world +X",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          21.7,
+          9
+        ],
+        [
+          22.3,
+          9
+        ],
+        [
+          22.3,
+          9.600000000000001
+        ],
+        [
+          21.7,
+          9.600000000000001
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_p_title": {
+      "id": "zone_lbl_c_p_title",
+      "name": "DEMO C -- PAGE INTENT (north-up, 1/2 scale)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          0.7,
+          20.7
+        ],
+        [
+          1.3,
+          20.7
+        ],
+        [
+          1.3,
+          21.3
+        ],
+        [
+          0.7,
+          21.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_w_title": {
+      "id": "zone_lbl_c_w_title",
+      "name": "DEMO C -- WORLD RESULT (full scale)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          11.7,
+          20.7
+        ],
+        [
+          12.3,
+          20.7
+        ],
+        [
+          12.3,
+          21.3
+        ],
+        [
+          11.7,
+          21.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_compass_a": {
+      "id": "zone_lbl_compass_a",
+      "name": "WORLD AXES (authoritative)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          4.7,
+          -3.8
+        ],
+        [
+          5.3,
+          -3.8
+        ],
+        [
+          5.3,
+          -3.2
+        ],
+        [
+          4.7,
+          -3.2
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_compass_b": {
+      "id": "zone_lbl_compass_b",
+      "name": "Plan [x,z] maps to world (x, 0, z) -- no sign flip",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          4.7,
+          -4.8
+        ],
+        [
+          5.3,
+          -4.8
+        ],
+        [
+          5.3,
+          -4.2
+        ],
+        [
+          4.7,
+          -4.2
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_w_title": {
+      "id": "zone_lbl_d_w_title",
+      "name": "DEMO D -- WORLD RESULT (full scale)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          33.7,
+          20.7
+        ],
+        [
+          34.3,
+          20.7
+        ],
+        [
+          34.3,
+          21.3
+        ],
+        [
+          33.7,
+          21.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_takeaway_band": {
+      "id": "zone_takeaway_band",
+      "name": "TAKEAWAY band",
+      "type": "zone",
+      "color": "#fff5d6",
+      "object": "node",
+      "polygon": [
+        [
+          0,
+          32
+        ],
+        [
+          40,
+          32
+        ],
+        [
+          40,
+          36
+        ],
+        [
+          0,
+          36
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_a_baseline": {
+      "id": "zone_lbl_a_baseline",
+      "name": "Baseline -- matches generate-apartment.md style",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          20.7,
+          5.2
+        ],
+        [
+          21.3,
+          5.2
+        ],
+        [
+          21.3,
+          5.8
+        ],
+        [
+          20.7,
+          5.8
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_axis_neg_x": {
+      "id": "zone_lbl_axis_neg_x",
+      "name": "-X (negative first component)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          -2.3,
+          0.7
+        ],
+        [
+          -1.7,
+          0.7
+        ],
+        [
+          -1.7,
+          1.3
+        ],
+        [
+          -2.3,
+          1.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_axis_neg_z": {
+      "id": "zone_lbl_axis_neg_z",
+      "name": "-Z (negative second component)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          0.7,
+          -2.3
+        ],
+        [
+          1.3,
+          -2.3
+        ],
+        [
+          1.3,
+          -1.7
+        ],
+        [
+          0.7,
+          -1.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_w_note_1": {
+      "id": "zone_lbl_d_w_note_1",
+      "name": "Note: z-reflection only helps against a true MIRROR",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          33.7,
+          27.3
+        ],
+        [
+          34.3,
+          27.3
+        ],
+        [
+          34.3,
+          27.900000000000002
+        ],
+        [
+          33.7,
+          27.900000000000002
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_w_note_2": {
+      "id": "zone_lbl_d_w_note_2",
+      "name": "Pascal's view rotates, not mirrors",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          33.7,
+          28.099999999999998
+        ],
+        [
+          34.3,
+          28.099999999999998
+        ],
+        [
+          34.3,
+          28.7
+        ],
+        [
+          33.7,
+          28.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_w_note_3": {
+      "id": "zone_lbl_d_w_note_3",
+      "name": "So this 'fix' doesn't correct on-screen orientation",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          33.7,
+          28.9
+        ],
+        [
+          34.3,
+          28.9
+        ],
+        [
+          34.3,
+          29.5
+        ],
+        [
+          33.7,
+          29.5
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_w_note_4": {
+      "id": "zone_lbl_d_w_note_4",
+      "name": "Real fix: apply whatever rotation matches your viewport",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          33.7,
+          29.7
+        ],
+        [
+          34.3,
+          29.7
+        ],
+        [
+          34.3,
+          30.3
+        ],
+        [
+          33.7,
+          30.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_w_note_5": {
+      "id": "zone_lbl_d_w_note_5",
+      "name": "Or verify against a scaled guide image",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          33.7,
+          30.5
+        ],
+        [
+          34.3,
+          30.5
+        ],
+        [
+          34.3,
+          31.1
+        ],
+        [
+          33.7,
+          31.1
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_p_title_1": {
+      "id": "zone_lbl_d_p_title_1",
+      "name": "DEMO D -- PAGE INTENT (1/2 scale)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          22.7,
+          20.7
+        ],
+        [
+          23.3,
+          20.7
+        ],
+        [
+          23.3,
+          21.3
+        ],
+        [
+          22.7,
+          21.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_d_p_title_2": {
+      "id": "zone_lbl_d_p_title_2",
+      "name": "Author applied z -> 5-z before paste",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          22.7,
+          19.9
+        ],
+        [
+          23.3,
+          19.9
+        ],
+        [
+          23.3,
+          20.5
+        ],
+        [
+          22.7,
+          20.5
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "slab_demo_c_page_ax_x": {
+      "id": "slab_demo_c_page_ax_x",
+      "name": "C page +x stub",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          0.1,
+          21.95
+        ],
+        [
+          1.9,
+          21.95
+        ],
+        [
+          1.9,
+          22.05
+        ],
+        [
+          0.1,
+          22.05
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_demo_c_page_ax_y": {
+      "id": "slab_demo_c_page_ax_y",
+      "name": "C page +y stub",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          -0.05,
+          22.1
+        ],
+        [
+          0.05,
+          22.1
+        ],
+        [
+          0.05,
+          23.9
+        ],
+        [
+          -0.05,
+          23.9
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_demo_d_page_ax_x": {
+      "id": "slab_demo_d_page_ax_x",
+      "name": "D page +x stub",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          22.1,
+          21.95
+        ],
+        [
+          23.9,
+          21.95
+        ],
+        [
+          23.9,
+          22.05
+        ],
+        [
+          22.1,
+          22.05
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "slab_demo_d_page_ax_y": {
+      "id": "slab_demo_d_page_ax_y",
+      "name": "D page +y stub",
+      "type": "slab",
+      "holes": [],
+      "object": "node",
+      "polygon": [
+        [
+          21.95,
+          22.1
+        ],
+        [
+          22.05,
+          22.1
+        ],
+        [
+          22.05,
+          23.9
+        ],
+        [
+          21.95,
+          23.9
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo",
+      "elevation": 0.01,
+      "holeMetadata": [],
+      "autoFromWalls": false
+    },
+    "zone_lbl_b_verified_1": {
+      "id": "zone_lbl_b_verified_1",
+      "name": "Verified: side lengths 6/4/6/4 m",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          21.7,
+          16.7
+        ],
+        [
+          22.3,
+          16.7
+        ],
+        [
+          22.3,
+          17.3
+        ],
+        [
+          21.7,
+          17.3
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_b_verified_2": {
+      "id": "zone_lbl_b_verified_2",
+      "name": "Verified: AB perpendicular to AD (dot=0)",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          21.7,
+          17.5
+        ],
+        [
+          22.3,
+          17.5
+        ],
+        [
+          22.3,
+          18.1
+        ],
+        [
+          21.7,
+          18.1
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_b_verified_3": {
+      "id": "zone_lbl_b_verified_3",
+      "name": "Verified: first edge heading = 30.0 deg from +X",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          21.7,
+          18.3
+        ],
+        [
+          22.3,
+          18.3
+        ],
+        [
+          22.3,
+          18.900000000000002
+        ],
+        [
+          21.7,
+          18.900000000000002
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_w_screen_1": {
+      "id": "zone_lbl_c_w_screen_1",
+      "name": "On-screen orientation depends on viewport",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          11.7,
+          27.3
+        ],
+        [
+          12.3,
+          27.3
+        ],
+        [
+          12.3,
+          27.900000000000002
+        ],
+        [
+          11.7,
+          27.900000000000002
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    },
+    "zone_lbl_c_w_screen_2": {
+      "id": "zone_lbl_c_w_screen_2",
+      "name": "2D plan: rotated 90 deg; 3D top-down: ~45 deg offset",
+      "type": "zone",
+      "color": "#f0f0f0",
+      "object": "node",
+      "polygon": [
+        [
+          11.7,
+          28.099999999999998
+        ],
+        [
+          12.3,
+          28.099999999999998
+        ],
+        [
+          12.3,
+          28.7
+        ],
+        [
+          11.7,
+          28.7
+        ]
+      ],
+      "visible": true,
+      "metadata": {},
+      "parentId": "level_conv_demo"
+    }
+  },
+  "rootNodeIds": [
+    "site_conv_demo"
+  ],
+  "collections": {}
+}

--- a/packages/mcp/examples/coordinate-conventions-demo.md
+++ b/packages/mcp/examples/coordinate-conventions-demo.md
@@ -1,0 +1,74 @@
+# Coordinate-conventions demo
+
+Companion scene for the **Coordinate conventions** section of
+[`../README.md`](../README.md). Stress-tests every claim that section
+makes against real Pascal-generated geometry, built entirely through the
+MCP API.
+
+## Load it
+
+```bash
+pascal-mcp --stdio --scene examples/coordinate-conventions-demo.json
+```
+
+or, through any MCP host configured for `@pascal-app/mcp`, call
+`load_scene` against the included graph. The scene fits in a 50 m × 50 m
+ground-plane footprint at `level: 0`.
+
+## What's in the scene
+
+A flat ground level with four demos, plus a labelled compass at the
+origin so the world axes are unambiguous regardless of which viewport
+you're in.
+
+| Section | What | Why |
+|---|---|---|
+| Reference compass at the origin | 12 m `+X` and `+Z` axis bars with arrowhead tips, short `-X` / `-Z` stubs, an origin marker, plus zone labels naming each component of `[x, z]`. | Establishes which way `+X` and `+Z` actually point in world space, independent of viewport rotation. |
+| **Demo A** at world `(18, 0)` | Axis-aligned 6 m × 4 m rectangle. | Baseline that matches the only example currently in `examples/generate-apartment.md` style (`[0,0] → [10,0]`). |
+| **Demo B** at world `(18, 10)` | The proposed README example, **verbatim**: `polygon: [[0,0],[5.196,3.0],[3.196,6.464],[-2.0,3.464]]` at this offset. | Programmatically verified to be a 6 m × 4 m rectangle whose first edge is heading 30° CCW from `+X` (side lengths 6/4/6/4 m to 4 dp, `AB · AD = 0`, heading = 30.0007°). Confirms the README's worked example produces the geometry it claims. |
+| **Demo C** at world `(0, 22)` and `(10, 22)` | An **L** authored on a north-up page (page-+x right, page-+y up) drawn at half scale and faded; alongside it, the same L pasted into `[x, z]` **uncorrected**, drawn at full scale and vivid. | Makes the external-coordinate gotcha visual: the author's page-+y direction lands on world +Z, which does not correspond to "screen-up" in any of Pascal's viewports. |
+| **Demo D** at world `(22, 22)` and `(32, 22)` | Same pairing for the L with its second coordinate reflected (`z → 5 − z`) before paste. | Makes plain that z-reflection only "corrects" a true mirror; Pascal's viewports apply a *rotation*, so the reflection produces a mirror-image of Demo C rather than a page-correct L. |
+| Takeaway band on the south edge | Short labels summarising the convention. | Self-documenting; readable in any viewport without an external README. |
+
+## What it confirms
+
+Open the scene in Pascal (or render it from the JSON) and you can read
+each claim directly off the geometry:
+
+1. **`[x, z] → world (x, 0, z)` is exact, no sign flip.** Demo A and
+   Demo B both sit flat on the floor at Y = 0; their polygon vertices
+   round-trip through `save_scene` / `get_scene` byte-identical to what
+   was authored (graph hash matches, see `validate_scene` output).
+
+2. **Demo B is the rectangle the README says it is.** A simple analytic
+   check on its 4 vertices yields side lengths 6, 4, 6, 4 m (to 4 dp)
+   with the first edge at 30.0007° from +X and perpendicular adjacent
+   edges. No rendering required.
+
+3. **External page coordinates *rotate* (not mirror) when pasted as
+   `[x, z]` and viewed in Pascal.** Inspecting Demo C in the 2-D plan
+   panel: the page-up L lands rotated 90° clockwise, so the author's
+   "stem-up, foot-bottom-right" reads as "stem-on-right, foot-along-top"
+   on screen. Inspecting Demo D right next to it: the z-reflected
+   variant lands as the *mirror* of Demo C — neither matches a
+   page-correct L. That demonstrates why "reflect across the axis" is
+   the wrong corrective for an issue that is, in this viewport, a
+   rotation.
+
+4. **The 3-D "top-down" snap is offset 45° from world axes by default.**
+   Viewing the scene in 3-D and snapping to top-down from the default
+   iso camera shows the rectangular site polygon as a *diamond* (its
+   long edges are diagonals on screen, not axis-aligned). That's the
+   camera's "up" vector being inherited from the iso start; once you
+   orbit to a true axis-aligned top-down it goes away. The label
+   inviting reviewers to "verify against a guide image" exists for this
+   reason.
+
+## Reproducibility
+
+The driver script and a static (PIL-rendered) two-panel comparison
+image live next to this file as `coordinate-conventions-demo.py` and
+`coordinate-conventions-demo.png` — not committed here because they
+depend on a `PASCAL_API_KEY` and on local Python, but the canonical
+form is the JSON. Anyone with access to a Pascal MCP server can rebuild
+the project from the JSON alone.

--- a/packages/mcp/examples/coordinate-conventions-demo.md
+++ b/packages/mcp/examples/coordinate-conventions-demo.md
@@ -11,9 +11,7 @@ MCP API.
 pascal-mcp --stdio --scene examples/coordinate-conventions-demo.json
 ```
 
-or, through any MCP host configured for `@pascal-app/mcp`, call
-`load_scene` against the included graph. The scene fits in a 50 m × 50 m
-ground-plane footprint at `level: 0`.
+The scene fits in a 50 m × 50 m ground-plane footprint at `level: 0`.
 
 ## What's in the scene
 
@@ -66,9 +64,5 @@ each claim directly off the geometry:
 
 ## Reproducibility
 
-The driver script and a static (PIL-rendered) two-panel comparison
-image live next to this file as `coordinate-conventions-demo.py` and
-`coordinate-conventions-demo.png` — not committed here because they
-depend on a `PASCAL_API_KEY` and on local Python, but the canonical
-form is the JSON. Anyone with access to a Pascal MCP server can rebuild
-the project from the JSON alone.
+The canonical demo is the JSON file in this directory; load that file to compare
+the geometry against the notes above.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -42,6 +42,7 @@
   },
   "files": [
     "dist",
+    "examples",
     "README.md",
     "CHANGELOG.md"
   ],


### PR DESCRIPTION
Adds a **Coordinate conventions** section to `packages/mcp/README.md`,
placed right before `## Tools` so authors read it before touching
geometry. Backed by a 71-node MCP demonstration scene that stress-tests
every claim the section makes.

Closes #337.

## Why

The README documents units (metres) and per-tool parameters well, but
there's no author-facing statement of the coordinate convention. When
generating geometry programmatically (e.g. from a land survey), this is
the first thing you need and currently has to be reverse-engineered from
source. The `examples/generate-apartment.md` walkthrough only uses
axis-aligned boxes (`[0,0] → [10,0]`), so the handedness never surfaces
in any existing example.

## What the new section covers

- Right-handed scene; X and Z form the ground plane, Y is up.
- Metres for lengths; radians for rotations, stored as Euler `[x, y, z]`.
- The `[x, z] → (x, y, z)` mapping for 2-D points (`wall.start` / `end`,
  `slab` / `zone` / `ceiling` `polygon` and `holes`) — no sign flip.
- **Heads-up for externally-computed coordinates:** Pascal's viewports
  apply their own rotations on top of the world axes. The 2-D plan
  panel wraps content in a +90° rotation (`FLOORPLAN_VIEW_ROTATION_DEG`
  in `floorplan-panel.tsx`), and the 3-D "top-down" snap defaults to a
  ~45° offset between world and screen axes when invoked from the iso
  default position. So a layout authored as if "Y = north, viewed
  top-down" will arrive **rotated** relative to its source — and
  possibly further reflected, depending on viewport state. The
  reliable fix is a scaled guide image at known anchors.
- One non-axis-aligned worked example (a 6 × 4 m slab rotated 30°)
  whose vertices verify analytically as sides 6/4/6/4 m, `AB · AD = 0`,
  heading 30.0007° from +X.

## How this got verified

I stress-tested the section against actual Pascal-generated geometry
before publishing. An iterative MCP-driven demo (see
[`examples/coordinate-conventions-demo.md`](../tree/docs/mcp-coordinate-conventions/packages/mcp/examples/coordinate-conventions-demo.md))
was authored, persisted, and inspected in the editor. The first
version of this PR claimed external coordinates "arrive mirrored when
viewed top-down" — but inspecting the rendered demo showed they arrive
**rotated**, not mirrored, and the proposed "reflect across the axis"
corrective doesn't help. The section and the demo were rewritten before
pushing. The demo is now included with the PR so future readers can
verify the same way.

### Demo files

- [`packages/mcp/examples/coordinate-conventions-demo.json`](../tree/docs/mcp-coordinate-conventions/packages/mcp/examples/coordinate-conventions-demo.json)
  — 71-node SceneGraph: reference compass at the origin, axis-aligned
  baseline (Demo A), rotated-30° example verbatim (Demo B, verified
  analytically), paired page-intent / world-result L pair (Demo C), and
  z-reflected variant showing the mis-corrective (Demo D), plus a
  takeaway band on the south edge. Loadable with
  `pascal-mcp --scene examples/coordinate-conventions-demo.json`.
- [`packages/mcp/examples/coordinate-conventions-demo.md`](../tree/docs/mcp-coordinate-conventions/packages/mcp/examples/coordinate-conventions-demo.md)
  — walks through what the scene is and what each demo proves.

### What Demo B verified

Loading and inspecting the polygon `[[0,0],[5.196,3.0],[3.196,6.464],[-2.0,3.464]]`:

```
side_lengths_m:               [5.9999, 3.9999, 5.9999, 3.9999]
first_edge_heading_deg_from_+X: 30.0007
AB · AD (perpendicularity):    0.0
```

So the example in the README is, to 4 decimal places, a 6 × 4 m rectangle
with its first edge at 30° CCW from +X and adjacent edges perpendicular.

### What Demo C / D showed about the doc

The L authored on a "north-up page" with page-+x right and page-+y up,
pasted directly as `[x, z]`, lands in Pascal's 2-D plan panel rotated
90° clockwise — stem along screen-right rather than screen-up. The
z-reflected variant (Demo D) lands as a *mirror* of Demo C, not as a
page-correct L. That's why the original draft's "reflect across the
appropriate axis" advice was wrong for Pascal's actual viewport
behavior, and why the section now points at viewport rotations as the
mechanism.

## Verified against `pascalorg/editor` @ main

- `packages/core/src/services/snap.ts` — *"Snaps a 3D point to a regular
  grid in the X/Z plane, preserving Y."*
- `packages/core/src/services/movement.ts` — `movePlanToward` packs
  `[x, y, z]` and returns `[result[0], result[2]]`.
- `packages/nodes/src/{wall,slab,ceiling}/tool.tsx` — `Vector3`
  construction uses `(plan[0], y, plan[1])` (destructured form:
  `([x, z]) => new Vector3(x, y, z)`).
- `packages/core/src/schema/nodes/level.ts` — `level: z.number()` (floor
  base elevation, metres).
- `packages/editor/src/components/editor/floorplan-panel.tsx` —
  `FLOORPLAN_VIEW_ROTATION_DEG = 90`, applied as
  `<g transform="rotate(${floorplanSceneRotationDeg})">` around the
  floor-plan content group.

## Out-of-scope but worth surfacing

While building the demo scene I hit a few API quirks in the hosted
`editor.pascal.app` MCP server (v0.6.1) that are unrelated to this
docs PR but a maintainer may want to track separately:

- `save_scene` with `graph` + `includeCurrentScene:false` tail-throws
  `MCP error -32600: undefined is not an object (evaluating 'this.loadProject')`
  even though the SceneStore row is durably written (the demo JSON
  here was published this way; `get_project_status` confirms the
  expected `nodeCount` and `graphHash`).
- `apply_patch` live-syncs against the same broken `loadProject` path;
  earlier deletes can persist while creates in the same batch roll
  back, so a batch is not atomic in practice.
- `create_project`'s `isPrivate: false` flag is declared in the input
  schema and the storage types, but the editor route still
  307-redirects anonymous visitors. So "public sharing" via the API
  alone doesn't currently produce an unauth-viewable URL.
- The renderer fails on zone names past ~500 chars (the editor shows
  "the editor scene failed to render"); shorter labels render fine.
  Bisected against several other suspects (small zones, concave
  half-scale slabs, thin slabs) — the name-length was the trigger.

Happy to break any of these out into separate issues if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
