### PR TITLE
viewer: survive block-misaligned KTX2 textures on WebGPU

### DIFF
--- a/packages/viewer/src/lib/ktx2-loader.ts
+++ b/packages/viewer/src/lib/ktx2-loader.ts
@@ -1,4 +1,111 @@
+import {
+  type CompressedTexture,
+  DataTexture,
+  LinearFilter,
+  LinearMipmapLinearFilter,
+  RGBAFormat,
+  UnsignedByteType,
+} from 'three'
 import { KTX2Loader } from 'three/examples/jsm/Addons.js'
+
+/** The private KTX2Loader surface this module relies on (stable across three
+ *  releases but not part of the public types). */
+type KTX2LoaderInternals = {
+  transcoderPath: string
+  workerConfig: Record<string, boolean> | null
+  _createTexture(buffer: ArrayBuffer, config?: Record<string, unknown>): Promise<unknown>
+}
+
+/** Base width/height of a Basis-supercompressed KTX2 payload needing transcode
+ *  (vkFormat 0 = ETC1S/UASTC) whose dimensions aren't block-aligned, or null
+ *  for anything safe. Little-endian u32s: vkFormat at byte 12, pixelWidth at
+ *  20, pixelHeight at 24. */
+function readMisalignedBasisSize(buffer: ArrayBuffer): { width: number; height: number } | null {
+  if (buffer.byteLength < 28) return null
+  const view = new DataView(buffer)
+  const vkFormat = view.getUint32(12, true)
+  if (vkFormat !== 0) return null
+  const width = view.getUint32(20, true)
+  const height = view.getUint32(24, true)
+  return width % 4 !== 0 || height % 4 !== 0 ? { width, height } : null
+}
+
+/**
+ * KTX2Loader that survives block-misaligned textures. WebGPU rejects
+ * block-compressed textures whose base dimensions aren't multiples of 4;
+ * three's KTX2Loader only warns and transcodes anyway, and the resulting
+ * invalid texture poisons every render pass that binds it (endless
+ * "Invalid BindGroup … Invalid CommandBuffer" spam — baked GLBs carrying an
+ * odd-sized user-item texture triggered exactly this). Such payloads are
+ * routed to a fallback loader whose support flags report no compressed
+ * formats, which makes the transcoder emit plain RGBA32 — uncompressed
+ * textures have no alignment requirement.
+ */
+class AlignmentSafeKTX2Loader extends KTX2Loader {
+  private rgbaFallback: KTX2Loader | null = null
+
+  private fallbackLoader(): KTX2LoaderInternals {
+    if (!this.rgbaFallback) {
+      this.rgbaFallback = new KTX2Loader(this.manager)
+      this.rgbaFallback.setTranscoderPath((this as unknown as KTX2LoaderInternals).transcoderPath)
+      // All formats unsupported → getTranscoderFormat falls through to RGBA32.
+      ;(this.rgbaFallback as unknown as KTX2LoaderInternals).workerConfig = {
+        astcSupported: false,
+        astcHDRSupported: false,
+        etc1Supported: false,
+        etc2Supported: false,
+        dxtSupported: false,
+        bptcSupported: false,
+        pvrtcSupported: false,
+      }
+    }
+    return this.rgbaFallback as unknown as KTX2LoaderInternals
+  }
+
+  /** Both `load()` and GLTFLoader's KHR_texture_basisu path funnel through
+   *  this internal — overriding it covers every entry point. */
+  async _createTexture(buffer: ArrayBuffer, config?: Record<string, unknown>): Promise<unknown> {
+    const misaligned = readMisalignedBasisSize(buffer)
+    if (misaligned) {
+      console.warn(
+        `[viewer] KTX2 texture is ${misaligned.width}x${misaligned.height} (not multiple-of-4); ` +
+          'transcoding uncompressed so WebGPU can create it.',
+      )
+      const transcoded = (await this.fallbackLoader()._createTexture(
+        buffer,
+        config,
+      )) as CompressedTexture
+      // The RGBA32 result still arrives as a CompressedTexture; three's WebGPU
+      // texture upload treats every CompressedTexture as block-compressed and
+      // crashes looking up a block descriptor for rgba8. Repackage the decoded
+      // pixels as a plain DataTexture instead.
+      const mip = (
+        transcoded.mipmaps as Array<{ data: Uint8Array; width: number; height: number }>
+      )?.[0]
+      if (!mip) return transcoded
+      const texture = new DataTexture(mip.data, mip.width, mip.height, RGBAFormat, UnsignedByteType)
+      texture.colorSpace = transcoded.colorSpace
+      texture.generateMipmaps = true
+      texture.minFilter = LinearMipmapLinearFilter
+      texture.magFilter = LinearFilter
+      texture.needsUpdate = true
+      transcoded.dispose()
+      return texture
+    }
+    return (KTX2Loader.prototype as unknown as KTX2LoaderInternals)._createTexture.call(
+      this,
+      buffer,
+      config,
+    )
+  }
+
+  dispose(): this {
+    this.rgbaFallback?.dispose()
+    this.rgbaFallback = null
+    super.dispose()
+    return this
+  }
+}
 
 /**
  * Single shared KTX2 loader for the whole viewer — used both by the GLB loader
@@ -9,7 +116,7 @@ import { KTX2Loader } from 'three/examples/jsm/Addons.js'
  * from the viewer root the moment the renderer is ready (even when no GLB is in
  * the scene, so catalog `.ktx2` finishes still load).
  */
