### PR TITLE
fix(core): coerce unknown material.preset to 'custom' (Sentry MONOREPO-EDITOR-DB)

### DIFF
--- a/packages/core/src/schema/material.test.ts
+++ b/packages/core/src/schema/material.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+import { MaterialSchema } from './material'
+
+describe('MaterialSchema', () => {
+  describe('preset', () => {
+    test('valid preset passes through unchanged', () => {
+      const result = MaterialSchema.parse({ preset: 'brick' })
+      expect(result.preset).toBe('brick')
+    })
+
+    test('every enum preset is accepted', () => {
+      const presets = [
+        'white',
+        'brick',
+        'concrete',
+        'wood',
+        'glass',
+        'metal',
+        'plaster',
+        'tile',
+        'marble',
+        'custom',
+      ] as const
+      for (const preset of presets) {
+        expect(MaterialSchema.parse({ preset }).preset).toBe(preset)
+      }
+    })
+
+    test("unknown preset coerces to 'custom' instead of throwing (Sentry MONOREPO-EDITOR-DB)", () => {
+      const result = MaterialSchema.parse({ preset: 'stone' })
+      expect(result.preset).toBe('custom')
+    })
+
+    test("non-string preset coerces to 'custom'", () => {
+      const result = MaterialSchema.parse({ preset: 42 })
+      expect(result.preset).toBe('custom')
+    })
+
+    test('missing preset stays undefined', () => {
+      const result = MaterialSchema.parse({})
+      expect(result.preset).toBeUndefined()
+    })
+
+    test('explicit undefined preset stays undefined', () => {
+      const result = MaterialSchema.parse({ preset: undefined })
+      expect(result.preset).toBeUndefined()
+    })
+  })
+})

--- a/packages/core/src/schema/material.ts
+++ b/packages/core/src/schema/material.ts
@@ -27,7 +27,8 @@ export type MaterialProperties = z.infer<typeof MaterialProperties>
 
 export const MaterialSchema = z.object({
   id: z.string().optional(),
-  preset: MaterialPreset.optional(),
+  // Coerce unknown presets (legacy/AI-generated data) to 'custom' instead of throwing.
+  preset: MaterialPreset.catch('custom').optional(),
   properties: MaterialProperties.optional(),
   texture: z
     .object({


### PR DESCRIPTION
## Problem

Production editor crashes with an unhandled `ZodError` during slab boundary edits (Sentry **MONOREPO-EDITOR-DB**, issue id `7543527892`):

```
ZodError: invalid_value at ["material","preset"]
expected one of white|brick|concrete|wood|glass|metal|plaster|tile|marble|custom
```

Stack: `polygon-editor.tsx` → slab/boundary-editor `handlePolygonChange` → `use-scene` `updateNode` → `SlabNode.parse`.

This happens when node data carries a `material.preset` value outside the `MaterialPreset` enum — typically legacy, imported, or AI-generated scenes (e.g. `"stone"`).

## Fix

In `MaterialSchema`, change:

```ts
preset: MaterialPreset.optional()
```

to:

```ts
preset: MaterialPreset.catch('custom').optional()
```

Unknown preset values are now coerced to `'custom'` instead of throwing, making loading/updating tolerant of bad data. The exported `MaterialPreset` enum itself stays strict, so all other consumers keep exact enum validation. `resolveMaterial` already falls back to `DEFAULT_MATERIALS.custom` merged with `material.properties` for `'custom'`, so coerced materials render with whatever explicit properties the node carries.

Verified `undefined` handling: missing/`undefined` preset still parses to `undefined` (zod v4 `.catch()` before `.optional()` does not swallow `undefined`).

## Tests

New `packages/core/src/schema/material.test.ts`:
- valid presets pass through unchanged (all 10 enum values)
- unknown preset (`'stone'`) coerces to `'custom'`
- non-string preset coerces to `'custom'`
- missing / explicit-`undefined` preset stays `undefined`

`bun test src/schema/` → 50 pass, 0 fail; `tsc --build` clean; biome check clean.