### PR TITLE
ci: add lint and typecheck workflow (closes #147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint & format check
+        run: bun run check
+
+      - name: Type check
+        run: bun run check-types

--- a/apps/editor/lib/bootstrap.ts
+++ b/apps/editor/lib/bootstrap.ts
@@ -45,7 +45,6 @@ function loadBuiltinsSync(): void {
   if (isDev()) {
     const kinds = Array.from(nodeRegistry.entries(), ([k]) => k)
     if (typeof console !== 'undefined') {
-      // biome-ignore lint/suspicious/noConsole: dev-only verification log
       console.info(
         `[pascal:registry] loaded ${builtinPlugin.id} v${builtinPlugin.apiVersion} (${kinds.length} kinds: ${kinds.join(', ') || '∅'})`,
       )
@@ -74,7 +73,6 @@ export async function loadExternalPlugins(): Promise<void> {
     await loadPlugin(plugin)
   }
   if (isDev() && externals.length > 0 && typeof console !== 'undefined') {
-    // biome-ignore lint/suspicious/noConsole: dev-only verification log
     console.info(`[pascal:registry] + ${externals.length} discovered plugin(s)`)
   }
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -110,7 +110,8 @@
       "!**/build",
       "!**/public",
       "!**/components/ui",
-      "!**/next-env.d.ts"
+      "!**/next-env.d.ts",
+      "!packages/mcp"
     ]
   },
   "overrides": [

--- a/packages/core/src/store/actions/node-actions.ts
+++ b/packages/core/src/store/actions/node-actions.ts
@@ -416,7 +416,9 @@ export const applyNodeChangesAction = (
     return { nodes: nextNodes, rootNodeIds: resolvedRootIds, collections: nextCollections }
   })
 
-  nodesToMarkDirty.forEach((id) => get().markDirty(id))
+  nodesToMarkDirty.forEach((id) => {
+    get().markDirty(id)
+  })
   parentsToMarkDirty.forEach((id) => {
     get().markDirty(id)
     const parent = get().nodes[id]

--- a/packages/editor/src/components/editor/first-person/build-collider-world.ts
+++ b/packages/editor/src/components/editor/first-person/build-collider-world.ts
@@ -294,7 +294,9 @@ export function buildFirstPersonColliderWorldFromRegistry(): FirstPersonCollider
   }
 
   const mergedGeometry = mergeGeometries(geometries, false)
-  geometries.forEach((geometry) => geometry.dispose())
+  geometries.forEach((geometry) => {
+    geometry.dispose()
+  })
 
   if (!mergedGeometry || mergedGeometry.getAttribute('position') == null) {
     mergedGeometry?.dispose()

--- a/packages/nodes/src/ceiling/tool.tsx
+++ b/packages/nodes/src/ceiling/tool.tsx
@@ -192,8 +192,12 @@ export const CeilingTool: React.FC = () => {
     if (points.length === 0) {
       mainLineRef.current.visible = false
       closingLineRef.current.visible = false
-      groundMainLineRef.current && (groundMainLineRef.current.visible = false)
-      groundClosingLineRef.current && (groundClosingLineRef.current.visible = false)
+      if (groundMainLineRef.current) {
+        groundMainLineRef.current.visible = false
+      }
+      if (groundClosingLineRef.current) {
+        groundClosingLineRef.current.visible = false
+      }
       return
     }
     const ceilingY = levelY + CEILING_HEIGHT

--- a/packages/nodes/src/chimney/panel.tsx
+++ b/packages/nodes/src/chimney/panel.tsx
@@ -133,6 +133,21 @@ export default function ChimneyPanel() {
     }
   }, [selectedId, node, deleteNode, setSelection])
 
+  // Match the current store node against the preset table so the
+  // segmented control highlights "the preset you'd land on if you
+  // applied X again". Compare against the store node, not the live-
+  // override-merged `node`, so the highlight is stable across slider
+  // drags. Null means the user has tweaked away from any preset; the
+  // segmented control will then render with no segment selected.
+  const activePreset = useMemo(() => detectActiveChimneyPreset(storeNode), [storeNode])
+  const applyPreset = useCallback(
+    (key: ChimneyPresetKey) => {
+      commitProp(chimneyPresets[key] as Partial<ChimneyNode>)
+      triggerSFX('sfx:item-pick')
+    },
+    [commitProp],
+  )
+
   if (!(node && node.type === 'chimney' && selectedId)) return null
 
   const scenestate = useScene.getState()
@@ -320,21 +335,6 @@ export default function ChimneyPanel() {
     }
     commitProp({ rotation: newWorldRot - ancestorWorldY })
   }
-
-  // Match the current store node against the preset table so the
-  // segmented control highlights "the preset you'd land on if you
-  // applied X again". Compare against the store node, not the live-
-  // override-merged `node`, so the highlight is stable across slider
-  // drags. Null means the user has tweaked away from any preset; the
-  // segmented control will then render with no segment selected.
-  const activePreset = useMemo(() => detectActiveChimneyPreset(storeNode), [storeNode])
-  const applyPreset = useCallback(
-    (key: ChimneyPresetKey) => {
-      commitProp(chimneyPresets[key] as Partial<ChimneyNode>)
-      triggerSFX('sfx:item-pick')
-    },
-    [commitProp],
-  )
 
   return (
     <PanelWrapper

--- a/packages/nodes/src/dormer/csg-geometry.ts
+++ b/packages/nodes/src/dormer/csg-geometry.ts
@@ -337,7 +337,6 @@ export function generateDormerGeometry(
 
   const dormerBrushes = getRoofSegmentBrushes(virtualSegment)
   if (!dormerBrushes) {
-    // biome-ignore lint/suspicious/noConsole: keep diagnostic — fallback path.
     console.warn('[dormer] getRoofSegmentBrushes returned null; using fallback silhouette.')
     return buildDormerFallbackGeometry(dormer)
   }
@@ -476,7 +475,6 @@ export function generateDormerGeometry(
     remapRoofShellFaces(resultGeo, virtualSegment)
     splitDormerGableMaterial(resultGeo, dormer.height, DORMER_GABLE_MATERIAL_INDEX)
   } catch (e) {
-    // biome-ignore lint/suspicious/noConsole: dormer CSG can throw; keep diagnostic.
     console.error('[dormer] CSG failed, falling back to silhouette:', e)
     if (dormerSolid) {
       try {
@@ -496,7 +494,6 @@ export function generateDormerGeometry(
   // dormer is at least visible.
   const triCount = resultGeo.getIndex()?.count ?? resultGeo.getAttribute('position')?.count ?? 0
   if (triCount === 0) {
-    // biome-ignore lint/suspicious/noConsole: keep diagnostic — empty CSG.
     console.warn('[dormer] CSG produced empty geometry; using fallback silhouette.')
     return buildDormerFallbackGeometry(dormer)
   }

--- a/packages/nodes/src/dormer/move-tool.tsx
+++ b/packages/nodes/src/dormer/move-tool.tsx
@@ -71,7 +71,6 @@ const MoveDormerTool = ({ node }: { node: DormerNode }) => {
         })
       }
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: capture-on-mount; meta is intentionally not re-read on changes.
   }, [node.id, isNew])
 
   const { activeBuildingId, segmentXform, hitLocal, ghostRotation } = useDormerPlacement({

--- a/packages/nodes/src/dormer/panel-position-section.tsx
+++ b/packages/nodes/src/dormer/panel-position-section.tsx
@@ -79,7 +79,6 @@ export function DormerPositionSection({
       if (Number.isFinite(lo_x)) bounds = { minX: lo_x, maxX: hi_x, minZ: lo_z, maxZ: hi_z }
     }
     return { worldX, worldZ, worldRotation, bounds }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: roofChildrenKey is the stable signature of `roof.children`; intentionally omitting `roof` (object identity) in favor of the joined ids.
   }, [selectedId, px, py, pz, nodeRotation, segmentId, roofChildrenKey])
 
   const worldX_now = worldXform.worldX

--- a/packages/nodes/src/dormer/panel.tsx
+++ b/packages/nodes/src/dormer/panel.tsx
@@ -107,7 +107,7 @@ export default function DormerPanel() {
   }, [node, selectedId, setMovingNode, setSelection])
 
   const handleDuplicate = useCallback(() => {
-    if (!(node && node.roofSegmentId)) return
+    if (!node?.roofSegmentId) return
     triggerSFX('sfx:item-pick')
     // Deep clone and strip the id so the move tool's onClick branch
     // (`isNew || !node.id`) takes the "create fresh" path. Setting

--- a/packages/nodes/src/dormer/window-assembly.tsx
+++ b/packages/nodes/src/dormer/window-assembly.tsx
@@ -144,7 +144,6 @@ const DormerWindowAssembly = ({
       {winGeo.glassPanes.map((pane, i) => (
         <mesh
           geometry={pane.geo}
-          // biome-ignore lint/suspicious/noArrayIndexKey: glass panes are derived from grid indices, no stable id.
           key={`${keyPrefix}-glass-${i}`}
           material={glassMaterial}
           name={`dormer-glass-${keyPrefix}-${i}`}
@@ -155,7 +154,6 @@ const DormerWindowAssembly = ({
         <mesh
           castShadow
           geometry={bar.geo}
-          // biome-ignore lint/suspicious/noArrayIndexKey: frame bars are derived from grid indices, no stable id.
           key={`${keyPrefix}-bar-${i}`}
           material={frameMaterial}
           name={`dormer-frame-${keyPrefix}-${i}`}

--- a/packages/viewer/src/components/renderers/parametric-node-renderer.tsx
+++ b/packages/viewer/src/components/renderers/parametric-node-renderer.tsx
@@ -50,9 +50,6 @@ type RenderableNode = AnyNode & {
 export const ParametricNodeRenderer = ({ node }: { node: AnyNode }) => {
   const ref = useRef<Group>(null!)
   const n = node as RenderableNode
-  // biome-ignore lint/suspicious/noExplicitAny: useNodeEvents is keyed by
-  // literal kind; the registry path passes a runtime kind union. Routing
-  // through the type cast is safer than widening the hook signature.
   const handlers = useNodeEvents(node as any, node.type as any)
   const liveTransform = useLiveTransforms((s) => s.get(node.id as AnyNodeId))
   // Registry arrow handles (rotation gizmo, position-affecting patches)

--- a/packages/viewer/src/r3f.d.ts
+++ b/packages/viewer/src/r3f.d.ts
@@ -78,21 +78,18 @@ interface ThreeJSXElements {
 }
 
 declare module 'react' {
-  // biome-ignore lint/style/noNamespace: Required for JSX module augmentation
   namespace JSX {
     interface IntrinsicElements extends ThreeJSXElements {}
   }
 }
 
 declare module 'react/jsx-runtime' {
-  // biome-ignore lint/style/noNamespace: Required for JSX module augmentation
   namespace JSX {
     interface IntrinsicElements extends ThreeJSXElements {}
   }
 }
 
 declare module 'react/jsx-dev-runtime' {
-  // biome-ignore lint/style/noNamespace: Required for JSX module augmentation
   namespace JSX {
     interface IntrinsicElements extends ThreeJSXElements {}
   }

--- a/turbo.json
+++ b/turbo.json
@@ -23,7 +23,7 @@
       "dependsOn": ["^lint"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^build", "^check-types"]
     },
     "dev": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Adds a CI workflow that runs `bun run check` and `bun run check-types` on every push to `main` and on pull requests, gated by a per-ref concurrency group so superseded runs cancel.

Closes #147.

The repo wasn't quite ready for green CI when I went to add this — `bun run check` had 7 lint errors and `bun run check-types` had ~30 type errors — so this PR also fixes those. Most of the diff is unblocking, not feature work.

### What was fixed

**Lint (biome):**
- Removed stale `// biome-ignore …` comments where the underlying rule no longer fires (`bootstrap.ts`, `parametric-node-renderer.tsx`, `r3f.d.ts`, several files under `packages/nodes/src/dormer/`).
- Refactored two `forEach` callbacks that returned a value (`useIterableCallbackReturn`) in `node-actions.ts` and `build-collider-world.ts`.
- Replaced `x && (x.foo = …)` assign-in-expression patterns with explicit `if (x)` guards in `ceiling/tool.tsx` (`noAssignInExpressions`).
- Moved a `useMemo` / `useCallback` pair in `chimney/panel.tsx` above the early `return null` so hooks always run in the same order (`useHookAtTopLevel`).
- Switched a `!(node && node.x)` check to `!node?.x` in `dormer/panel.tsx` (`useOptionalChain`).
- Excluded `packages/mcp` from biome's scope — it has its own pipeline (`mcp-ci.yml`) and was the source of an unrelated formatter diff on a JSON fixture.

**Types (tsc):**
The 30 type errors were all of the form _\"X is not exported from `@pascal-app/core`\"_ or _\"property Y does not exist on type Z\"_. They reproduce on a fresh checkout but disappear once `packages/core` (and friends) are built, because the package's `exports` field points at `dist/` (`moduleResolution: bundler`). The actual fix is making sure consumers see fresh `.d.ts` files:

- `turbo.json`: `check-types` now `dependsOn: [\"^build\", \"^check-types\"]` so internal package builds run first.

No code changes were needed in the consuming files — the symbols (`useAlignmentGuides`, `AlignmentAnchor`, `bboxAnchors`, `resolveAlignment`, `TranslateHandle`, `ParamAction`, `GutterNode`, the handle/event property additions, the new `PaintableMaterialTarget` variants) all already exist in `packages/core/src/` and are re-exported through the `services` / `registry` / `schema` barrels; the published `dist/` was just stale.

### Verification

- `bun run check` → 0 errors, 0 warnings (101 infos remain, all `useExhaustiveDependencies` non-blocking).
- `bun run check-types` → 0 errors across all 9 typed projects.

### Notes

- No rules were globally suppressed in `biome.jsonc`; the only change there is excluding `packages/mcp` from the scope.
- No `@ts-ignore` / `as any` workarounds were added.
- Diffs are intentionally minimal — one concern per file.