### PR TITLE
fix(wall-tool): null-guard wallPreviewRef writes (Sentry MONOREPO-EDITOR-D0)

### DIFF
--- a/packages/nodes/src/wall/tool.tsx
+++ b/packages/nodes/src/wall/tool.tsx
@@ -542,7 +542,7 @@ export const WallTool: React.FC = () => {
         // BoxGeometry stays visible for a frame on top of the
         // freshly-committed real wall, producing a brief
         // double-paint at the new wall's position.
-        wallPreviewRef.current.visible = false
+        if (wallPreviewRef.current) wallPreviewRef.current.visible = false
         setDraftMeasurement(null)
       }
     }


### PR DESCRIPTION
Fixes Sentry **MONOREPO-EDITOR-D0** (and duplicate **MONOREPO-EDITOR-BE**): `TypeError: Cannot set properties of null (setting 'visible')` firing in production at editor.pascal.app. Repro path: `onGridClick` fires once after the wall-tool component starts unmounting (level switch, tool change). The `<mesh ref={wallPreviewRef}>` has already been removed from R3F by the time the emitter listener runs, so `wallPreviewRef.current === null` when the line `wallPreviewRef.current.visible = false` executes inside the second `onGridClick` branch.

This PR guards that one remaining unguarded write with the same `if (wallPreviewRef.current)` style used in `stopDrafting` (which was guarded earlier in #323 — that PR caught one of the two writes from this crash family; this one was missed because it sits inside the second `onGridClick` branch rather than the cleanup path). No other changes; `onGridMove` already early-returns when either ref is null.