### PR TITLE
fix(plugin-trees): consume dirty marks so scene-ready fires for plant scenes

### DIFF
--- a/packages/plugin-trees/src/instanced.tsx
+++ b/packages/plugin-trees/src/instanced.tsx
@@ -9,6 +9,7 @@ import {
   useScene,
 } from '@pascal-app/core'
 import { useNodeEvents, useViewer } from '@pascal-app/viewer'
+import { useFrame } from '@react-three/fiber'
 import { useLayoutEffect, useMemo, useRef } from 'react'
 import { type BufferGeometry, type InstancedMesh, type Material, Matrix4, Object3D } from 'three'
 import { toStaticMaterial } from './wind-node'
@@ -73,6 +74,26 @@ export function InstancedKindSystem<N extends Placeable>({
       (n) => (n.type as string) === kind && !active.has(n.id as string),
     ) as unknown as N[]
   }, [scene, kind, activeKey])
+
+  // Consume the dirty marks for this kind. Instances rebuild synchronously
+  // from the store (the memos above), so a rendered node is already "built" —
+  // but `FloorElevationSystem` deliberately leaves the mark for kinds with a
+  // `def.system`, expecting that system to clear it. Without this pass the
+  // marks live forever: `hasPendingSceneBuildWork` never goes false, so the
+  // scene-ready signal (and every headless bake) stalls at its frame cap.
+  // Priority 2 = after the priority-1 floor-elevation lift in the same frame;
+  // clearing only registered nodes leaves unmounted proxies for a later frame.
+  useFrame(() => {
+    const { dirtyNodes, nodes: sceneNodes, clearDirty } = useScene.getState()
+    if (dirtyNodes.size === 0) return
+    for (const id of dirtyNodes) {
+      const node = sceneNodes[id]
+      if (!node || (node.type as string) !== kind) continue
+      if (!sceneRegistry.nodes.has(id)) continue
+      clearDirty(id)
+    }
+  }, 2)
+
   return <InstancedNodes getVariant={getVariant} nodes={nodes} variantKeyOf={variantKeyOf} />
 }
 


### PR DESCRIPTION
## What does this PR do?

Instanced plant kinds (`trees:tree`, `trees:grass`, `trees:flower`) never cleared their scene-store dirty marks. `FloorElevationSystem` deliberately leaves the mark for any kind with a `def.system` ("the downstream consumer will clear it"), but `InstancedKindSystem` never participated in the dirty protocol — so the marks lived forever, `hasPendingSceneBuildWork()` never went false, and the Viewer's scene-ready signal stalled at `SCENE_READY_MAX_WAIT_FRAMES` (180 frames) on every scene containing a plant.

The visible cost: on the headless bake worker (SwiftShader, ~1s frames) every plant-containing scene paid ~190s of pure cap-wait per bake — measured as `pageSettleMs ≈ 193s` on prod bakes of a plant-heavy scene, regardless of warm caches.

The fix adds a priority-2 `useFrame` pass to `InstancedKindSystem` that clears this kind's dirty marks:

- **priority 2** — runs after `FloorElevationSystem`'s priority-1 lift pass in the same frame, so the mark survives long enough for the lift to apply (same contract `GeometrySystem`/`ItemSystem` rely on);
- **only for registered nodes** — a node whose selection proxy isn't in `sceneRegistry` yet keeps its mark for a later frame;
- instances rebuild synchronously from the store (the `useMemo` chain), so a rendered node is already "built" — there is no async work the mark needs to outlive.

## How to test

1. `bun dev`, open a scene containing trees/grass — verify plants render, hover/selection outlines work, and moving a plant on an elevated slab still sits at the right height.
2. Bake a plant-heavy scene headlessly (`bun apps/community/scripts/bake.ts <id>` from private-editor) and check the `[bake:timing]` line: `pageSettleMs` should be actual load time (~seconds), not ~180 × frame-time.
3. Export correctness: baking the same scene with and without this change produces a byte-identical GLB (verified on a 35 MB plant-heavy prod scene — 35,193,812 bytes both ways; settle dropped 22.5s → 11.6s locally).

## Screenshots / screen recording

N/A — non-visual change (render output and exported GLB verified byte-identical; only the readiness signal timing changes).

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to dirty-mark lifecycle timing; no auth/data paths and render output is intended to stay identical.
> 
> **Overview**
> Instanced plant kinds (`trees:tree`, grass, flowers) now **participate in the scene dirty-node protocol** by clearing their own marks after each frame, instead of leaving them set indefinitely.
> 
> `InstancedKindSystem` gains a **priority-2 `useFrame` pass** that calls `clearDirty` for dirty nodes of this kind that are already in `sceneRegistry`. That runs **after** `FloorElevationSystem`’s priority-1 lift (same ordering other `def.system` consumers use). Nodes without a mounted proxy keep their mark until registration catches up.
> 
> **Effect:** `hasPendingSceneBuildWork()` can go false when only plants were dirty, so the viewer **scene-ready** signal and **headless bakes** no longer sit at the ~180-frame cap; rendering is unchanged because instances already rebuild synchronously from the store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93bcdae50036c07b54f705805047910de4893223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->