### PR TITLE
fix: capture-mode polish for studio & presets + pausable render loop

### DIFF
--- a/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
+++ b/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
@@ -600,7 +600,9 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
           </div>
         )}
 
-        {!isMobile && (
+        {/* Preset captures carry their own "Frame your item" banner — the
+            snapshot pitch only applies to the studio/reference flow. */}
+        {!isMobile && !isPreset && (
           <span className="pointer-events-none max-w-90 rounded-lg border border-white/10 bg-neutral-950/85 px-3.5 py-1.5 text-center text-[11.5px] text-white/85 leading-relaxed backdrop-blur-md">
             A <b className="font-semibold text-white">snapshot</b>
             {' freezes this exact camera angle as a reusable reference for renders & videos.'}
@@ -608,7 +610,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
         )}
 
         <button
-          aria-label="Take snapshot"
+          aria-label={isPreset ? 'Capture' : 'Take snapshot'}
           className="group pointer-events-auto relative grid h-14 w-14 place-items-center rounded-full disabled:opacity-50"
           disabled={captureDisabled}
           onClick={handleCapture}
@@ -634,7 +636,9 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
             ? 'Capturing…'
             : captureState === 'saved'
               ? 'Saved'
-              : 'Take snapshot'}
+              : isPreset
+                ? 'Capture'
+                : 'Take snapshot'}
         </span>
       </div>
     </div>

--- a/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
+++ b/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
@@ -497,8 +497,9 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
         </div>
       )}
 
-      {/* Top-center HUD — what the shot will be */}
-      {!isMobile && (
+      {/* Top-center HUD — what the shot will be. Preset captures are a fixed
+          square and carry their own "Frame your item" banner up there. */}
+      {!isMobile && !isPreset && (
         <div className="pointer-events-none absolute top-4 left-1/2 flex -translate-x-1/2 gap-2">
           <div className={HUD_CHIP_CLASS}>
             <span className="font-mono text-[8.5px] text-white/50 uppercase tracking-[0.14em]">

--- a/packages/editor/src/components/ui/helpers/helper-manager.tsx
+++ b/packages/editor/src/components/ui/helpers/helper-manager.tsx
@@ -95,6 +95,7 @@ function useActiveModifierKeys(): ActiveModifierKeys {
 export function HelperManager() {
   const mode = useEditor((s) => s.mode)
   const tool = useEditor((s) => s.tool)
+  const workspaceMode = useEditor((s) => s.workspaceMode)
   const scope = useInteractionScope((s) => s.scope)
   const movingNode = useMovingNode()
   const activeHandleDrag = useActiveHandleDrag()
@@ -145,6 +146,10 @@ export function HelperManager() {
 
   // Helpers are keyboard-driven hints (Esc, R, etc.) — irrelevant on touch.
   if (isMobile) return null
+
+  // The studio workspace (compose panel / gallery) has no scene selection or
+  // tools — editor shortcut hints would only mislead there.
+  if (workspaceMode === 'studio') return null
 
   // Rotating a node (or a multi-selection group) via its in-world gizmo:
   // advertise Shift = free rotation, the same angle-step bypass wall drafting

--- a/packages/viewer/src/components/viewer/frame-limiter.tsx
+++ b/packages/viewer/src/components/viewer/frame-limiter.tsx
@@ -1,5 +1,6 @@
 import { useThree } from '@react-three/fiber'
 import { useLayoutEffect } from 'react'
+import useViewer from '../../store/use-viewer'
 
 type FrameLimiterProps = {
   fps?: number
@@ -8,8 +9,11 @@ type FrameLimiterProps = {
 const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
   const { advance, set, frameloop: initFrameloop, scene, clock } = useThree()
   const renderer = useThree((state) => state.gl)
+  // Fully covered canvas (e.g. studio gallery) → stop advancing frames
+  const renderPaused = useViewer((s) => s.renderPaused)
 
   useLayoutEffect(() => {
+    if (renderPaused) return
     let elapsed = 0
     let then = 0
     let i = 0
@@ -35,7 +39,7 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
       }
       set({ frameloop: initFrameloop })
     }
-  }, [fps, advance, set, initFrameloop])
+  }, [fps, advance, set, initFrameloop, renderPaused])
 
   return null
 }

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -49,6 +49,10 @@ type ViewerState = {
   isExporting: boolean
   setExporting: (value: boolean) => void
 
+  /** Suspend the render loop while the canvas is fully covered (e.g. studio gallery). */
+  renderPaused: boolean
+  setRenderPaused: (value: boolean) => void
+
   shading: RenderShading
   shadingByContext: Partial<Record<RenderContext, RenderShading>>
   setShading: (shading: RenderShading) => void
@@ -232,6 +236,9 @@ const useViewer = create<ViewerState>()(
 
       isExporting: false,
       setExporting: (value) => set({ isExporting: value }),
+
+      renderPaused: false,
+      setRenderPaused: (value) => set({ renderPaused: value }),
 
       shading: 'rendered',
       shadingByContext: {},


### PR DESCRIPTION
Four small fixes surfaced by the studio v2 feedback pass in the host app:

## Capture overlay (preset flow)
- **Gate the snapshot pitch on \`isPreset\`** — the "A snapshot freezes this exact camera angle…" hint and the "Take snapshot" shutter label leaked into the save-as-preset thumbnail flow, clashing with its own "Frame your item — click Capture" banner. The preset flow now labels the shutter **Capture** and shows no snapshot copy.
- **Hide the crop/format HUD in preset mode** — the pills crowded the preset banner and repeat what the fixed square frame already shows.

## Viewer
- **\`renderPaused\` store flag** — suspends FrameLimiter's RAF loop when a host fully covers the canvas (the community app sets it while the studio gallery overlay is up). On heavy animated scenes (tree wind at ~5 FPS) the loop otherwise starves the GPU behind the overlay and makes it visibly stutter.

## Helpers
- **No contextual shortcut hints in the studio workspace** — holding Shift surfaced select-mode/snapping hints over the studio compose panel and gallery, where there's no scene selection or tool to act on.

The host-side counterpart (setting \`renderPaused\` on stage switch) lands in private-editor once this merges and the submodule SHA is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy/gating and an opt-in render pause flag; no auth, persistence, or capture pipeline logic changes beyond when the loop runs.
> 
> **Overview**
> Polishes **preset thumbnail capture** so it no longer shows studio/snapshot-specific chrome: the top crop/format HUD, the “snapshot freezes this camera angle…” pitch, and **Take snapshot** labeling are gated off when `captureMode` is preset; the shutter uses **Capture** for aria-label and idle label instead.
> 
> **Studio workspace** no longer shows contextual editor shortcut hints (`HelperManager` bails when `workspaceMode === 'studio'`), avoiding misleading Shift/select hints over the compose panel and gallery.
> 
> The viewer gains a transient **`renderPaused`** flag on the store; **`FrameLimiter`** skips starting its custom RAF loop while paused so a fully covered canvas (e.g. studio gallery overlay) does not keep advancing heavy 3D frames behind the UI. Host apps are expected to toggle `setRenderPaused` when covering the canvas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e2bc9d90dbf8130347233380fbae084c1f64ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->