### PR TITLE
fix(viewer): make HDRI environment fetch non-fatal (Sentry MONOREPO-EDITOR-99)

### DIFF
--- a/packages/viewer/src/components/viewer/scene-environment.tsx
+++ b/packages/viewer/src/components/viewer/scene-environment.tsx
@@ -2,6 +2,7 @@
 
 import { Environment } from '@react-three/drei'
 import { Suspense } from 'react'
+import { ErrorBoundary } from '../error-boundary'
 
 /**
  * Scene IBL — drei's prefiltered environment map, exported as an opt-in
@@ -12,11 +13,27 @@ import { Suspense } from 'react'
  * do alone. Intensity is dialled below the preset default so it complements
  * the scene lights rather than washing them out. Only visible in `rendered`
  * shading.
+ *
+ * The `sunset` preset resolves to an HDR (venice_sunset_1k.hdr) hosted on the
+ * free githack CDN, which is flaky and periodically rate-limits/500s. A failed
+ * fetch throws *asynchronously* from Suspense — the surrounding <Suspense> only
+ * handles the pending/loading state, not the thrown error — so the rejection
+ * propagated uncaught and was reported to Sentry daily (MONOREPO-EDITOR-99).
+ * We wrap the <Environment> in the viewer ErrorBoundary so a failed HDR fetch
+ * degrades gracefully: the scene simply renders without IBL reflections
+ * (acceptable — matches the "surfaces that don't want the HDRI simply don't
+ * mount it" behaviour above) instead of crashing.
+ *
+ * TODO(MONOREPO-EDITOR-99): self-host venice_sunset_1k.hdr under our own assets
+ * CDN and point drei's Environment at it (via `files`) to remove the external
+ * githack dependency entirely, rather than only tolerating its failures.
  */
 export function SceneEnvironment() {
   return (
     <Suspense fallback={null}>
-      <Environment preset="sunset" environmentIntensity={0.6} />
+      <ErrorBoundary fallback={null} scope="scene-environment-hdri">
+        <Environment preset="sunset" environmentIntensity={0.6} />
+      </ErrorBoundary>
     </Suspense>
   )
 }


### PR DESCRIPTION
## Sentry: MONOREPO-EDITOR-99 (recurring, seen daily)

### Root cause
`packages/viewer/src/components/viewer/scene-environment.tsx` renders drei's `<Environment preset="sunset" />`. drei resolves that preset to an HDR hosted on the free **githack** CDN (`raw.githack.com/pmndrs/drei-assets/.../hdri/venice_sunset_1k.hdr`), which is flaky and periodically rate-limits / 500s.

When the fetch fails it throws `Could not load venice_sunset_1k.hdr: Failed to fetch`. Because this error is thrown *asynchronously* out of Suspense, the surrounding `<Suspense fallback={null}>` does **not** catch it — Suspense only handles the pending/loading state, not a thrown error. The rejection therefore propagated **uncaught** and was reported to Sentry every time githack hiccupped.

### Fix (code-only, low-risk graceful degradation)
Wrap `<Environment>` in the existing viewer-scoped `ErrorBoundary` (`packages/viewer/src/components/error-boundary.tsx`), *inside* the existing `<Suspense>`. On a failed HDR fetch the boundary renders `null`, so the scene simply loses IBL reflections instead of crashing — which is already an accepted state (embed/thumbnail surfaces intentionally don't mount the HDRI).

- Reuses the existing `ErrorBoundary` (no new component); its `componentDidCatch` already `console.error`s and does **not** re-throw or call Sentry capture, so the noise stops.
- No behavioural change on the happy path.

### Follow-up
`TODO(MONOREPO-EDITOR-99)`: self-host `venice_sunset_1k.hdr` under our own assets CDN and point drei's `Environment` at it (via `files`) to remove the external githack dependency entirely, rather than only tolerating its failures. (Not done here — no CDN upload access from this change.)

### Files changed
- `packages/viewer/src/components/viewer/scene-environment.tsx` (+18/-1)

### Verification
- `biome check` on the changed file — clean, no fixes.
- `tsc --build` for `packages/viewer` — passes (exit 0).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component graceful degradation on error only; reuses existing viewer ErrorBoundary with no happy-path behavior change.
> 
> **Overview**
> **Fixes recurring Sentry noise** when drei's `sunset` HDRI fails to load from the flaky githack CDN. Async fetch failures were not caught by `<Suspense>`, so they surfaced as uncaught errors.
> 
> **`SceneEnvironment` now wraps** `<Environment>` in the viewer `ErrorBoundary` (inside the existing `Suspense`) with `fallback={null}` and scope `scene-environment-hdri`. On failure the scene renders without IBL instead of crashing—same outcome as surfaces that skip mounting the HDRI. Happy path is unchanged.
> 
> **Docs:** inline comments explain the failure mode and a **TODO** to self-host `venice_sunset_1k.hdr` and pass it via `files` to drop the external CDN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be6c58d7d468337da3347138487145c086b4386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->