-export const ktx2Loader = new KTX2Loader()
+export const ktx2Loader = new AlignmentSafeKTX2Loader()
 ktx2Loader.setTranscoderPath('https://cdn.jsdelivr.net/gh/pmndrs/drei-assets@master/basis/')
 
 const configuredRenderers = new WeakSet<object>()


### PR DESCRIPTION
## What does this PR do?

Fixes the community `/viewer` black-screen + endless `Invalid BindGroup "bindGroup_object"` / `Invalid CommandBuffer` validation spam on baked GLBs that carry a KTX2 texture with non-multiple-of-4 dimensions (e.g. a 299×399 user-item JPEG that the bake pipeline encoded unresized).

WebGPU rejects block-compressed textures whose base dimensions aren't multiples of 4. three's `KTX2Loader` only warns about such payloads and transcodes them to a block format anyway; the resulting invalid texture then poisons every render pass that binds it, once per frame.

`ktx2-loader.ts` now exports an `AlignmentSafeKTX2Loader`: it reads the width/height straight from the KTX2 header for Basis payloads (vkFormat 0), and routes misaligned ones through a fallback loader whose support flags report no compressed formats — the transcoder then emits plain RGBA32, which has no alignment requirement. The decoded pixels are repackaged as a regular `DataTexture` because the loader's RGBA output still arrives wrapped in a `CompressedTexture`, and three's WebGPU upload path (`WebGPUTextureUtils._copyCompressedBufferToTexture`) crashes looking up a block descriptor for rgba8. Aligned textures take the unchanged fast path.

Companion private-editor PR fixes the bake LOD encoder to power-of-two-resize JPEG sources too, so new artifacts won't contain misaligned KTX2 in the first place; this change is what makes the already-baked prod artifacts render.

## How to test

1. Reproduced with prod artifact `project_dAYO2MJVTHExwsQY` (lod0.glb contains one 299×399 ETC1S KTX2 texture): served the GLB locally, pointed a local `projects_bakes` row at it, and drove `/viewer/<id>` with WebGPU-enabled headless Chromium (`--enable-unsafe-webgpu --use-angle=metal`). Before: 4,025 GPU validation errors in 60s, black scene. After: 0 errors, scene renders, single console warning `KTX2 texture is 299x399 (not multiple-of-4); transcoding uncompressed…`.
2. Regression: a healthy scene (aligned KTX2 textures, catalog finishes) renders with 0 validation errors and never hits the fallback path.
3. `bun run check-types` and `bunx biome check` pass.

## Screenshots / screen recording

N/A — non-visual change when textures are well-formed; for the affected artifacts the change is "black screen + error spam" → "renders normally".

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the central KTX2 load path for all GLB and catalog textures and relies on private three.js loader internals, though aligned textures are unchanged and the fallback is narrowly scoped to misaligned Basis payloads.
> 
> **Overview**
> Fixes **WebGPU black screens** and per-frame `Invalid BindGroup` / `Invalid CommandBuffer` spam when baked GLBs include Basis KTX2 textures whose width or height are not multiples of 4 (e.g. odd-sized user-item images).
> 
> The shared `ktx2Loader` is now an **`AlignmentSafeKTX2Loader`** that inspects the KTX2 header and, for misaligned Basis payloads, transcodes via a fallback loader with all compressed formats disabled so output is **RGBA32**, then wraps the result in a **`DataTexture`** (three’s WebGPU path still treats RGBA from `CompressedTexture` as block-compressed). **Aligned textures** keep the existing fast path through stock `KTX2Loader._createTexture`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2448acce5ebf3d69960166a9034c6c9a256d8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->