### PR TITLE
fix(editor): guard null bounds in box-select registry-selectable branch

### DIFF
--- a/packages/editor/src/components/tools/select/box-select-tool.tsx
+++ b/packages/editor/src/components/tools/select/box-select-tool.tsx
@@ -285,7 +285,7 @@ function collectNodeIdsInBounds(bounds: Bounds | null): string[] {
         // Registry-driven selectable kinds (shelf + future furnish/structure
         // kinds) aren't in the hardcoded list above; pick them up by their
         // rendered bounding box, the same path column/stair use.
-        if (objectBoundsIntersectsBounds(node.id, bounds)) {
+        if (!bounds || objectBoundsIntersectsBounds(node.id, bounds)) {
           result.push(node.id)
         }
       }


### PR DESCRIPTION
## What & why

`collectNodeIdsInBounds` in `box-select-tool.tsx` takes `bounds: Bounds | null` (a `null` bounds means *select-all* / no drag rectangle). Every branch guards with `!bounds || …` before calling the bounds-typed helpers — except the registry-driven selectable branch, which called `objectBoundsIntersectsBounds(node.id, bounds)` directly.

That compiled in the editor repo but broke `tsc --build` in downstream consumers (`@pascal-app/nodes`):

```
box-select-tool.tsx(288,51): error TS2345: Argument of type 'Bounds | null'
is not assignable to parameter of type 'Bounds'.
```

Adding the `!bounds ||` guard fixes the build **and** restores correct select-all behavior for registry-selectable kinds (shelf + future furnish/structure kinds), matching the column/stair branches.

Introduced in #357; surfaced once the submodule was bumped into private-editor.

## Testing
- `tsc --build` across all editor packages (core/viewer/editor/nodes/mcp) → clean.