### PR TITLE
editor: export the headless-composition surface (ToolManager, keyboard, camera, edit systems)

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -11,6 +11,12 @@ export { default as Editor } from './components/editor'
 // they're referenced throughout the editor's own internals; the public
 // surface uses the shorter, shell-friendly names from the unified
 // preset-system spec.
+// Headless-composition surface: lets embedders compose `<Viewer>` +
+// tool routing + camera + keyboard directly (without mounting the full
+// `<Editor>` chrome). Tool/affordance implementations stay kind-owned via
+// the registry (`def.tool` / `def.affordanceTools`); these exports are the
+// thin editor-side glue that routes and hosts them.
+export { CustomCameraControls } from './components/editor/custom-camera-controls'
 export { FloatingActionMenu as FloatingMenu } from './components/editor/floating-action-menu'
 export { formatMeasurement, MeasurementPill } from './components/editor/measurement-pill'
 export {
@@ -26,6 +32,15 @@ export {
   buildSvgArrowHeadPoints,
   getArcPlanPoint,
 } from './components/editor-2d/svg-paths'
+// Edit-affordance systems for kinds whose geometry editing lives outside
+// their registry tools (ceiling boundaries, roof slope handles, stair
+// segments, zone boundaries). Mounted by `<Editor>` internally; exported so
+// self-composed shells get the same editing affordances.
+export { CeilingSelectionAffordanceSystem } from './components/systems/ceiling/ceiling-selection-affordance-system'
+export { CeilingSystem } from './components/systems/ceiling/ceiling-system'
+export { RoofEditSystem } from './components/systems/roof/roof-edit-system'
+export { StairEditSystem } from './components/systems/stair/stair-edit-system'
+export { ZoneSystem } from './components/systems/zone/zone-system'
 // Phase 5 Stage D transitional exports — pure drafting / angle helpers
 // consumed by kind-owned drag actions in @pascal-app/nodes. Stage F
 // cleanup moves these into @pascal-app/nodes (fence/drafting.ts +
@@ -58,6 +73,12 @@ export {
   type PlacementCoordinatorConfig,
   usePlacementCoordinator,
 } from './components/tools/item/use-placement-coordinator'
+// Screen-space marquee selection — mounted by `<Editor>` internally;
+// exported for self-composed shells.
+export { BoxSelectTool } from './components/tools/select/box-select-tool'
+// Resolves a kind's drag affordance component from `def.affordanceTools`
+// (the registry contract) — the dispatcher `ToolManager` uses internally.
+export { getRegistryAffordanceTool } from './components/tools/shared/affordance-dispatch'
 export { CursorSphere } from './components/tools/shared/cursor-sphere'
 export { DragBoundingBox } from './components/tools/shared/drag-bounding-box'
 export { getFloorStackPreviewPosition } from './components/tools/shared/floor-stack-preview'
@@ -96,6 +117,11 @@ export {
   DEFAULT_STAIR_TYPE,
   DEFAULT_STAIR_WIDTH,
 } from './components/tools/stair/stair-defaults'
+// The tool router: reads `useEditor` (phase/mode/tool) + the node registry
+// and lazy-mounts the active kind-owned tool / affordance / legacy fallback.
+// The single component a self-composed shell mounts inside `<Viewer>` to get
+// the complete interaction layer.
+export { ToolManager } from './components/tools/tool-manager'
 export {
   createWallOnCurrentLevel,
   getSegmentGridStep,
@@ -172,7 +198,7 @@ export type { SaveStatus } from './hooks/use-auto-save'
 // can express their affordances declaratively in their own folder.
 export { type UseDragActionArgs, useDragAction } from './hooks/use-drag-action'
 // Phase 5 Stage D — extras for kind-owned placement tools (FenceTool etc.).
-export { markToolCancelConsumed } from './hooks/use-keyboard'
+export { markToolCancelConsumed, useKeyboard } from './hooks/use-keyboard'
 export { type Selection, useSelection } from './hooks/use-selection'
 export {
   CEILING_ALIGNMENT_THRESHOLD_M,
@@ -286,6 +312,7 @@ export type {
   FloorplanSelectionTool,
   MovingFenceEndpoint,
   MovingWallEndpoint,
+  Phase,
   SplitOrientation,
   Tool,
   ToolDefaults,


### PR DESCRIPTION
## What does this PR do?

Exports the thin editor-side glue that lets embedders compose `<Viewer>` + the interaction layer directly, without mounting the full `<Editor>` chrome — the registry already owns the per-kind tools (`def.tool` / `def.affordanceTools` / `def.floorplanAffordances`); these exports are the router and hosts around it:

- `ToolManager` — the tool router (registry-driven + legacy fallbacks)
- `useKeyboard` — the global shortcut hook (alongside the already-public `markToolCancelConsumed`)
- `CustomCameraControls` — orbit/pan/first-person camera glue
- `getRegistryAffordanceTool` — the `def.affordanceTools` dispatcher
- `BoxSelectTool` — screen-space marquee selection
- `CeilingSystem`, `CeilingSelectionAffordanceSystem`, `RoofEditSystem`, `StairEditSystem`, `ZoneSystem` — edit-affordance systems
- `Phase` type (joins the already-exported `Tool` type from `store/use-editor`)

Additive only — no behavior change, no signature change, no file moves. Follows the same embedder story as `layoutVersion`, the v2 slot props, and the recent Phase 5 Stage D/E export waves: we build a custom shell on `@pascal-app/editor` and currently must choose between mounting all of `<Editor>`'s chrome or forking these files; with these exports we can compose `Viewer + ToolManager + CustomCameraControls + useKeyboard (+ systems)` and own the chrome while every kind-owned tool keeps working untouched.

## How to test

1. `bun install && bun run build` (or `turbo run build --filter='@pascal-app/*'`) — builds green.
2. `cd packages/editor && bun run check-types` — clean (verified locally).
3. `bunx biome check packages/editor/src/index.tsx` — clean (verified locally).
4. Consumer smoke (optional): in any app depending on `@pascal-app/editor`, `import { ToolManager, useKeyboard, CustomCameraControls, Phase } from '@pascal-app/editor'` resolves and `<Viewer><ToolManager/><CustomCameraControls/></Viewer>` mounts the registry tools.

## Screenshots / screen recording

N/A — non-visual change (barrel exports only).

## Checklist

- [ ] I've tested this locally with `bun dev` (verified via package typecheck + workspace build instead; no app run)
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch