### PR TITLE
fix(release): add missing nodes package to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
           - core
           - viewer
           - editor
+          - nodes
           - mcp
           - ifc-converter
           - all
@@ -75,7 +76,7 @@ jobs:
           # peerDeps sync below must use shell vars, not env indirection.
           declare -A NEW_VERSIONS
 
-          for pkg in core viewer editor mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter; do
             if [ "$TARGET" = "$pkg" ] || [ "$TARGET" = "all" ]; then
               CUR=$(jq -r '.version' packages/$pkg/package.json)
               NEW=$(bump_version "$CUR")
@@ -90,9 +91,9 @@ jobs:
 
           # Sync inter-package references in peerDependencies and devDependencies.
           # Anything that references a bumped @pascal-app/* package is updated to ^NEW.
-          for pkg in core viewer editor mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter; do
             FILE=packages/$pkg/package.json
-            for dep in core viewer editor mcp ifc-converter; do
+            for dep in core viewer editor nodes mcp ifc-converter; do
               VAL="${NEW_VERSIONS[$dep]}"
               [ -z "$VAL" ] && continue
               jq --arg name "@pascal-app/$dep" --arg v "^$VAL" '
@@ -103,7 +104,7 @@ jobs:
           done
 
           echo "=== @pascal-app/* refs after sync ==="
-          for pkg in core viewer editor mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter; do
             echo "--- packages/$pkg/package.json ---"
             jq '{ peerDependencies: (.peerDependencies // {} | with_entries(select(.key | startswith("@pascal-app/")))), devDependencies: (.devDependencies // {} | with_entries(select(.key | startswith("@pascal-app/")))) }' packages/$pkg/package.json
           done
@@ -150,6 +151,21 @@ jobs:
           else
             npm publish --access public
             echo "📦 Published @pascal-app/editor@$EDITOR_VERSION"
+          fi
+
+      - name: Build & publish nodes
+        if: inputs.package == 'nodes' || inputs.package == 'all'
+        working-directory: packages/nodes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          bun run build
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            echo "🏜️ Dry run — would publish @pascal-app/nodes@$NODES_VERSION"
+            npm publish --dry-run --access public
+          else
+            npm publish --access public
+            echo "📦 Published @pascal-app/nodes@$NODES_VERSION"
           fi
 
       - name: Build & publish mcp
@@ -202,6 +218,10 @@ jobs:
           if [ -n "$EDITOR_VERSION" ]; then
             PKGS="$PKGS @pascal-app/editor@$EDITOR_VERSION"
             TAGS="$TAGS @pascal-app/editor@$EDITOR_VERSION"
+          fi
+          if [ -n "$NODES_VERSION" ]; then
+            PKGS="$PKGS @pascal-app/nodes@$NODES_VERSION"
+            TAGS="$TAGS @pascal-app/nodes@$NODES_VERSION"
           fi
           if [ -n "$MCP_VERSION" ]; then
             PKGS="$PKGS @pascal-app/mcp@$MCP_VERSION"


### PR DESCRIPTION
## What does this PR do?

Adds the missing `nodes` package to the release workflow.

`@pascal-app/nodes` was split out into its own package but never added
to this workflow's `package` choice list or publish steps, so it has
never been publishable to npm — that's the root cause of npm-only
installs rendering nothing on 0.9.x (empty nodeRegistry).

This mirrors the existing core/viewer pattern: adds `nodes` to every
loop that iterates packages, and adds a "Build & publish nodes" step.

Fixes #454

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release workflow only; no runtime or application code changes.
> 
> **Overview**
> **Wires `@pascal-app/nodes` into the manual release workflow** so it can be version-bumped, built, and published like the other packages.
> 
> The workflow dispatch **package** choice now includes **`nodes`**, and every shell loop that bumps versions and syncs `@pascal-app/*` **peerDependencies** / **devDependencies** treats **`nodes`** the same as **core**, **viewer**, **editor**, **mcp**, and **ifc-converter**. A new **Build & publish nodes** step runs `bun run build` in `packages/nodes` and publishes with dry-run support, and the commit/tag step records **`NODES_VERSION`** when that package is released.
> 
> This closes the gap where the split-out **nodes** package was never on npm—matching the PR’s link to empty **nodeRegistry** on npm-only 0.9.x installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0a4df5e6e4c90afef79804d65b86a7e56ac25d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->