### PR TITLE
chore: add clean:cache and restart scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "check:fix": "biome check --write",
     "check-types": "turbo run check-types",
     "kill": "lsof -ti:3002 | xargs kill -9 2>/dev/null || echo 'No processes found on port 3002'",
+    "clean:cache": "rm -rf apps/*/.next apps/*/.swc apps/*/.turbo packages/*/.turbo tooling/*/.turbo .turbo node_modules/.cache",
+    "restart": "bun kill && bun clean:cache && bun dev",
     "release": "gh workflow run release.yml -f package=all -f bump=patch",
     "release:viewer": "gh workflow run release.yml -f package=viewer -f bump=patch",
     "release:core": "gh workflow run release.yml -f package=core -f bump=patch",


### PR DESCRIPTION
## What does this PR do?

Adds two root scripts so a stale-cache reset works the same here as in the `private-editor` root (which already has `clean:cache`):

- **`bun clean:cache`** — removes `.next` / `.swc` / `.turbo` across apps, packages, and tooling, the root `.turbo`, and `node_modules/.cache`.
- **`bun restart`** — convenience that runs `kill` → `clean:cache` → `dev`.

Tooling-only; root `package.json` scripts only, no dependency or behavior changes.

## How to test

1. `bun clean:cache` → confirm the caches are gone (`find . -type d \( -name .turbo -o -name .next \) -not -path "*/node_modules/*"` returns nothing).
2. `bun dev` (or `bun restart`) → editor boots on http://localhost:3002.

## Screenshots / screen recording

N/A — tooling-only change.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)