### PR TITLE
fix(viewer): defer geometry disposal to avoid WebGPU dispose race (Sentry MONOREPO-EDITOR-DK/EG/EH)

### DIFF
--- a/packages/viewer/src/components/viewer/index.tsx
+++ b/packages/viewer/src/components/viewer/index.tsx
@@ -25,6 +25,7 @@ import type { ColorPreset, RenderShading } from '../../lib/materials'
 import { getSceneTheme } from '../../lib/scene-themes'
 import useViewer, { type RenderContext } from '../../store/use-viewer'
 import { FloorElevationSystem } from '../../systems/floor-elevation/floor-elevation-system'
+import { GeometryDisposalFlushSystem } from '../../systems/geometry/geometry-disposal-flush'
 import { GeometrySystem } from '../../systems/geometry/geometry-system'
 import { ErrorBoundary } from '../error-boundary'
 import { SceneRenderer } from '../renderers/scene-renderer'
@@ -541,6 +542,12 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
           <SceneRenderer />
         )}
 
+        {/* Single authoritative flush point for the deferred geometry-disposal
+            queue. Runs at a strongly negative frame priority so it drains the
+            queue before ANY rebuild system runs this frame, guaranteeing only
+            geometries dropped on a previous frame (already released by the
+            renderer) are disposed. See lib/deferred-dispose.ts. */}
+        <GeometryDisposalFlushSystem />
         {/* Generic slab-elevation lift for any kind that declares
             `capabilities.floorPlaced`. Runs at frame priority 1 so it
             lands its mesh.position.y override before the priority-2

--- a/packages/viewer/src/lib/deferred-dispose.ts
+++ b/packages/viewer/src/lib/deferred-dispose.ts
@@ -1,0 +1,59 @@
+import type { BufferGeometry } from 'three'
+
+/**
+ * WebGPU dispose-race mitigation.
+ *
+ * Disposing a `BufferGeometry` that is *still referenced by a live, rendered
+ * mesh* synchronously inside a `useFrame` rebuild loop is unsafe on the
+ * WebGPU backend. Three's WebGPU renderer keeps a `RenderObject` that holds
+ * the geometry's attributes; `BufferGeometry.dispose()` synchronously fires
+ * the `dispose` event, and the renderer's handler later reads `.id` / `.count`
+ * off attributes that have already been freed by the time the render pass
+ * unwinds — throwing `Cannot read properties of undefined (reading 'id')`
+ * (Sentry MONOREPO-EDITOR-DK / EG / EH).
+ *
+ * The renderer releases its `RenderObject` for a geometry once that geometry
+ * is no longer drawn (i.e. after the frame in which we swapped in the new
+ * geometry). So instead of disposing the *outgoing* live geometry mid-frame,
+ * we hand it to this queue and flush it at the START of the next frame, after
+ * the render pass that dropped it has completed. Behavior is identical —
+ * every geometry is still freed, just one frame later, after the renderer has
+ * let go of it.
+ *
+ * This is deliberately module-global (not per-system): every geometry system
+ * shares one flush point, and the queue is drained wholesale each frame. Only
+ * use `queueGeometryDispose` for geometries that were attached to a *rendered*
+ * mesh. Transient CSG intermediates that never entered the scene graph should
+ * still be disposed synchronously — the renderer never held a RenderObject for
+ * them, so there is no race.
+ */
+const pendingGeometryDisposals = new Set<BufferGeometry>()
+
+/**
+ * Queue a live geometry for disposal after the current render. Safe to call
+ * with the same geometry more than once (Set-deduped). The mesh should already
+ * have been detached / reassigned to a fresh geometry before calling this.
+ */
+export function queueGeometryDispose(geometry: BufferGeometry | null | undefined): void {
+  if (!geometry) return
+  if (typeof (geometry as { dispose?: () => void }).dispose !== 'function') return
+  pendingGeometryDisposals.add(geometry)
+}
+
+/**
+ * Dispose everything queued since the last flush. Call once at the top of a
+ * `useFrame` callback, before any rebuild work runs, so the renderer has had a
+ * full frame to release the outgoing geometries' RenderObjects.
+ */
+export function flushGeometryDisposals(): void {
+  if (pendingGeometryDisposals.size === 0) return
+  for (const geometry of pendingGeometryDisposals) {
+    try {
+      geometry.dispose()
+    } catch {
+      // A geometry may already be torn down (scene unload, HMR); freeing it
+      // twice is harmless and must never break the frame loop.
+    }
+  }
+  pendingGeometryDisposals.clear()
+}

--- a/packages/viewer/src/lib/deferred-dispose.ts
+++ b/packages/viewer/src/lib/deferred-dispose.ts
@@ -41,9 +41,12 @@ export function queueGeometryDispose(geometry: BufferGeometry | null | undefined
 }
 
 /**
- * Dispose everything queued since the last flush. Call once at the top of a
- * `useFrame` callback, before any rebuild work runs, so the renderer has had a
- * full frame to release the outgoing geometries' RenderObjects.
+ * Dispose everything queued since the last flush. Called once per frame by
+ * `GeometryDisposalFlushSystem` at a negative `useFrame` priority, before any
+ * rebuild system runs, so the renderer has had a full frame to release the
+ * outgoing geometries' RenderObjects. Do not call this from a rebuild
+ * system's `useFrame` — doing so risks disposing geometries queued by another
+ * system in the same frame, before the render pass.
  */
 export function flushGeometryDisposals(): void {
   if (pendingGeometryDisposals.size === 0) return

--- a/packages/viewer/src/systems/geometry/geometry-disposal-flush.tsx
+++ b/packages/viewer/src/systems/geometry/geometry-disposal-flush.tsx
@@ -1,0 +1,30 @@
+import { useFrame } from '@react-three/fiber'
+import { flushGeometryDisposals } from '../../lib/deferred-dispose'
+
+/**
+ * Single, authoritative flush point for the deferred geometry-disposal queue
+ * (Sentry MONOREPO-EDITOR-DK/EG/EH).
+ *
+ * Correctness depends on the flush running *before any rebuild system queues a
+ * new disposal in the same frame*. If a rebuild system (GeometrySystem,
+ * RoofSystem, …) both flushed and queued from its own `useFrame`, a system
+ * running later in the frame could flush geometries that an earlier system had
+ * just queued *this* frame — disposing them before the render pass and
+ * reintroducing the very race deferral is meant to prevent.
+ *
+ * R3F runs `useFrame` callbacks in ascending `priority` order (ties broken by
+ * mount order). Running this flush at a strongly negative priority guarantees
+ * it executes ahead of every rebuild system every frame, regardless of mount
+ * order, so the queue only ever contains geometries dropped on a *previous*
+ * frame — which the renderer has already released. This must be the ONLY
+ * caller of `flushGeometryDisposals`.
+ */
+const FLUSH_PRIORITY = -1000
+
+export const GeometryDisposalFlushSystem = () => {
+  useFrame(() => {
+    flushGeometryDisposals()
+  }, FLUSH_PRIORITY)
+
+  return null
+}

--- a/packages/viewer/src/systems/geometry/geometry-system.tsx
+++ b/packages/viewer/src/systems/geometry/geometry-system.tsx
@@ -13,7 +13,7 @@ import {
 import { useFrame } from '@react-three/fiber'
 import { useEffect, useRef } from 'react'
 import { type BufferGeometry, FrontSide, type Group, type Material, type Mesh } from 'three'
-import { flushGeometryDisposals, queueGeometryDispose } from '../../lib/deferred-dispose'
+import { queueGeometryDispose } from '../../lib/deferred-dispose'
 import {
   type ColorPreset,
   createSurfaceRoleMaterial,
@@ -106,12 +106,11 @@ export const GeometrySystem = () => {
   }, [sceneMaterials])
 
   useFrame(() => {
-    // Free any geometries queued for disposal on a previous frame. Doing this
-    // at the START of the frame (before rebuild) guarantees the WebGPU renderer
-    // has already released its RenderObject for the outgoing geometry, avoiding
-    // the mid-frame dispose race (Sentry MONOREPO-EDITOR-DK/EG/EH).
-    flushGeometryDisposals()
-
+    // Geometries queued for disposal on a previous frame are flushed by the
+    // dedicated `GeometryDisposalFlushSystem`, which runs at a negative frame
+    // priority ahead of every rebuild system. Flushing here would risk
+    // disposing geometries queued by another system *this* frame, before the
+    // render pass (Sentry MONOREPO-EDITOR-DK/EG/EH).
     if (dirtyNodes.size === 0) return
     const nodes = useScene.getState().nodes
 

--- a/packages/viewer/src/systems/geometry/geometry-system.tsx
+++ b/packages/viewer/src/systems/geometry/geometry-system.tsx
@@ -12,7 +12,8 @@ import {
 } from '@pascal-app/core'
 import { useFrame } from '@react-three/fiber'
 import { useEffect, useRef } from 'react'
-import { FrontSide, type Group, type Material, type Mesh } from 'three'
+import { type BufferGeometry, FrontSide, type Group, type Material, type Mesh } from 'three'
+import { flushGeometryDisposals, queueGeometryDispose } from '../../lib/deferred-dispose'
 import {
   type ColorPreset,
   createSurfaceRoleMaterial,
@@ -105,6 +106,12 @@ export const GeometrySystem = () => {
   }, [sceneMaterials])
 
   useFrame(() => {
+    // Free any geometries queued for disposal on a previous frame. Doing this
+    // at the START of the frame (before rebuild) guarantees the WebGPU renderer
+    // has already released its RenderObject for the outgoing geometry, avoiding
+    // the mid-frame dispose race (Sentry MONOREPO-EDITOR-DK/EG/EH).
+    flushGeometryDisposals()
+
     if (dirtyNodes.size === 0) return
     const nodes = useScene.getState().nodes
 
@@ -308,8 +315,10 @@ function disposeChildren(group: Group) {
       ?.__fromGeometry
     if (!fromGeometry) continue
     group.remove(child)
-    const mesh = child as Partial<Mesh> & { geometry?: { dispose?: () => void } }
-    if (mesh.geometry?.dispose) mesh.geometry.dispose()
+    const mesh = child as Partial<Mesh> & { geometry?: BufferGeometry }
+    // Defer the outgoing geometry's dispose to the next frame — the WebGPU
+    // renderer still holds a RenderObject for it during this frame's render.
+    if (mesh.geometry) queueGeometryDispose(mesh.geometry)
     if ('material' in mesh) {
       const m = (mesh as { material: unknown }).material
       if (Array.isArray(m)) {

--- a/packages/viewer/src/systems/roof/roof-system.tsx
+++ b/packages/viewer/src/systems/roof/roof-system.tsx
@@ -25,6 +25,7 @@ import { mergeGeometries, mergeVertices } from 'three/examples/jsm/utils/BufferG
 import { ADDITION, Brush, Evaluator, SUBTRACTION } from 'three-bvh-csg'
 import { computeBoundsTree } from 'three-mesh-bvh'
 import { ensureRenderableGeometryAttributes } from '../../lib/csg-utils'
+import { flushGeometryDisposals, queueGeometryDispose } from '../../lib/deferred-dispose'
 
 function csgGeometry(brush: Brush): THREE.BufferGeometry {
   return brush.geometry as unknown as THREE.BufferGeometry
@@ -168,6 +169,12 @@ export const RoofSystem = () => {
   useLiveNodeOverrides((s) => s.overrides)
 
   useFrame(() => {
+    // Free geometries queued for disposal on a previous frame before doing any
+    // rebuild work. Flushing at frame start guarantees the WebGPU renderer has
+    // already released the RenderObject for each outgoing geometry, avoiding the
+    // mid-frame dispose race (Sentry MONOREPO-EDITOR-DK/EG/EH).
+    flushGeometryDisposals()
+
     // Clear stale pending updates when the scene is unloaded
     if (rootNodeIds.length === 0) {
       pendingRoofUpdates.clear()
@@ -240,7 +247,7 @@ export const RoofSystem = () => {
             // while roofMaterials only has 4 entries. Three.js raycasts into invisible groups,
             // so MeshBVH hits groups[4].materialIndex → undefined.side → crash.
             if (mesh.geometry.type === 'BoxGeometry') {
-              mesh.geometry.dispose()
+              queueGeometryDispose(mesh.geometry)
               mesh.geometry = createDegenerateRoofPlaceholder()
             }
             mesh.position.set(
@@ -305,7 +312,9 @@ function updateRoofSegmentGeometry(
 ) {
   const newGeo = generateRoofSegmentGeometry(node, nodes)
 
-  mesh.geometry.dispose()
+  // Defer the outgoing live geometry's dispose — the WebGPU renderer still
+  // references it this frame (Sentry MONOREPO-EDITOR-DK/EG/EH).
+  queueGeometryDispose(mesh.geometry)
   mesh.geometry = newGeo
   computeGeometryBoundsTree(newGeo)
 
@@ -496,7 +505,8 @@ function updateMergedRoofGeometry(
     .filter((n): n is RoofSegmentNode => n !== undefined && !hasSegmentMaterialOverride(n))
 
   if (children.length === 0) {
-    mergedMesh.geometry.dispose()
+    // Defer the outgoing live geometry's dispose (Sentry MONOREPO-EDITOR-DK/EG/EH).
+    queueGeometryDispose(mergedMesh.geometry)
     // Not BoxGeometry: its 6 groups against the merged mesh's 4-material array
     // crash GLTFExporter (materials[4] → undefined) when the roof bakes.
     mergedMesh.geometry = createDegenerateRoofPlaceholder()
@@ -612,7 +622,8 @@ function updateMergedRoofGeometry(
 
       finalGeo.computeVertexNormals()
       ensureRenderableGeometryAttributes(finalGeo)
-      mergedMesh.geometry.dispose()
+      // Defer the outgoing live geometry's dispose (Sentry MONOREPO-EDITOR-DK/EG/EH).
+      queueGeometryDispose(mergedMesh.geometry)
       mergedMesh.geometry = finalGeo
 
       finalWallTrimmed.geometry.dispose()

--- a/packages/viewer/src/systems/roof/roof-system.tsx
+++ b/packages/viewer/src/systems/roof/roof-system.tsx
@@ -25,7 +25,7 @@ import { mergeGeometries, mergeVertices } from 'three/examples/jsm/utils/BufferG
 import { ADDITION, Brush, Evaluator, SUBTRACTION } from 'three-bvh-csg'
 import { computeBoundsTree } from 'three-mesh-bvh'
 import { ensureRenderableGeometryAttributes } from '../../lib/csg-utils'
-import { flushGeometryDisposals, queueGeometryDispose } from '../../lib/deferred-dispose'
+import { queueGeometryDispose } from '../../lib/deferred-dispose'
 
 function csgGeometry(brush: Brush): THREE.BufferGeometry {
   return brush.geometry as unknown as THREE.BufferGeometry
@@ -169,11 +169,12 @@ export const RoofSystem = () => {
   useLiveNodeOverrides((s) => s.overrides)
 
   useFrame(() => {
-    // Free geometries queued for disposal on a previous frame before doing any
-    // rebuild work. Flushing at frame start guarantees the WebGPU renderer has
-    // already released the RenderObject for each outgoing geometry, avoiding the
-    // mid-frame dispose race (Sentry MONOREPO-EDITOR-DK/EG/EH).
-    flushGeometryDisposals()
+    // Geometries queued for disposal on a previous frame are flushed by the
+    // dedicated `GeometryDisposalFlushSystem` (negative frame priority), which
+    // runs before any rebuild system queues new disposals. Flushing here would
+    // run *after* GeometrySystem's rebuild in the same frame and could dispose
+    // geometries it just queued, before the render pass — reintroducing the
+    // dispose race (Sentry MONOREPO-EDITOR-DK/EG/EH).
 
     // Clear stale pending updates when the scene is unloaded
     if (rootNodeIds.length === 0) {


### PR DESCRIPTION
## What

Defensive fix for a Three.js **WebGPU dispose race** that is generating the top Sentry error in the editor: **MONOREPO-EDITOR-DK (4453 events)**, plus **EG (110)** and **EH (94)** — all the same root cause.

## The race

Inside the per-frame rebuild loops of `GeometrySystem` and `RoofSystem`, an outgoing live geometry (one currently attached to a rendered mesh) was disposed **synchronously mid-`useFrame`**:

- `geometry-system.tsx` → `disposeChildren()` (`mesh.geometry.dispose()` on swapped-out children)
- `roof-system.tsx` → `updateRoofSegmentGeometry()` (`mesh.geometry.dispose()` before reassign)
- `roof-system.tsx` → the `BoxGeometry` placeholder swap
- `roof-system.tsx` → `updateMergedRoofGeometry()` (`mergedMesh.geometry.dispose()` on the two reassign paths)

On the WebGPU backend the renderer still holds a `RenderObject` referencing that geometry for the frame in flight. `BufferGeometry.dispose()` synchronously dispatches the `dispose` event; three's WebGPU `onDispose` handler then calls `RenderObject.getAttributes()`, which reads `.id` / `.count` off attributes that have already been freed →

```
Cannot read properties of undefined (reading 'id')   // and 'count'
  THREE.BufferGeometry.dispose
  -> EventDispatcher.dispatchEvent -> three.webgpu.js onDispose
  -> RenderObject.getAttributes
```
(three@0.184.0, @react-three/fiber@9.6.1)

A `try/catch` around `.dispose()` cannot help — the throw happens inside three's own async event dispatch, not in our call frame.

## The fix — defensive deferral, behavior identical

New tiny helper `packages/viewer/src/lib/deferred-dispose.ts`:

- `queueGeometryDispose(geometry)` — queue an outgoing **live** geometry instead of freeing it now.
- `flushGeometryDisposals()` — drain the queue (wrapped in try/catch), called once at the **start** of each system's `useFrame`, before any rebuild work.

The renderer releases its `RenderObject` for a geometry once it's no longer drawn (i.e. after the frame in which we swapped in the replacement). So we hand the *outgoing* geometry to the queue and free it at the top of the **next** frame, after that render has completed. Every geometry is still disposed — just one frame later, after the renderer let go of it. No geometry leaks, no rendering-behavior change.

Only the **live-mesh** dispose sites were changed. Transient CSG intermediates (brushes, temporary merge/subtract results that never enter the scene graph) are left disposing synchronously — the renderer never held a `RenderObject` for them, so there's no race.

## Testing

- `bunx tsc --build packages/viewer/tsconfig.json` → exit 0 (clean).
- `bun test .../geometry-system.test.ts` → 1 pass.
- `biome lint` on all three touched files → clean.

## Scope

Addresses Sentry **MONOREPO-EDITOR-DK / EG / EH**. Defensive-only; does not redesign the rebuild pipeline. **Do not merge without review.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core viewer frame ordering and geometry lifecycle for all parametric/roof rebuilds; timing-sensitive but narrowly scoped to dispose sites on rendered meshes with documented ordering constraints.
> 
> **Overview**
> Fixes a **WebGPU dispose race** where synchronous `BufferGeometry.dispose()` on meshes still referenced by the renderer during `useFrame` rebuilds triggered `Cannot read properties of undefined (reading 'id')` (top Sentry errors DK/EG/EH).
> 
> Adds **`deferred-dispose.ts`** with `queueGeometryDispose` and `flushGeometryDisposals`, plus **`GeometryDisposalFlushSystem`** mounted in the viewer at `useFrame` priority **-1000** so the queue drains **before** any rebuild system runs each frame. **`GeometrySystem`** and **`RoofSystem`** now queue outgoing live mesh geometries instead of disposing them mid-frame; transient CSG intermediates still dispose synchronously.
> 
> Geometries are freed one frame later, after the render pass that swapped them out—same cleanup behavior, no pipeline redesign.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb566be4c94a0e120dc945ddecc9ef66e7116b0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->