### PR TITLE
Remove unused action bar controls

### DIFF
--- a/packages/editor/src/components/ui/action-menu/control-modes.tsx
+++ b/packages/editor/src/components/ui/action-menu/control-modes.tsx
@@ -33,13 +33,6 @@ const controls: ControlConfig[] = [
     activeColor: 'bg-blue-500/20 text-blue-400',
   },
   {
-    id: 'box-select',
-    iconifyIcon: 'mdi:select-drag',
-    label: 'Box select',
-    color: 'hover:bg-white/5',
-    activeColor: 'bg-white/10 hover:bg-white/10',
-  },
-  {
     id: 'site-edit',
     imageSrc: '/icons/site.png',
     label: 'Edit site',

--- a/packages/editor/src/components/ui/action-menu/view-toggles.tsx
+++ b/packages/editor/src/components/ui/action-menu/view-toggles.tsx
@@ -995,7 +995,6 @@ export function SecondaryToggles() {
   return (
     <div className="flex items-center gap-1">
       <ReferencesControl />
-      <ReferenceFloorControl />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove the Box select control from the bottom action bar without deleting the selection tool implementation
- remove the unused Reference floor split button from the secondary action bar group

## Validation
- `bun run --cwd packages/editor check-types`
- `git diff --check HEAD~1..HEAD`
