### PR TITLE
viewer/nodes: fix WebGPU pipeline poisoning from missing uv2 on slabs and empty roofs

### DIFF
--- a/packages/nodes/src/slab/geometry.ts
+++ b/packages/nodes/src/slab/geometry.ts
@@ -122,7 +122,14 @@ function splitSlabFacesByFacing(geometry: BufferGeometry): {
   const build = (data: { pos: number[]; uv: number[] }) => {
     const geo = new BufferGeometry()
     geo.setAttribute('position', new Float32BufferAttribute(data.pos, 3))
-    if (data.uv.length > 0) geo.setAttribute('uv', new Float32BufferAttribute(data.uv, 2))
+    if (data.uv.length > 0) {
+      geo.setAttribute('uv', new Float32BufferAttribute(data.uv, 2))
+      // Slot finishes with an aoMap (e.g. the default woodplank) sample uv2;
+      // a referenced-but-missing attribute crashes the WebGPU renderer mid
+      // scene pass, which leaks the MRT render target and poisons every
+      // pipeline built afterwards.
+      geo.setAttribute('uv2', new Float32BufferAttribute(data.uv.slice(), 2))
+    }
     geo.computeVertexNormals()
     return geo
   }

--- a/packages/viewer/src/components/viewer/post-processing.tsx
+++ b/packages/viewer/src/components/viewer/post-processing.tsx
@@ -598,6 +598,12 @@ const PostProcessingPasses = ({
       }
     } catch (error) {
       hasPipelineErrorRef.current = true
+      // A mid-pass exception (e.g. thrown inside a PassNode's scene render)
+      // leaves the pass's MRT render target bound on the renderer. Every
+      // pipeline compiled afterwards then validates against that 3-attachment
+      // framebuffer and fails, poisoning the rebuilt pipeline and the fallback
+      // path alike. Restore the default target before retrying.
+      ;(renderer as any).setRenderTarget?.(null)
       console.error('[viewer/post-processing] Render pass failed.', {
         retryCount: retryCountRef.current,
         rendererCtor: (renderer as any).constructor?.name,

--- a/packages/viewer/src/systems/roof/roof-system.tsx
+++ b/packages/viewer/src/systems/roof/roof-system.tsx
@@ -497,8 +497,10 @@ function updateMergedRoofGeometry(
 
   if (children.length === 0) {
     mergedMesh.geometry.dispose()
-    // Keep a valid position attribute so Drei's BVH can index safely.
-    mergedMesh.geometry = new THREE.BoxGeometry(0, 0, 0)
+    // Keep a valid position attribute so Drei's BVH can index safely. Must
+    // also carry uv2 — the roof finish's aoMap samples it, and a missing
+    // attribute crashes the WebGPU renderer (BoxGeometry has no uv2).
+    mergedMesh.geometry = ensureRenderableGeometryAttributes(new THREE.BufferGeometry())
     return
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the WebGPU error cascade (`Color target has no corresponding fragment stage output` → `Invalid RenderPipeline` → `Invalid CommandBuffer` on every queue submit) that fires when a scene contains slabs or segment-less roofs whose default catalog finish carries an aoMap — most visibly when loading IFC files in `apps/ifc-converter`.

Root cause: two geometry producers ship meshes without a `uv2` attribute while their slot material samples `uv2` (aoMap):

- `buildSlabGeometry`'s top/side face split rebuilt geometries with only `position` + `uv`; the default surface finish `library:wood-woodplank48` has an AO map.
- The children-less merged-roof fallback assigned `BoxGeometry(0, 0, 0)`, which has `uv` but no `uv2`; roofs imported from IFC have no segments, so they all hit this branch.

three r184's WebGPU renderer throws mid scene pass on the referenced-but-missing attribute (`Cannot read properties of undefined (reading 'id')` in `RenderObject.getAttributes`), which leaves the post-processing MRT render target bound on the renderer — every pipeline compiled afterwards validates against the wrong 3-attachment framebuffer, and post FX permanently falls back once the retry budget is exhausted.

Changes:

- `packages/nodes/src/slab/geometry.ts` — emit `uv2` (copy of `uv`) on the split top/side geometries, matching the existing `ensureUv2Attribute` convention.
- `packages/viewer/src/systems/roof/roof-system.tsx` — replace the `BoxGeometry(0,0,0)` fallback with `ensureRenderableGeometryAttributes(new BufferGeometry())`, which carries all four attributes and keeps a valid position for Drei's BVH.
- `packages/viewer/src/components/viewer/post-processing.tsx` — defense-in-depth: reset the render target when a render pass throws, so any future mid-pass exception costs one frame instead of poisoning every pipeline for the session.

## How to test

1. `bun install && bun dev`, then open the IFC converter app (port 3003) and load the "Revit Architectural" example (`?file=07-revit-architectural.ifc`) — any example with slabs reproduces.
2. Before this PR: the console fills with `THREE.AttributeNode: Vertex attribute "uv2" not found`, `[viewer/post-processing] Render pass failed.`, and repeating `WebGPU uncaptured error: Invalid RenderPipeline / Invalid CommandBuffer` entries; post FX (SSGI/ink) drops out after 3 retries.
3. After this PR: console is clean and the model renders with post-processing active.
4. Editor regression check: place a slab and a roof in the editor app, paint the slab top, delete all segments from a roof — no console errors, slab finish still tiles correctly (uv2 mirrors uv).

## Screenshots / screen recording

N/A — the change is "errors gone": before, the converter console streams GPUValidationError spam and the viewer loses SSGI/ink; after, the same model loads with a clean console and full post FX.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebGPU rendering and geometry attributes on common paths (IFC slabs/roofs); changes are narrow and align with existing ensureRenderableGeometryAttributes patterns, with low regression risk outside WebGPU/post-FX.
> 
> **Overview**
> Fixes a **WebGPU error cascade** when slab or segment-less roof meshes use default finishes whose **aoMap** samples **`uv2`**, but the geometry only had **`position`** + **`uv`**.
> 
> **Slab split geometry** now mirrors **`uv`** into **`uv2`** on top/side buffers (same convention as **`ensureRenderableGeometryAttributes`**). **Empty merged roofs** no longer use **`BoxGeometry(0,0,0)`**; they use **`ensureRenderableGeometryAttributes(new BufferGeometry())`** so BVH-safe position and **`uv2`** are present.
> 
> **Post-processing** resets the render target to **`null`** when a render pass throws, so a mid-pass failure does not leave the MRT bound and poison subsequent pipeline compiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d883ee2af8d7e1281e8f0bd12c8437ad149bafe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->