### PR TITLE
fix(editor): point compass needle at true north, not camera

### DIFF
--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -10316,14 +10316,14 @@ export function FloorplanPanel({
           (compassHost ? (
             createPortal(
               <FloorplanCompassButton
-                northRotationDeg={-floorplanUserRotationDeg}
+                northRotationDeg={floorplanUserRotationDeg}
                 onAlignNorth={alignFloorplanViewToNorth}
               />,
               compassHost,
             )
           ) : (
             <FloorplanCompassButton
-              northRotationDeg={-floorplanUserRotationDeg}
+              northRotationDeg={floorplanUserRotationDeg}
               onAlignNorth={alignFloorplanViewToNorth}
             />
           ))}


### PR DESCRIPTION
## Problem

The compass needle in the viewer pointed in the direction the camera was facing instead of at true north — as you orbited, the needle swung *with* the camera rather than staying pinned to a fixed world direction.

## Cause

The needle rotation was `-floorplanUserRotationDeg`. The 2D/3D views are kept in sync via `floorplanUserRotationDeg = cameraAzimuth − 90°`, and working through the projection math (three.js spherical θ → screen, and the SVG `rotate()` for the 2D case) true north lands at **`+floorplanUserRotationDeg`**. The negated sign made the needle rotate *opposite* to north.

The formula was originally written for the 2D-floorplan-only compass and reused verbatim when the compass was portaled into the 3D viewer, so both `FloorplanCompassButton` instances carried the flipped sign.

## Fix

Drop the negation on both compass instances (3D-viewer portal + 2D-floorplan fallback):

```diff
- northRotationDeg={-floorplanUserRotationDeg}
+ northRotationDeg={floorplanUserRotationDeg}
```

"Align to north" is unaffected (resets `userRotation → 0 → needle up`).

## Testing

Verified manually against the community server — orbiting the camera now keeps the red needle pinned to a fixed world direction.

> Note: for buildings with a non-zero rotation the 2D floorplan de-rotates the building while the 3D view shows true world angle, so the two branches strictly diverge by `buildingRotationDeg`. This PR keeps the minimal sign-flip (correct for the common axis-aligned case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)