### PR TITLE
fix(editor): guard GLB export against undefined array-material slots (Sentry MONOREPO-EDITOR-79)

### DIFF
--- a/packages/editor/src/lib/glb-export.test.ts
+++ b/packages/editor/src/lib/glb-export.test.ts
@@ -107,6 +107,26 @@ describe('prepareSceneForExport', () => {
     expect(visibleChildren).toHaveLength(1)
   })
 
+  test('fills undefined slots in an array material so no undefined survives the prune', () => {
+    // Multi-material / group geometry where one slot was never assigned:
+    // `mesh.material = [validMat, undefined]`. The scalar-null guard doesn't
+    // catch this (an array is never `== null`), so the undefined slot used to
+    // reach GLTFExporter and crash on `material.isShaderMaterial`.
+    const root = new THREE.Group()
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1))
+    mesh.material = [nodeMaterial(), undefined as unknown as THREE.Material]
+    root.add(mesh)
+
+    const { scene } = prepareSceneForExport(root, {})
+
+    const exported = scene.children[0] as THREE.Mesh
+    const materials = exported.material as THREE.Material[]
+    expect(Array.isArray(materials)).toBe(true)
+    expect(materials).toHaveLength(2)
+    // No undefined/null slot survives; every slot is a real material.
+    expect(materials.every((m) => m != null)).toBe(true)
+  })
+
   test('stamps identity from the scene registry and strips other userData', () => {
     const root = new THREE.Group()
     const doorGroup = new THREE.Group()

--- a/packages/editor/src/lib/glb-export.ts
+++ b/packages/editor/src/lib/glb-export.ts
@@ -216,6 +216,20 @@ function pruneNonRenderableMeshes(root: THREE.Object3D, identityNodes: Set<THREE
       }
       return
     }
+    // The scalar branch above only catches `material == null`; an ARRAY material
+    // (multi-material / group geometry) is never `== null`, so a slot that was
+    // never assigned — e.g. `[validMat, undefined]` — slips through and reaches
+    // GLTFExporter, which reads `material.isShaderMaterial` on every group's
+    // material and crashes on the undefined slot. Don't drop the mesh (the other
+    // slots may be real geometry): fill any null/undefined holes with the hidden
+    // placeholder so the exporter never sees an undefined material.
+    if (
+      (renderable.isMesh === true || renderable.isLine === true || renderable.isPoints === true) &&
+      Array.isArray(renderable.material) &&
+      renderable.material.some((m) => m == null)
+    ) {
+      renderable.material = renderable.material.map((m) => m ?? PLACEHOLDER_MATERIAL)
+    }
     const mesh = object as THREE.Mesh
     if (!mesh.isMesh || isRenderableMesh(mesh)) return
     if (mesh.children.length > 0) {


### PR DESCRIPTION
## Summary

Follow-up hardening for **Sentry MONOREPO-EDITOR-79** — `TypeError: Cannot read properties of undefined (reading 'isShaderMaterial')` (224 events, firing since 2026-04-22 through 2026-07-02) thrown from `three` `GLTFExporter.processMaterialAsync` during the automated GLB bake/thumbnail path (`userCount:0`).

## The scalar-vs-array gap left by f75cffed

Commit `f75cffed` added a guard in `pruneNonRenderableMeshes` for renderables whose material is scalar null/undefined:

```ts
if ((renderable.isMesh || renderable.isLine || renderable.isPoints) && renderable.material == null) { … }
```

That only catches a **scalar** null. A mesh with an **array** material (multi-material / group geometry) where one slot was never assigned — e.g. `mesh.material = [validMat, undefined]` — is never `== null`, so it slips through. `isRenderableMesh` then returns `true` (the valid slot satisfies `material.some((m) => m?.visible !== false)`), so the mesh survives to `GLTFExporter`, which iterates every group's material and crashes on `undefined.isShaderMaterial`. That is the remaining trigger for this issue.

## Fix

In `pruneNonRenderableMeshes`, after the existing scalar-null branch, handle the array case: for a renderable whose material is an array containing any null/undefined slot, fill the holes with the existing hidden `PLACEHOLDER_MATERIAL` and keep the mesh. The valid slots stay renderable; the exporter never sees an `undefined` material.

- Scalar branch behavior is unchanged.
- Reuses the existing `PLACEHOLDER_MATERIAL` constant.
- Does **not** drop the whole mesh in the array case (other slots may be real geometry).

## Tests

Added a `prepareSceneForExport` unit test covering `material = [mat, undefined]`: after prune, the array still has both slots and every slot is non-null (no `undefined` survives).

> Note: `bun test` / `check-types` couldn't fully run in the isolated triage clone because the sibling workspace packages `@pascal-app/core` / `@pascal-app/viewer` aren't linked there (pre-existing, unrelated to this change). The change only touches local `THREE.*` usage and the existing `PLACEHOLDER_MATERIAL`.

Scope: `packages/editor/src/lib/glb-export.ts` and its test file only. No dependency changes.

**Do not merge without review.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to export-time mesh pruning with a matching unit test; no auth, data, or runtime behavior outside automated GLB bake.
> 
> **Overview**
> Hardens **GLB export** against **Sentry MONOREPO-EDITOR-79**: meshes with **multi-material arrays** where a slot is `undefined` (e.g. `[validMat, undefined]`) no longer reach `GLTFExporter`, which used to throw on `material.isShaderMaterial`.
> 
> In `pruneNonRenderableMeshes`, after the existing **scalar** `material == null` handling, any **array** material with null/undefined slots is normalized by mapping holes to the existing hidden **`PLACEHOLDER_MATERIAL`**—the mesh is kept so valid slots still export.
> 
> Adds a **`prepareSceneForExport`** unit test asserting `[mat, undefined]` leaves a two-slot array with every entry non-null after prune.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fc8c0c7f03c94f1b57ec3df33a8f0474a73b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->