### PR TITLE
fix(editor): don't crash GLB export on a material-less renderable

### DIFF
--- a/packages/editor/src/lib/glb-export.ts
+++ b/packages/editor/src/lib/glb-export.ts
@@ -156,6 +156,11 @@ function pairClones(
 // plain transform node instead of a primitive.
 const EMPTY_GEOMETRY = new THREE.BufferGeometry()
 
+// Hidden placeholder for a neutralised renderable that has no material: a valid
+// material keeps GLTFExporter from crashing on `material.isShaderMaterial`, while
+// EMPTY_GEOMETRY makes it emit a transform node instead of a primitive.
+const PLACEHOLDER_MATERIAL = new THREE.MeshBasicMaterial({ visible: false })
+
 /**
  * Strip everything that must not bake into the model:
  *  - Editor overlays on non-scene layers (gizmos, selection handles, ground
@@ -180,6 +185,25 @@ function pruneNonRenderableMeshes(root: THREE.Object3D, identityNodes: Set<THREE
     if (!object.layers.isEnabled(SCENE_LAYER)) {
       if (identityNodes.has(object)) return
       toRemove.push(object)
+      return
+    }
+    // A renderable (Mesh / Line / Points) with no material can't produce valid
+    // glTF and crashes GLTFExporter, which reads `material.isShaderMaterial`
+    // unconditionally — e.g. an imported sub-model that left a mesh material-less.
+    // Non-Mesh renderables also slip past the `isMesh` checks below and the
+    // material conversion. Neutralise it: keep the node (so children survive) but
+    // strip its geometry + give it the hidden placeholder, or drop it if a leaf.
+    const renderable = object as THREE.Mesh & { isLine?: boolean; isPoints?: boolean }
+    if (
+      (renderable.isMesh === true || renderable.isLine === true || renderable.isPoints === true) &&
+      renderable.material == null
+    ) {
+      if (object.children.length > 0) {
+        renderable.geometry = EMPTY_GEOMETRY
+        renderable.material = PLACEHOLDER_MATERIAL
+      } else {
+        toRemove.push(object)
+      }
       return
     }
     const mesh = object as THREE.Mesh


### PR DESCRIPTION
## What does this PR do?

Fixes a GLB bake failure: `Cannot read properties of undefined (reading 'isShaderMaterial')`.

`GLTFExporter` reads `material.isShaderMaterial` unconditionally, so any renderable (Mesh / Line / Points) with **no material** crashes the export. A non-Mesh renderable also slips past both the `isMesh` check in `pruneNonRenderableMeshes` and the material conversion pass, so it reaches the exporter untouched (e.g. an imported sub-model that left a mesh material-less).

`pruneNonRenderableMeshes` now guards it: a material-less renderable is **dropped** if it's a leaf, or **neutralised** (empty geometry + a hidden placeholder material) if it has children, so its subtree survives. This runs before material conversion, so both crash paths are covered.

It surfaced now because disabling post-processing during bake (`?disable=postFx`) lets these scenes load fast enough to actually reach the export.

## How to test

1. Bake a project that has a material-less renderable (repro: `project_0hrQfgRZo4uiNZSo`) — previously failed with the `isShaderMaterial` error.
2. The bake completes and produces a valid GLB; the material-less object is omitted (or an empty transform node if it had children).
3. Other projects export unchanged.

## Screenshots / screen recording

N/A — export-internals fix, no UI.

## Checklist

- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've tested this locally with `bun dev`
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to export-time scene pruning on the cloned bake tree; no auth, persistence, or live editor rendering changes.
> 
> **Overview**
> Fixes GLB bake crashes when `GLTFExporter` hits a **Mesh, Line, or Points** object with `material == null` (it reads `material.isShaderMaterial` unconditionally). Those objects could slip past existing mesh-only pruning and the material conversion pass—e.g. material-less pieces on imported sub-models.
> 
> **`pruneNonRenderableMeshes`** now handles them before conversion: leaf renderables are removed; nodes with children are **neutralised** with shared `EMPTY_GEOMETRY` and a hidden `PLACEHOLDER_MATERIAL` so the subtree stays in the export tree without emitting a broken primitive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75cffed9f8db06ea2e07f1b0f566c529b4abffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->