### PR TITLE
fix(viewer): kick render on focus and visibility resume

### DIFF
--- a/packages/viewer/src/components/viewer/frame-limiter.tsx
+++ b/packages/viewer/src/components/viewer/frame-limiter.tsx
@@ -28,11 +28,33 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     set({ frameloop: 'never' })
     // Kick off custom render loop
     raf = requestAnimationFrame(tick)
+
+    // Browsers throttle requestAnimationFrame when the tab is hidden, the
+    // window is unfocused, or the system marks the tab as occluded. With
+    // frameloop="never" rAF is the only render driver, so when it stalls the
+    // canvas freezes — Linux Firefox/Chrome and Zen show this as the viewer
+    // "turning off" between cursor interactions. Force one synchronous advance
+    // whenever the page resumes so the next visible frame matches the current
+    // scene state.
+    function kick() {
+      i += 1 / 1000
+      advance(i)
+    }
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible') kick()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('focus', kick)
+    window.addEventListener('pageshow', kick)
+
     // Restore initial setting
     return () => {
       if (raf) {
         cancelAnimationFrame(raf)
       }
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('focus', kick)
+      window.removeEventListener('pageshow', kick)
       set({ frameloop: initFrameloop })
     }
   }, [fps, advance, set, initFrameloop])


### PR DESCRIPTION
Lands #291 (@mvanhorn) onto current `main`. The original PR was correct but conflicted on surrounding comments; this is the same fix rebased clean.

With `frameloop="never"` the rAF loop is the only render driver. Browsers throttle `requestAnimationFrame` when the tab is hidden/unfocused/occluded, freezing the canvas (viewer appears to 'turn off' between interactions). Adds `visibilitychange`/`focus`/`pageshow` listeners that force one synchronous `advance()` on resume, with matching cleanup. Deps unchanged.

Typecheck + lint pass. Co-authored with @mvanhorn. Fixes #275, closes #196.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized viewer render-loop change with proper listener cleanup; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a frozen canvas when the tab is hidden, unfocused, or occluded while **`FrameLimiter`** runs with `frameloop="never"` (rAF is the only render driver).
> 
> Adds a **`kick()`** helper that bumps the internal clock and calls **`advance()`** once synchronously. **`visibilitychange`** (when state becomes visible), **`window` `focus`**, and **`pageshow`** invoke it so the first frame after resume reflects current scene state. The effect cleanup removes those listeners alongside the existing rAF cancel and frameloop restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dada9c77b6aa705338489c3720192a138a5d214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->