### PR TITLE
viewer: slow first-person walk/run/jump speeds

### DIFF
--- a/packages/editor/src/components/editor/first-person-controls.tsx
+++ b/packages/editor/src/components/editor/first-person-controls.tsx
@@ -1388,11 +1388,11 @@ export const FirstPersonControls = () => {
             floatSensorRadius={0.15}
             floatSpringK={1200}
             gravity={9.81}
-            jumpVel={6}
+            jumpVel={5}
             key="first-person-controller"
-            maxRunSpeed={5.5}
+            maxRunSpeed={5}
             maxSlope={1.2}
-            maxWalkSpeed={4}
+            maxWalkSpeed={2}
             paused={isElevatorRideLocked}
             position={controllerStart.position}
             ref={setControllerApi}

--- a/packages/viewer/src/components/viewer/glb-walkthrough-controller.tsx
+++ b/packages/viewer/src/components/viewer/glb-walkthrough-controller.tsx
@@ -410,10 +410,10 @@ export function GlbWalkthroughController({ url }: { url: string }) {
         floatSensorRadius={0.15}
         floatSpringK={1200}
         gravity={9.81}
-        jumpVel={6}
-        maxRunSpeed={5.5}
+        jumpVel={5}
+        maxRunSpeed={5}
         maxSlope={1.2}
-        maxWalkSpeed={4}
+        maxWalkSpeed={2}
         position={start.position}
         ref={setControllerApi}
       />


### PR DESCRIPTION
## What does this PR do?

Slows down first-person navigation, which felt too fast. Applied identically to both the GLB walkthrough controller (`packages/viewer`) and the editor's first-person controls (`packages/editor`) so the two surfaces stay consistent.

- Walk: 4 → 2 m/s
- Run (Shift): 5.5 → 5 m/s
- Jump (`jumpVel`): 6 → 5 (~1.83 m → ~1.27 m peak)

## How to test

1. `bun dev` and open a scene.
2. Enter first-person / walkthrough mode.
3. Walk with WASD — movement is noticeably slower (2 m/s) and more deliberate.
4. Hold Shift to sprint — clearly faster than walking (5 m/s, 2.5× gap).
5. Press Space to jump — peak is lower (~1.27 m), no longer overshooting low ledges.

## Screenshots / screen recording

N/A — tuning of movement constants only, no visual/UI change.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only numeric movement props on two first-person call sites; no auth, data, or shared physics logic changes.
> 
> **Overview**
> First-person movement felt too fast, so **`BVHEcctrl`** tuning is reduced in both the editor street-view controller and the baked GLB walkthrough so behavior stays aligned.
> 
> **Walk** (`maxWalkSpeed`) goes from 4 → **2** m/s, **sprint** (`maxRunSpeed`) from 5.5 → **5** m/s, and **jump** (`jumpVel`) from 6 → **5**, which lowers peak jump height and makes low ledges easier to clear without overshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36132bbcea9a1c2815e6af34fa8a59ed29d0cf70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->