### PR TITLE
fix(nodes): guard previewRef in fence tool onGridClick (Sentry EDITOR-BE/CR)

### DIFF
--- a/packages/nodes/src/fence/tool.tsx
+++ b/packages/nodes/src/fence/tool.tsx
@@ -552,6 +552,7 @@ export const FenceTool: React.FC = () => {
     }
 
     const onGridClick = (event: GridEvent) => {
+      if (!previewRef.current) return
       if (buildingState.current === 1 && event.nativeEvent.detail >= 2) {
         stopDrafting()
         return


### PR DESCRIPTION
## Summary

Fixes a production null-deref crash in the fence tool.

**Sentry:** MONOREPO-EDITOR-BE / EDITOR-CR
**Error:** `TypeError: Cannot set properties of null (setting 'visible')`
**Where:** editor.pascal.app/editor/:projectId

## Root cause

In `packages/nodes/src/fence/tool.tsx`, the `onGridClick` handler sets `previewRef.current.visible = true` / `= false` without a null guard. `previewRef` is declared `useRef<Mesh>(null!)` and is genuinely `null` until the `<mesh ref={previewRef}>` mounts. A grid click processed before the preview mesh mounts (or during an unmount race) dereferences `null` and throws.

The sibling `onGridMove` handler already guards correctly with `if (!(cursorRef.current && previewRef.current)) return`.

## Fix

Add an early guard at the top of the `onGridClick` callback, mirroring the existing `onGridMove` pattern:

```ts
const onGridClick = (event: GridEvent) => {
  if (!previewRef.current) return
  ...
}
```

Minimal and surgical — no other behavior changes.

## Testing

Isolated `tsc` on the package surfaces only pre-existing, unrelated peer-dependency errors (e.g. `@pascal-app/viewer` exports) that exist on `main` independent of this change; nothing new is introduced by the one-line guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive null check in editor fence drafting; no auth, data, or behavior change when the preview mesh is mounted.
> 
> **Overview**
> Adds an early **`if (!previewRef.current) return`** at the start of the fence tool’s **`onGridClick`** handler so grid clicks are ignored until the preview mesh ref is attached.
> 
> This aligns **`onGridClick`** with **`onGridMove`**, which already bails when **`previewRef`** is unset, and prevents production crashes from setting **`visible`** on a null ref when a click races mount/unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e1b830caad2cb713a820ecc47d3bc99370a2e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->