### PR TITLE
fix(item-catalog): prevent first-open layout flash by reserving tile min-height

### DIFF
--- a/packages/editor/src/components/ui/item-catalog/item-catalog.tsx
+++ b/packages/editor/src/components/ui/item-catalog/item-catalog.tsx
@@ -96,7 +96,8 @@ export function ItemCatalog({
             onMouseEnter={() => triggerSFX('sfx:menu-hover')}
             type="button"
           >
-            <div className="relative aspect-square w-full overflow-hidden rounded-lg">
+            {/* min-h 兜底:首开网格列宽未定时仍占住高度,避免瓦片塌缩成文字行(防闪) */}
+            <div className="relative aspect-square min-h-[90px] w-full overflow-hidden rounded-lg">
               <img
                 alt={item.name}
                 className="h-full w-full object-cover"


### PR DESCRIPTION
## What

Reserve a `min-height` on the item-catalog tile's square thumbnail wrapper so tiles keep a stable footprint from the first paint.

## Why

On the **first open** of the item catalog, the `auto-fill, minmax(90px, 1fr)` grid has no resolved column width for a frame and the `<img loading="eager">` thumbnails haven't decoded yet, so the `aspect-square` wrappers collapse to near‑zero height. The labels then stack into a cramped two‑row text layout that visibly reflows into the normal grid once the images arrive (a brief FOUC). Subsequent opens look fine because the images are cached.

## Fix

Add `min-h-[90px]` (matching the column min) to the thumbnail wrapper in `item-catalog.tsx`. Each tile now reserves its footprint before images load, so the grid renders in its final shape immediately. No change to the steady state once thumbnails are loaded.

## Notes

Single-line change. Verified on the standalone editor (`apps/editor`, dev) — the first-open flash is gone and the loaded grid is unchanged.
