### PR TITLE
ci: add lint and typecheck workflow (closes #147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint & format check
+        run: bun run check
+
+      - name: Type check
+        run: bun run check-types

--- a/apps/editor/lib/bootstrap.ts
+++ b/apps/editor/lib/bootstrap.ts
@@ -45,7 +45,6 @@ function loadBuiltinsSync(): void {
   if (isDev()) {
     const kinds = Array.from(nodeRegistry.entries(), ([k]) => k)
     if (typeof console !== 'undefined') {
-      // biome-ignore lint/suspicious/noConsole: dev-only verification log
       console.info(
         `[pascal:registry] loaded ${builtinPlugin.id} v${builtinPlugin.apiVersion} (${kinds.length} kinds: ${kinds.join(', ') || '∅'})`,
       )
@@ -74,7 +73,6 @@ export async function loadExternalPlugins(): Promise<void> {
     await loadPlugin(plugin)
   }
   if (isDev() && externals.length > 0 && typeof console !== 'undefined') {
-    // biome-ignore lint/suspicious/noConsole: dev-only verification log
     console.info(`[pascal:registry] + ${externals.length} discovered plugin(s)`)
   }
 }

--- a/packages/core/src/store/actions/node-actions.ts
+++ b/packages/core/src/store/actions/node-actions.ts
@@ -416,8 +416,10 @@ export const applyNodeChangesAction = (
     return { nodes: nextNodes, rootNodeIds: resolvedRootIds, collections: nextCollections }
   })
 
-  nodesToMarkDirty.forEach((id) => get().markDirty(id))
-  parentsToMarkDirty.forEach((id) => {
+  for (const id of nodesToMarkDirty) {
+    get().markDirty(id)
+  }
+  for (const id of parentsToMarkDirty) {
     get().markDirty(id)
     const parent = get().nodes[id]
     if (parent && 'children' in parent && Array.isArray(parent.children)) {
@@ -425,7 +427,7 @@ export const applyNodeChangesAction = (
         get().markDirty(childId as AnyNodeId)
       }
     }
-  })
+  }
 }
 
 export const updateNodesAction = (

--- a/packages/editor/src/components/editor/first-person/build-collider-world.ts
+++ b/packages/editor/src/components/editor/first-person/build-collider-world.ts
@@ -294,7 +294,9 @@ export function buildFirstPersonColliderWorldFromRegistry(): FirstPersonCollider
   }
 
   const mergedGeometry = mergeGeometries(geometries, false)
-  geometries.forEach((geometry) => geometry.dispose())
+  for (const geometry of geometries) {
+    geometry.dispose()
+  }
 
   if (!mergedGeometry || mergedGeometry.getAttribute('position') == null) {
     mergedGeometry?.dispose()

--- a/packages/nodes/src/ceiling/tool.tsx
+++ b/packages/nodes/src/ceiling/tool.tsx
@@ -192,8 +192,8 @@ export const CeilingTool: React.FC = () => {
     if (points.length === 0) {
       mainLineRef.current.visible = false
       closingLineRef.current.visible = false
-      groundMainLineRef.current && (groundMainLineRef.current.visible = false)
-      groundClosingLineRef.current && (groundClosingLineRef.current.visible = false)
+      if (groundMainLineRef.current) groundMainLineRef.current.visible = false
+      if (groundClosingLineRef.current) groundClosingLineRef.current.visible = false
       return
     }
     const ceilingY = levelY + CEILING_HEIGHT

--- a/packages/nodes/src/chimney/panel.tsx
+++ b/packages/nodes/src/chimney/panel.tsx
@@ -133,6 +133,21 @@ export default function ChimneyPanel() {
     }
   }, [selectedId, node, deleteNode, setSelection])
 
+  // Match the current store node against the preset table so the
+  // segmented control highlights "the preset you'd land on if you
+  // applied X again". Compare against the store node, not the live-
+  // override-merged `node`, so the highlight is stable across slider
+  // drags. Null means the user has tweaked away from any preset; the
+  // segmented control will then render with no segment selected.
+  const activePreset = useMemo(() => detectActiveChimneyPreset(storeNode), [storeNode])
+  const applyPreset = useCallback(
+    (key: ChimneyPresetKey) => {
+      commitProp(chimneyPresets[key] as Partial<ChimneyNode>)
+      triggerSFX('sfx:item-pick')
+    },
+    [commitProp],
+  )
+
   if (!(node && node.type === 'chimney' && selectedId)) return null
 
   const scenestate = useScene.getState()
@@ -322,20 +337,6 @@ export default function ChimneyPanel() {
   }
 
   // Match the current store node against the preset table so the
-  // segmented control highlights "the preset you'd land on if you
-  // applied X again". Compare against the store node, not the live-
-  // override-merged `node`, so the highlight is stable across slider
-  // drags. Null means the user has tweaked away from any preset; the
-  // segmented control will then render with no segment selected.
-  const activePreset = useMemo(() => detectActiveChimneyPreset(storeNode), [storeNode])
-  const applyPreset = useCallback(
-    (key: ChimneyPresetKey) => {
-      commitProp(chimneyPresets[key] as Partial<ChimneyNode>)
-      triggerSFX('sfx:item-pick')
-    },
-    [commitProp],
-  )
-
   return (
     <PanelWrapper
       icon="/icons/roof.png"

--- a/packages/viewer/src/components/renderers/parametric-node-renderer.tsx
+++ b/packages/viewer/src/components/renderers/parametric-node-renderer.tsx
@@ -50,9 +50,6 @@ type RenderableNode = AnyNode & {
 export const ParametricNodeRenderer = ({ node }: { node: AnyNode }) => {
   const ref = useRef<Group>(null!)
   const n = node as RenderableNode
-  // biome-ignore lint/suspicious/noExplicitAny: useNodeEvents is keyed by
-  // literal kind; the registry path passes a runtime kind union. Routing
-  // through the type cast is safer than widening the hook signature.
   const handlers = useNodeEvents(node as any, node.type as any)
   const liveTransform = useLiveTransforms((s) => s.get(node.id as AnyNodeId))
   // Registry arrow handles (rotation gizmo, position-affecting patches)

--- a/packages/viewer/src/r3f.d.ts
+++ b/packages/viewer/src/r3f.d.ts
@@ -78,21 +78,18 @@ interface ThreeJSXElements {
 }
 
 declare module 'react' {
-  // biome-ignore lint/style/noNamespace: Required for JSX module augmentation
   namespace JSX {
     interface IntrinsicElements extends ThreeJSXElements {}
   }
 }
 
 declare module 'react/jsx-runtime' {
-  // biome-ignore lint/style/noNamespace: Required for JSX module augmentation
   namespace JSX {
     interface IntrinsicElements extends ThreeJSXElements {}
   }
 }
 
 declare module 'react/jsx-dev-runtime' {
-  // biome-ignore lint/style/noNamespace: Required for JSX module augmentation
   namespace JSX {
     interface IntrinsicElements extends ThreeJSXElements {}
   }

--- a/turbo.json
+++ b/turbo.json
@@ -23,7 +23,7 @@
       "dependsOn": ["^lint"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^build", "^check-types"]
     },
     "dev": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Adds the CI workflow contributors have been asking for, and resolves the lint/typecheck blockers that were preventing it from being added cleanly.

Closes #147.

## What's in the workflow

`.github/workflows/ci.yml` runs `bun run check` (Biome lint + format) and `bun run check-types` (TypeScript) on every push and PR to `main`. Concurrency groups cancel stale runs.

## What had to be cleaned up first

`bun run check` had 4 lint errors and `bun run check-types` had 32 errors on `main` — merging the workflow without fixing those would have blocked every subsequent push.

**Lint (4 errors → 0):**

- Removed stale `biome-ignore` comments in `bootstrap.ts`, `r3f.d.ts`, and `parametric-node-renderer.tsx` — the rules they were suppressing no longer fire in those positions, so the suppressions themselves were the lint errors (`suppressions/unused`).
- Replaced two `forEach` callbacks that returned values with `for...of` loops (`node-actions.ts`, `build-collider-world.ts`) — fixes `useIterableCallbackReturn`.
- Rewrote `x && (x.foo = false)` short-circuit-assignment guards in `ceiling/tool.tsx` as explicit `if` statements — fixes `noAssignInExpressions`.
- Hoisted a `useMemo`/`useCallback` pair above an early `return null` in `chimney/panel.tsx` — fixes `useHookAtTopLevel`.

**Types (32 errors → 0):**

The 32 type errors all reproduce on a fresh checkout but disappear once `packages/core` is built — the symbols (`useAlignmentGuides`, `AlignmentAnchor`, `bboxAnchors`, `resolveAlignment`, `TranslateHandle`, `ParamAction`, `GutterNode`, plus the various missing handle/event properties and `PaintableMaterialTarget` variants) all exist in `packages/core/src/` and are re-exported through the package barrels. The published `dist/` was just stale, and consumers resolve types via `dist` (per the package's `exports` field with `moduleResolution: "bundler"`).

The fix is a single `turbo.json` change: `check-types` now `dependsOn: ["^build", "^check-types"]` so internal builds run before type-checks. No `@ts-ignore`, no `as any`, no consumer code changes needed.

## Verification

- `bun run check` — 0 errors, 0 warnings (101 non-blocking `useExhaustiveDependencies` infos remain at `info` level per existing config — those don't fail CI).
- `bun run check-types` — 0 errors across all 9 typed projects.

## Out of scope

- The `useExhaustiveDependencies` infos in `viewer/index.tsx`, `door-system.tsx`, `geometry-system.tsx`, `window-system.tsx`, etc. — they're warnings/infos not errors, and fixing them properly needs more familiarity with each component than this PR should take on.
- `packages/mcp` already has its own `mcp-ci.yml` workflow with build + test + biome on path-filtered changes; this new general workflow runs alongside it.
