### PR TITLE
editor: unbreak bakes and STL/OBJ exports on malformed/placeholder meshes

### DIFF
--- a/packages/editor/src/components/editor/bake-exporter.tsx
+++ b/packages/editor/src/components/editor/bake-exporter.tsx
@@ -41,6 +41,10 @@ export function BakeExporter({
         const buffer = await exportSceneToGlb(sceneGroup, useScene.getState().nodes)
         onComplete(buffer)
       } catch (err) {
+        // The bake worker relays page console output into the job's error
+        // trail; the message alone rarely localises an exporter crash, so
+        // surface the full stack here.
+        console.error('[bake-exporter]', err instanceof Error ? (err.stack ?? err.message) : err)
         onError(err instanceof Error ? err.message : String(err))
       } finally {
         useViewer.getState().setExporting(false)

--- a/packages/editor/src/components/editor/export-manager.tsx
+++ b/packages/editor/src/components/editor/export-manager.tsx
@@ -4,9 +4,32 @@ import { emitter, useScene } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import { useThree } from '@react-three/fiber'
 import { useEffect } from 'react'
+import * as THREE from 'three'
 import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter.js'
 import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js'
 import { exportSceneToGlb, prepareSceneForExport } from '../../lib/glb-export'
+
+// prepareSceneForExport neutralises container meshes (door/window hitbox roots,
+// material-less renderables) with an attribute-less geometry — GLTFExporter
+// emits those as plain transform nodes, but STL/OBJExporter read
+// `position.count` unconditionally and crash. Swap in a geometry with an empty
+// (count-0) position so they iterate zero vertices instead. Shared: the export
+// scene is a throwaway clone, only its geometry *ref* is swapped.
+const EMPTY_POSITION_GEOMETRY = new THREE.BufferGeometry()
+EMPTY_POSITION_GEOMETRY.setAttribute(
+  'position',
+  new THREE.Float32BufferAttribute(new Float32Array(0), 3),
+)
+
+function ensurePositionAttributes(root: THREE.Object3D) {
+  root.traverse((object) => {
+    const renderable = object as THREE.Mesh & { isLine?: boolean; isPoints?: boolean }
+    if (!(renderable.isMesh || renderable.isLine || renderable.isPoints)) return
+    if (!renderable.geometry?.getAttribute('position')) {
+      renderable.geometry = EMPTY_POSITION_GEOMETRY
+    }
+  })
+}
 
 export function ExportManager() {
   const scene = useThree((state) => state.scene)
@@ -41,7 +64,8 @@ export function ExportManager() {
       } finally {
         emitter.emit('thumbnail:after-capture', undefined)
       }
-      const { scene: exportScene, animations } = prepared
+      const { scene: exportScene } = prepared
+      ensurePositionAttributes(exportScene)
 
       if (format === 'stl') {
         const exporter = new STLExporter()

--- a/packages/editor/src/lib/glb-export.ts
+++ b/packages/editor/src/lib/glb-export.ts
@@ -130,6 +130,7 @@ export function prepareSceneForExport(
   }
 
   pruneNonRenderableMeshes(scene, identityNodes)
+  sanitizeMaterialGroups(scene, identityNodes)
   convertMaterials(scene)
 
   const { clips, clipNamesByNode } = bakeAnimationClips(cloneByOriginal, nodes)
@@ -223,6 +224,68 @@ function pruneNonRenderableMeshes(root: THREE.Object3D, identityNodes: Set<THREE
     } else {
       toRemove.push(mesh)
     }
+  })
+  for (const object of toRemove) {
+    object.removeFromParent()
+  }
+}
+
+/**
+ * Repair meshes whose geometry groups don't line up with their material array —
+ * GLTFExporter reads `materials[group.materialIndex]` per group and crashes on
+ * undefined (`reading 'isShaderMaterial'`). The known producer is a roof
+ * placeholder (BoxGeometry's 6 groups vs the 4 roof materials), but any
+ * system/CSG output can end up here, so repair generically:
+ *  - groups indexing past the array (or drawing zero triangles) are dropped;
+ *  - null slots referenced by surviving groups get the hidden placeholder;
+ *  - a mesh left with no drawable group — including an array-material mesh
+ *    with no groups at all (three draws nothing for those, e.g. the roof
+ *    system's degenerate placeholder) — is neutralised like other
+ *    non-renderables (kept as a bare transform node, or removed if a leaf
+ *    that carries no node identity).
+ * Geometry/material refs are shared with the live scene (`clone(true)` is
+ * shallow for both), so repairs swap refs instead of mutating in place.
+ */
+function sanitizeMaterialGroups(root: THREE.Object3D, identityNodes: Set<THREE.Object3D>) {
+  const toRemove: THREE.Object3D[] = []
+  root.traverse((object) => {
+    const mesh = object as THREE.Mesh
+    if (!mesh.isMesh || !Array.isArray(mesh.material)) return
+    const materials = mesh.material
+    const groups = mesh.geometry.groups
+    const broken =
+      groups.length === 0 ||
+      groups.some((g) => (g.materialIndex ?? 0) >= materials.length || g.count === 0) ||
+      materials.some((m) => m == null)
+    if (!broken) return
+
+    const validGroups = groups.filter(
+      (g) => (g.materialIndex ?? 0) < materials.length && g.count !== 0,
+    )
+    if (validGroups.length === 0) {
+      if (mesh.children.length > 0 || identityNodes.has(mesh)) {
+        mesh.geometry = EMPTY_GEOMETRY
+        mesh.material = PLACEHOLDER_MATERIAL
+      } else {
+        toRemove.push(mesh)
+      }
+      return
+    }
+    // Only the group list needs repair — share the attribute/index refs
+    // instead of geometry.clone(), which deep-copies every vertex buffer.
+    if (validGroups.length !== groups.length) {
+      const geometry = new THREE.BufferGeometry()
+      geometry.index = mesh.geometry.index
+      for (const [name, attribute] of Object.entries(mesh.geometry.attributes)) {
+        geometry.setAttribute(name, attribute)
+      }
+      geometry.morphAttributes = mesh.geometry.morphAttributes
+      geometry.morphTargetsRelative = mesh.geometry.morphTargetsRelative
+      geometry.setDrawRange(mesh.geometry.drawRange.start, mesh.geometry.drawRange.count)
+      geometry.groups = validGroups.map((g) => ({ ...g }))
+      mesh.geometry = geometry
+    }
+    mesh.material = materials.map((m) => m ?? PLACEHOLDER_MATERIAL)
   })
   for (const object of toRemove) {
     object.removeFromParent()

--- a/packages/viewer/src/components/viewer/index.tsx
+++ b/packages/viewer/src/components/viewer/index.tsx
@@ -345,6 +345,14 @@ interface ViewerProps {
    */
   sceneReadyKey?: string | number | null
   onSceneReadyChange?: (ready: boolean) => void
+  /**
+   * Skip the TSL post-processing pipeline (SSGI/denoise/ink/outline) and render
+   * the scene directly. For headless/capture surfaces (the bake page) where
+   * frame quality is irrelevant: on a software-rasterised worker the pipeline
+   * consumes the whole CPU budget and bakes time out. Equivalent to the
+   * `?disable=postFx` diagnostic URL flag, but host-controlled.
+   */
+  disablePostFx?: boolean
 }
 
 /** Imperative handle exposed via `ref` on `<Viewer>`. */
@@ -371,6 +379,7 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
     isolate,
     sceneReadyKey,
     onSceneReadyChange,
+    disablePostFx = false,
   },
   ref,
 ) {
@@ -549,7 +558,7 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
             kind's `def.system` is loaded via lazy() and rendered here,
             ordered by `system.priority`. */}
         <RegisteredSystems />
-        <PostProcessing hoverStyles={hoverStyles} />
+        <PostProcessing disablePostFx={disablePostFx} hoverStyles={hoverStyles} />
         {selectionManager === 'default' && <SelectionManager />}
         {(perf || PERF_OVERLAY_ENABLED) && <PerfMonitor />}
         {children}

--- a/packages/viewer/src/components/viewer/post-processing.tsx
+++ b/packages/viewer/src/components/viewer/post-processing.tsx
@@ -126,8 +126,11 @@ function sanitizeOutlineObjects(objects: Object3D[]) {
 
 const PostProcessingPasses = ({
   hoverStyles = DEFAULT_HOVER_STYLES,
+  disablePostFx = false,
 }: {
   hoverStyles?: HoverStyles
+  /** Host-controlled equivalent of `?disable=postFx` — see the Viewer prop. */
+  disablePostFx?: boolean
 }) => {
   const { gl: renderer, invalidate, scene, camera, size } = useThree()
   const renderPipelineRef = useRef<RenderPipeline | null>(null)
@@ -264,6 +267,19 @@ const PostProcessingPasses = ({
     }
 
     const perfDisable = readPerfDisableFlags()
+
+    // postFx off (host prop or ?disable=postFx): never allocate the pipeline —
+    // useFrame's null-pipeline branch direct-renders. Before this check the
+    // URL flag only skipped the pipeline at render time; the build still
+    // allocated every pass.
+    if (disablePostFx || perfDisable.postFx) {
+      hasPipelineErrorRef.current = false
+      if (renderPipelineRef.current) {
+        renderPipelineRef.current.dispose()
+      }
+      renderPipelineRef.current = null
+      return
+    }
     const ssgiEnabled = shading === 'rendered' && SSGI_PARAMS.enabled && !perfDisable.ao
     const denoiseEnabled = ssgiEnabled && !perfDisable.denoise
     const outlineEnabled = !perfDisable.outline
@@ -521,6 +537,7 @@ const PostProcessingPasses = ({
     // whole pipeline. The uniform refs below are stable (useMemo), so they
     // never trigger a rebuild either.
     camera,
+    disablePostFx,
     hoverHiddenColor,
     hoverPulseMix,
     hoverStrength,
@@ -556,7 +573,12 @@ const PostProcessingPasses = ({
     sanitizeOutlineObjects(outliner.selectedObjects)
     sanitizeOutlineObjects(outliner.hoveredObjects)
 
-    if (PERF_POST_FX_DISABLED || hasPipelineErrorRef.current || !renderPipelineRef.current) {
+    if (
+      disablePostFx ||
+      PERF_POST_FX_DISABLED ||
+      hasPipelineErrorRef.current ||
+      !renderPipelineRef.current
+    ) {
       try {
         if ((renderer as any).setClearAlpha) {
           ;(renderer as any).setClearAlpha(transparentBackground ? 0 : 1)

--- a/packages/viewer/src/systems/roof/roof-system.tsx
+++ b/packages/viewer/src/systems/roof/roof-system.tsx
@@ -125,6 +125,28 @@ const _surfaceV1 = new THREE.Vector3()
 const _surfaceV2 = new THREE.Vector3()
 const _surfaceFaceNormal = new THREE.Vector3()
 
+/**
+ * Degenerate placeholder for a roof mesh with nothing to draw (initial
+ * BoxGeometry swap-out, or a roof whose segments were all deleted/painted).
+ * Three zero-vertices (one invisible triangle), not an empty attribute: an
+ * empty position (count 0) leaves WebGPU vertex buffer slot 0 unbound if the
+ * mesh is ever drawn, and computeBoundsTree needs a real position buffer to
+ * index. Deliberately NO groups: count-0 groups crash MeshBVH's packed-tree
+ * build (it partitions roots by group), and a BoxGeometry's 6 groups against
+ * the 4 roof materials crash raycasts and GLTFExporter. Group-less + a
+ * zero-area triangle is safe everywhere — it draws nothing under an array
+ * material and can never be ray-hit.
+ */
+function createDegenerateRoofPlaceholder(): THREE.BufferGeometry {
+  const placeholder = new THREE.BufferGeometry()
+  placeholder.setAttribute('position', new THREE.Float32BufferAttribute(new Float32Array(9), 3))
+  placeholder.setAttribute('normal', new THREE.Float32BufferAttribute(new Float32Array(9), 3))
+  placeholder.setAttribute('uv', new THREE.Float32BufferAttribute(new Float32Array(6), 2))
+  placeholder.setAttribute('uv2', new THREE.Float32BufferAttribute(new Float32Array(6), 2))
+  computeGeometryBoundsTree(placeholder)
+  return placeholder
+}
+
 // Pending merged-roof updates carried across frames (for throttling)
 const pendingRoofUpdates = new Set<AnyNodeId>()
 const warnedMergedRoofNaNIds = new Set<AnyNodeId>()
@@ -219,29 +241,7 @@ export const RoofSystem = () => {
             // so MeshBVH hits groups[4].materialIndex → undefined.side → crash.
             if (mesh.geometry.type === 'BoxGeometry') {
               mesh.geometry.dispose()
-              const placeholder = new THREE.BufferGeometry()
-              // Three zero-vertices (one degenerate, invisible triangle), not an
-              // empty attribute: an empty position (count 0) leaves WebGPU vertex
-              // buffer slot 0 unbound if the mesh is ever drawn, and computeBoundsTree
-              // needs a real position buffer to index.
-              placeholder.setAttribute(
-                'position',
-                new THREE.Float32BufferAttribute(new Float32Array(9), 3),
-              )
-              placeholder.setAttribute(
-                'normal',
-                new THREE.Float32BufferAttribute(new Float32Array(9), 3),
-              )
-              placeholder.setAttribute(
-                'uv',
-                new THREE.Float32BufferAttribute(new Float32Array(6), 2),
-              )
-              placeholder.setAttribute(
-                'uv2',
-                new THREE.Float32BufferAttribute(new Float32Array(6), 2),
-              )
-              computeGeometryBoundsTree(placeholder)
-              mesh.geometry = placeholder
+              mesh.geometry = createDegenerateRoofPlaceholder()
             }
             mesh.position.set(
               effectiveSegment.position[0],
@@ -497,8 +497,9 @@ function updateMergedRoofGeometry(
 
   if (children.length === 0) {
     mergedMesh.geometry.dispose()
-    // Keep a valid position attribute so Drei's BVH can index safely.
-    mergedMesh.geometry = new THREE.BoxGeometry(0, 0, 0)
+    // Not BoxGeometry: its 6 groups against the merged mesh's 4-material array
+    // crash GLTFExporter (materials[4] → undefined) when the roof bakes.
+    mergedMesh.geometry = createDegenerateRoofPlaceholder()
     return
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the two live production bake-failure classes plus the STL/OBJ export crash, all rooted in meshes whose geometry groups don't line up with their material arrays:

- **`isShaderMaterial` bake crashes** (every prod scene containing a roof node with zero segments): the roof system's placeholder geometry was a `BoxGeometry` — its 6 groups against the roof's 4-material array make `GLTFExporter` read `materials[groups[i].materialIndex]` → undefined. Both placeholder sites (initial swap-out and the empty-roof merged shell) now use a shared group-less degenerate geometry. Deliberately no count-0 groups: those crash MeshBVH's packed-tree build, which partitions roots by group.
- **Exporter hardening**: a `sanitizeMaterialGroups` pass in `glb-export.ts` repairs any mesh whose groups index past its material array before export (drops out-of-range/empty groups, placeholder-fills null material slots, neutralises meshes left with nothing drawable). Preserves `sceneRegistry` identity nodes and shares attribute refs instead of deep-cloning vertex buffers.
- **STL/OBJ export crash** (`Cannot read properties of undefined (reading 'count')` at `STLExporter.js:51` / `OBJExporter.js:147`): `prepareSceneForExport` neutralises container meshes with an attribute-less geometry, which GLTFExporter tolerates but STL/OBJ exporters don't. `ExportManager` now gives those meshes an empty (count-0) position attribute before parsing.
- **`disablePostFx` prop** on `Viewer` → `PostProcessing`: skips *building* the SSGI/denoise pipeline entirely (the `?disable=postFx` URL flag only bypassed it per-frame while still allocating every pass). Needed by private-editor's `/bake` page — the pipeline starves the 1-vCPU SwiftShader bake worker into 180s capture timeouts.
- `BakeExporter` logs the full error stack so the bake worker's console relay captures it in the job's error trail.

## How to test

1. `bun dev`, open a scene, add a roof, then delete all of its segments (leave the roof node) — the scene keeps rendering and raycasting normally.
2. Export the scene as GLB from the export menu — previously crashed with `Cannot read properties of undefined (reading 'isShaderMaterial')` when an empty roof was present; now succeeds.
3. Export the same scene as STL and as OBJ — previously crashed with `reading 'count'`; both now download valid files.
4. Verified end-to-end against production data: two prod projects (one from the `isShaderMaterial` failure class, one 180s-timeout class) copied into a local DB both bake green through the community `/bake/:id` page driven headlessly; GLB output byte-identical before/after the sanitizer refactor.
5. `disablePostFx`: with the prop set on `<Viewer>`, the `[viewer/post-processing] Building pipeline` log no longer appears and frames direct-render (same scene wall-clock 73s → 44s headless).

## Screenshots / screen recording

N/A — non-visual change (crash fixes + a headless-surface opt-out; rendered output is unchanged).

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches export cloning (shallow geometry/material ref swaps), roof runtime geometry, and the viewer render path; changes are targeted at crash/timeout cases but affect all GLB exports and any host that sets `disablePostFx`.
> 
> **Overview**
> Fixes **production bake failures** and **STL/OBJ export crashes** caused by meshes whose geometry **groups** do not match their **material** arrays (notably empty roofs and export placeholders).
> 
> **Roof system:** Replaces `BoxGeometry` / zero-size box placeholders with a shared **group-less degenerate** geometry (invisible triangle, BVH-safe) when segments are not individually drawn or the merged shell has no segments—avoiding raycast and `GLTFExporter` `isShaderMaterial` crashes from 6 groups vs 4 materials.
> 
> **GLB export:** Adds **`sanitizeMaterialGroups`** in `prepareSceneForExport` to drop invalid groups, fill null material slots, and neutralize meshes with nothing drawable before `GLTFExporter` runs.
> 
> **STL/OBJ export:** After `prepareSceneForExport`, **`ensurePositionAttributes`** assigns a count-0 position buffer to meshes that were neutralized with attribute-less geometry so `STLExporter` / `OBJExporter` no longer read undefined `position.count`.
> 
> **Headless bakes:** New **`disablePostFx`** on `Viewer` skips allocating the TSL post-processing pipeline (not just bypassing it per frame like `?disable=postFx`), for software-rasterized bake workers that would otherwise time out.
> 
> **Diagnostics:** `BakeExporter` logs the full error **stack** to the console for bake worker error trails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b7f8f71fd17216fdc11bef54b32c18cc8da964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->