### PR TITLE
fix(editor): render slab side walls solid regardless of polygon winding

### DIFF
--- a/packages/viewer/src/systems/slab/slab-system.tsx
+++ b/packages/viewer/src/systems/slab/slab-system.tsx
@@ -81,6 +81,20 @@ export function generateSlabGeometry(slabNode: SlabNode): THREE.BufferGeometry {
   return elevation < 0 ? generatePoolGeometry(slabNode) : generatePositiveSlabGeometry(slabNode)
 }
 
+// Earcut normalizes cap triangulation regardless of input winding, but the side
+// walls below assume a CCW contour (the unflipped quad's right-hand normal faces
+// outward only for CCW). outsetPolygon and the slab tool preserve the drawn
+// winding, so a CW-drawn slab gets inward-facing walls that FrontSide culls and
+// the slab reads as see-through from the front. Normalize to CCW first.
+function ensureCounterClockwisePolygon(polygon: Array<[number, number]>): Array<[number, number]> {
+  let area2 = 0
+  for (let i = 0; i < polygon.length; i++) {
+    const j = (i + 1) % polygon.length
+    area2 += polygon[i]![0] * polygon[j]![1] - polygon[j]![0] * polygon[i]![1]
+  }
+  return area2 < 0 ? [...polygon].reverse() : polygon
+}
+
 /**
  * Standard slab: flat extrusion upward from Y=0 by elevation thickness.
  *
@@ -94,7 +108,7 @@ export function generateSlabGeometry(slabNode: SlabNode): THREE.BufferGeometry {
  * because exactly one faces the camera under FrontSide culling.
  */
 function generatePositiveSlabGeometry(slabNode: SlabNode): THREE.BufferGeometry {
-  const polygon = getRenderableSlabPolygon(slabNode)
+  const polygon = ensureCounterClockwisePolygon(getRenderableSlabPolygon(slabNode))
   const elevation = slabNode.elevation ?? 0.05
   const holePolygons = mergeSurfaceHolePolygons(slabNode.holes ?? [])
 
@@ -187,7 +201,7 @@ function generatePositiveSlabGeometry(slabNode: SlabNode): THREE.BufferGeometry 
  *   - walls from Y=0 to Y=depth, inward-facing normals (visible from inside pool)
  */
 function generatePoolGeometry(slabNode: SlabNode): THREE.BufferGeometry {
-  const polygon = getRenderableSlabPolygon(slabNode)
+  const polygon = ensureCounterClockwisePolygon(getRenderableSlabPolygon(slabNode))
   const depth = Math.abs(slabNode.elevation ?? 0.05)
   const holePolygons = mergeSurfaceHolePolygons(slabNode.holes ?? [])
 


### PR DESCRIPTION
## Problem
When a floor slab is placed, ~half the time its vertical side walls don't render — the camera-facing walls vanish and you see through to the far walls (production bug).

## Cause
`generatePositiveSlabGeometry` / `generatePoolGeometry` build side walls assuming a **CCW contour** (the unflipped quad's right-hand normal is outward only for CCW). But `outsetPolygon` and the slab tool **preserve the drawn winding**, so a **CW-drawn slab** gets inward-facing side-wall normals → `FrontSide` culling drops the front faces → see-through. Which half breaks depends on the click/draw direction.

## Fix
`ensureCounterClockwisePolygon` — reverse the contour when signed area < 0 — applied to both the positive-slab and pool contours before geometry generation. Matches how three.js `ExtrudeGeometry` normalizes winding via `ShapeUtils.isClockWise`.

## Verified
- Caps unaffected (Earcut normalizes the outer ring internally — that's why the *top* always rendered).
- Holes already double-emitted + winding-normalized (`unionPolygons`); ceilings use flat `ShapeGeometry` (no extruded walls); 2D floorplan is a separate path; `autoFromWalls` slabs are already CCW (no-op).
- Reviewed adversarially (Codex) + against the three.js winding convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)