### PR TITLE
fix: guard WallTool grid handlers against null wallPreviewRef

### DIFF
--- a/packages/nodes/src/wall/tool.tsx
+++ b/packages/nodes/src/wall/tool.tsx
@@ -621,6 +621,11 @@ export const WallTool: React.FC = () => {
     }
 
     const onGridClick = (event: GridEvent) => {
+      // A mitt-emitted `grid:click` can arrive after the preview
+      // `<mesh>` unmounts (e.g. the user switches tool mid-draft),
+      // leaving the ref null — same guard as `onGridMove`.
+      if (!wallPreviewRef.current) return
+
       if (buildingState.current === 1 && event.nativeEvent.detail >= 2) {
         stopDrafting()
         return


### PR DESCRIPTION
## Sentry: MONOREPO-EDITOR-BE (issue 7494188332)

`TypeError: Cannot set properties of null (setting 'visible')` in `WallTool`.

### Root cause
`onGridClick` is subscribed to the mitt `grid:click` event. When the user switches tools mid-draft, the `WallTool` preview `<mesh>` unmounts and `wallPreviewRef.current` becomes null — but a queued `grid:click` event can still fire before the effect cleanup runs `emitter.off`. The state-1 branch then writes `wallPreviewRef.current.visible = false` on a null ref and throws.

### Fix
Add `if (!wallPreviewRef.current) return` at the top of `onGridClick`, mirroring the guard `onGridMove` already has (`if (!(cursorRef.current && wallPreviewRef.current)) return`). `stopDrafting` already null-guards its `wallPreviewRef.current.visible` write (it's also called from `onCancel`), so no change needed there.

`curve-tool.tsx` was checked for the same pattern — its `onGridClick` doesn't touch a preview mesh ref, so no change needed.

Typecheck (`tsc --build` in `packages/nodes`): ✅ passes.

Precedent: same class of fix as "fix: guard onShelfMove against null cursorGroupRef (Sentry EDITOR-BC)".