### PR TITLE
feat(paint-slots): roof shingle catalog default finish

### DIFF
--- a/packages/nodes/src/roof/roof-materials.ts
+++ b/packages/nodes/src/roof/roof-materials.ts
@@ -2,6 +2,7 @@ import {
   type ColorPreset,
   createDefaultMaterial,
   createSurfaceRoleMaterial,
+  resolveSlotDefaultMaterial,
   type RenderShading,
 } from '@pascal-app/viewer'
 import * as THREE from 'three'
@@ -24,7 +25,7 @@ export function getRoofMaterials(
         createDefaultMaterial('white', 1, shading, THREE.DoubleSide), // 0: Wall/Trim
         createDefaultMaterial('#e5e5e5', 1, shading, THREE.FrontSide), // 1: Deck
         createDefaultMaterial('white', 1, shading, THREE.DoubleSide), // 2: Interior
-        createDefaultMaterial('#e5e5e5', 0.9, shading, THREE.FrontSide), // 3: Shingle
+        resolveSlotDefaultMaterial('library:roof-weatheredshingles', shading), // 3: Shingle
       ]
     : [
         createSurfaceRoleMaterial('roof', colorPreset),


### PR DESCRIPTION
Part of the phase-5 tail of the paint-slots plan (`editor-paint-slots.md`): default materials for the remaining procedural kinds.

## What
- Roof's main shingle surface (material index 3) now defaults to the catalog `library:roof-weatheredshingles` finish instead of the flat `#e5e5e5` placeholder, via `resolveSlotDefaultMaterial`.
- Wall/trim, deck, and interior surfaces unchanged; textures-off (monochrome) role array unchanged.

## Scope (intentional)
Roof keeps its existing per-segment role-based material system (edge/wall/top + parent-roof inheritance). It is **not** migrated to the unified `node.slots` model in this PR — scoped to defaults-only by decision. Note: roof painting is not currently wired through a registry `capabilities.paint`; that remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)