### PR TITLE
fix(editor): guard model export against undefined geometry.index (Sentry MONOREPO-EDITOR-E0)

### DIFF
--- a/packages/editor/src/lib/glb-export.ts
+++ b/packages/editor/src/lib/glb-export.ts
@@ -120,6 +120,7 @@ export function prepareSceneForExport(
   }
 
   pruneNonRenderableMeshes(scene, identityNodes)
+  normalizeGeometryIndex(scene)
   convertMaterials(scene)
 
   const { clips, clipNamesByNode } = bakeAnimationClips(cloneByOriginal, nodes)
@@ -217,6 +218,24 @@ function pruneNonRenderableMeshes(root: THREE.Object3D, identityNodes: Set<THREE
   for (const object of toRemove) {
     object.removeFromParent()
   }
+}
+
+/**
+ * Coerce every surviving mesh's `geometry.index` from `undefined` to `null`.
+ * three r184's STLExporter (and the OBJ/GLB paths) guard with `index !== null`
+ * and then read `index.count`; a `BufferGeometry` whose index was never set
+ * reports `undefined`, which passes that guard and crashes with
+ * `Cannot read properties of undefined (reading 'count')`. `BufferGeometry`
+ * treats `null` as "no index" (non-indexed draw), so this is the safe form the
+ * exporters expect. Fixes Sentry MONOREPO-EDITOR-E0.
+ */
+function normalizeGeometryIndex(root: THREE.Object3D) {
+  root.traverse((object) => {
+    const mesh = object as THREE.Mesh
+    if (!mesh.isMesh) return
+    const geometry = mesh.geometry as THREE.BufferGeometry | undefined
+    if (geometry && geometry.index === undefined) geometry.index = null
+  })
 }
 
 function isRenderableMesh(mesh: THREE.Mesh): boolean {


### PR DESCRIPTION
## Sentry: MONOREPO-EDITOR-E0 / 6H

`TypeError: Cannot read properties of undefined (reading 'count')` thrown during STL/OBJ/GLB model export.

**Stack:** settings-panel `onClick` → export-manager `exportFn` → three's `STLExporter.parse` → `Object3D.traverse`.

## Root cause

three r184's `STLExporter` does:

```js
triangles += ( index !== null ) ? ( index.count / 3 ) : ( positionAttribute.count / 3 );
```

A `BufferGeometry` whose index was **never set** reports `geometry.index === undefined`, not `null`. The exporter's guard `index !== null` is therefore truthy for `undefined`, so it falls into the `index.count` branch and crashes reading `undefined.count`.

`BufferGeometry` semantically treats `null` as "no index" (non-indexed draw), which is the form all three exporters expect — but a freshly traversed/cloned mesh can carry `undefined` instead.

Note: the export pipeline referenced in the original Sentry report (`export-manager.tsx` with `isMeshWithInvalidGeometry`/`prepareSceneForExport`) has since been refactored into `packages/editor/src/lib/glb-export.ts`. The fix is applied there, in `prepareSceneForExport`, which is the shared prep path used by STL **and** OBJ **and** GLB exports.

## Fix

Add a minimal, defensive `normalizeGeometryIndex()` pass that runs after `pruneNonRenderableMeshes` on the cloned export scene. For every surviving mesh, it coerces `geometry.index` from `undefined` → `null`:

```ts
function normalizeGeometryIndex(root: THREE.Object3D) {
  root.traverse((object) => {
    const mesh = object as THREE.Mesh
    if (!mesh.isMesh) return
    const geometry = mesh.geometry as THREE.BufferGeometry | undefined
    if (geometry && geometry.index === undefined) geometry.index = null
  })
}
```

Because it runs on the cloned export tree (never the live scene) and only touches the `undefined` case, it's safe and idempotent. STL/OBJ/GLB all benefit.

## Test
Pre-existing monorepo cross-package typecheck errors (unbuilt `@pascal-app/viewer`/`core` workspaces) are unrelated to this change; no new errors reference the added code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive normalization on the export clone only, with no auth, persistence, or live-scene mutation.
> 
> **Overview**
> Fixes **STL/OBJ/GLB export crashes** when a mesh’s `BufferGeometry` has `geometry.index === undefined` instead of `null`. three r184 exporters treat `undefined` as indexed geometry and read `index.count`, which throws during export from the settings panel.
> 
> Adds **`normalizeGeometryIndex()`** on the **cloned** export scene in `prepareSceneForExport`, immediately after `pruneNonRenderableMeshes`, setting `geometry.index` from `undefined` → `null` so non-indexed geometry matches what STL/OBJ/GLB paths expect. Only the export clone is touched; meshes that already have an index or `null` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d40d68a74ba4af09675d59e6abe03b512bd6aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->