### PR TITLE
fix(editor): area readouts + generated names follow the unit toggle; bump lingo to 0.2.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@iconify/react": "^6.0.2",
         "@number-flow/react": "^0.6.0",
-        "@pascal-app/lingo": "^0.1.0",
+        "@pascal-app/lingo": "^0.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -221,7 +221,7 @@
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@pascal-app/lingo": "^0.1.0",
+        "@pascal-app/lingo": "^0.2.0",
         "zod": "^4.3.5",
       },
       "devDependencies": {
@@ -716,7 +716,7 @@
 
     "@pascal-app/ifc-converter": ["@pascal-app/ifc-converter@workspace:packages/ifc-converter"],
 
-    "@pascal-app/lingo": ["@pascal-app/lingo@0.1.0", "", { "peerDependencies": { "react": "^19" }, "optionalPeers": ["react"] }, "sha512-j4cN9DSc3QD4LGG003TCIO5+jMYySFpJO6467V0Q3IPumVkwq7/BpEAw8JGY6zTZFmFETIeupuPEi4drnA9m+g=="],
+    "@pascal-app/lingo": ["@pascal-app/lingo@0.2.0", "", { "peerDependencies": { "react": "^19" }, "optionalPeers": ["react"] }, "sha512-Ws+Utm23SmDbMB0Jc7joIp4KPkXhs4Z1boUcW9dl8nC3ATJz+a50F7/MyVTbE3QaL5Fr+YwNfsiOMxrKdhwPhA=="],
 
     "@pascal-app/mcp": ["@pascal-app/mcp@workspace:packages/mcp"],
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -26,7 +26,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@iconify/react": "^6.0.2",
     "@number-flow/react": "^0.6.0",
-    "@pascal-app/lingo": "^0.1.0",
+    "@pascal-app/lingo": "^0.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/load-build-dialog.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/load-build-dialog.tsx
@@ -1,4 +1,5 @@
 import type { BuildStats, SchemaIssue, ValidateBuildJsonResult } from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
 import {
   AlertTriangle,
   AppWindow,
@@ -22,6 +23,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../../../../../components/ui/primitives/dialog'
+import {
+  getAreaUnitLabel,
+  type LinearUnit,
+  squareMetersToAreaUnit,
+} from '../../../../../lib/measurements'
 
 export type PendingImport = {
   fileName: string
@@ -80,15 +86,17 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function formatFloorArea(m2: number): string {
+function formatFloorArea(m2: number, unit: LinearUnit): string {
   if (m2 === 0) return '—'
-  if (m2 < 10) return `${m2.toFixed(2)} m²`
-  return `${m2.toFixed(1)} m²`
+  const value = squareMetersToAreaUnit(m2, unit)
+  const label = getAreaUnitLabel(unit)
+  return `${value < 10 ? value.toFixed(2) : value.toFixed(1)} ${label}`
 }
 
 export function LoadBuildDialog({ pending, onCancel, onConfirm }: Props) {
   const [showAllWarnings, setShowAllWarnings] = useState(false)
   const [showSchemaIssues, setShowSchemaIssues] = useState(false)
+  const unit = useViewer((state) => state.unit)
 
   if (!pending) return null
 
@@ -165,7 +173,7 @@ export function LoadBuildDialog({ pending, onCancel, onConfirm }: Props) {
                     <div className="flex items-center justify-between border-t px-3 py-2">
                       <span className="text-muted-foreground text-sm">Floor area</span>
                       <span className="font-medium text-sm">
-                        {formatFloorArea(stats.floorAreaM2)}
+                        {formatFloorArea(stats.floorAreaM2, unit)}
                       </span>
                     </div>
                   )}

--- a/packages/editor/src/components/ui/sidebar/panels/site-panel/ceiling-tree-node.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/site-panel/ceiling-tree-node.tsx
@@ -3,6 +3,7 @@ import { useViewer } from '@pascal-app/viewer'
 import Image from 'next/image'
 import { memo, useCallback, useEffect, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
+import { formatAreaLabel } from './../../../../../lib/measurements'
 import useEditor from './../../../../../store/use-editor'
 import { InlineRenameInput } from './inline-rename-input'
 import { focusTreeNode, handleTreeSelection, TreeNode, TreeNodeWrapper } from './tree-node'
@@ -32,6 +33,7 @@ export const CeilingTreeNode = memo(function CeilingTreeNode({
   const isHovered = useViewer((state) => state.hoveredId === nodeId)
   const setSelection = useViewer((state) => state.setSelection)
   const setHoveredId = useViewer((state) => state.setHoveredId)
+  const unit = useViewer((state) => state.unit)
 
   // Expand when a descendant is selected — imperative to avoid subscribing to the full selectedIds array
   useEffect(() => {
@@ -75,8 +77,7 @@ export const CeilingTreeNode = memo(function CeilingTreeNode({
   const handleStartEditing = useCallback(() => setIsEditing(true), [])
   const handleStopEditing = useCallback(() => setIsEditing(false), [])
 
-  const area = calculatePolygonArea(polygon).toFixed(1)
-  const defaultName = `Ceiling (${area}m²)`
+  const defaultName = `Ceiling (${formatAreaLabel(calculatePolygonArea(polygon), unit)})`
 
   return (
     <TreeNodeWrapper

--- a/packages/editor/src/components/ui/sidebar/panels/site-panel/index.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/site-panel/index.tsx
@@ -39,9 +39,12 @@ import {
 import { getDefaultLevelName } from '@pascal-app/core'
 import { deleteLevelWithFallbackSelection } from './../../../../../lib/level-selection'
 import {
+  formatAreaLabel,
+  getAreaUnitLabel,
   getLinearUnitLabel,
   linearUnitToMeters,
   metersToLinearUnit,
+  squareMetersToAreaUnit,
 } from './../../../../../lib/measurements'
 import { createLocalGuideImage } from './../../../../../lib/local-guide-image'
 import { cn } from './../../../../../lib/utils'
@@ -112,7 +115,7 @@ const PropertyLineSection = memo(function PropertyLineSection() {
   const linearLabel = getLinearUnitLabel(viewerUnit)
   const toDisplayLinear = (meters: number) => metersToLinearUnit(meters, viewerUnit)
   const toStoredLinear = (display: number) => linearUnitToMeters(display, viewerUnit)
-  const displayArea = isImperial ? area * 10.763_910_417 : area
+  const displayArea = squareMetersToAreaUnit(area, viewerUnit)
   const displayPerimeter = toDisplayLinear(perimeter)
 
   const handleToggleEdit = () => {
@@ -182,7 +185,7 @@ const PropertyLineSection = memo(function PropertyLineSection() {
         <div className="text-muted-foreground text-xs">
           Area:{' '}
           <span className="text-foreground">
-            {displayArea.toFixed(1)} {isImperial ? 'ft²' : 'm²'}
+            {displayArea.toFixed(1)} {getAreaUnitLabel(viewerUnit)}
           </span>
         </div>
         <div className="text-muted-foreground text-xs">
@@ -1117,6 +1120,7 @@ const ZoneItem = memo(function ZoneItem({ zone, isLast }: { zone: ZoneNode; isLa
   const setHoveredId = useViewer((state) => state.setHoveredId)
   const setPhase = useEditor((state) => state.setPhase)
   const setMode = useEditor((state) => state.setMode)
+  const unit = useViewer((state) => state.unit)
 
   const isSelected = selectedZoneId === zone.id
   const isHovered = hoveredId === zone.id
@@ -1129,8 +1133,7 @@ const ZoneItem = memo(function ZoneItem({ zone, isLast }: { zone: ZoneNode; isLa
     }
   }, [isSelected])
 
-  const area = calculatePolygonArea(zone.polygon).toFixed(1)
-  const defaultName = `Zone (${area}m²)`
+  const defaultName = `Zone (${formatAreaLabel(calculatePolygonArea(zone.polygon), unit)})`
 
   const handleClick = () => {
     setSelection({ zoneId: zone.id })

--- a/packages/editor/src/components/ui/sidebar/panels/site-panel/slab-tree-node.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/site-panel/slab-tree-node.tsx
@@ -2,6 +2,7 @@ import { type AnyNodeId, type SlabNode, useScene } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import Image from 'next/image'
 import { memo, useCallback, useState } from 'react'
+import { formatAreaLabel } from './../../../../../lib/measurements'
 import useEditor from './../../../../../store/use-editor'
 import { InlineRenameInput } from './inline-rename-input'
 import { focusTreeNode, handleTreeSelection, TreeNodeWrapper } from './tree-node'
@@ -25,6 +26,7 @@ export const SlabTreeNode = memo(function SlabTreeNode({
   const isHovered = useViewer((state) => state.hoveredId === nodeId)
   const setSelection = useViewer((state) => state.setSelection)
   const setHoveredId = useViewer((state) => state.setHoveredId)
+  const unit = useViewer((state) => state.unit)
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -45,8 +47,7 @@ export const SlabTreeNode = memo(function SlabTreeNode({
   const handleStartEditing = useCallback(() => setIsEditing(true), [])
   const handleStopEditing = useCallback(() => setIsEditing(false), [])
 
-  const area = calculatePolygonArea(polygon).toFixed(1)
-  const defaultName = `Slab (${area}m²)`
+  const defaultName = `Slab (${formatAreaLabel(calculatePolygonArea(polygon), unit)})`
 
   return (
     <TreeNodeWrapper

--- a/packages/editor/src/components/ui/sidebar/panels/site-panel/zone-tree-node.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/site-panel/zone-tree-node.tsx
@@ -2,6 +2,7 @@ import { useScene, type ZoneNode } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import { memo, useCallback, useState } from 'react'
 import { ColorDot } from './../../../../../components/ui/primitives/color-dot'
+import { formatAreaLabel } from './../../../../../lib/measurements'
 import { InlineRenameInput } from './inline-rename-input'
 import { focusTreeNode, TreeNodeWrapper } from './tree-node'
 import { TreeNodeActions } from './tree-node-actions'
@@ -26,6 +27,7 @@ export const ZoneTreeNode = memo(function ZoneTreeNode({
   const isHovered = useViewer((state) => state.hoveredId === nodeId)
   const setSelection = useViewer((state) => state.setSelection)
   const setHoveredId = useViewer((state) => state.setHoveredId)
+  const unit = useViewer((state) => state.unit)
 
   const handleClick = useCallback(() => setSelection({ zoneId: nodeId }), [nodeId, setSelection])
   const handleDoubleClick = useCallback(() => focusTreeNode(nodeId), [nodeId])
@@ -34,9 +36,7 @@ export const ZoneTreeNode = memo(function ZoneTreeNode({
   const handleStartEditing = useCallback(() => setIsEditing(true), [])
   const handleStopEditing = useCallback(() => setIsEditing(false), [])
 
-  // Calculate approximate area from polygon
-  const area = calculatePolygonArea(polygon).toFixed(1)
-  const defaultName = `Zone (${area}m²)`
+  const defaultName = `Zone (${formatAreaLabel(calculatePolygonArea(polygon), unit)})`
 
   return (
     <TreeNodeWrapper

--- a/packages/editor/src/lib/measurements.test.ts
+++ b/packages/editor/src/lib/measurements.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  formatAreaLabel,
   formatLinearMeasurement,
+  getAreaUnitLabel,
   getLinearUnitLabel,
   linearControlValueToMeters,
   linearUnitToMeters,
   metersToLinearUnit,
+  squareMetersToAreaUnit,
 } from './measurements'
 
 describe('linear measurements', () => {
@@ -71,5 +74,24 @@ describe('linear measurements', () => {
   test('returns the display label for numeric controls', () => {
     expect(getLinearUnitLabel('metric')).toBe('m')
     expect(getLinearUnitLabel('imperial')).toBe('ft')
+  })
+})
+
+describe('area measurements', () => {
+  test('converts square meters to the active area unit', () => {
+    expect(squareMetersToAreaUnit(0, 'imperial')).toBe(0)
+    expect(squareMetersToAreaUnit(12.5, 'metric')).toBe(12.5)
+    expect(squareMetersToAreaUnit(1, 'imperial')).toBeCloseTo(10.7639)
+  })
+
+  test('returns the display label for area readouts', () => {
+    expect(getAreaUnitLabel('metric')).toBe('m²')
+    expect(getAreaUnitLabel('imperial')).toBe('ft²')
+  })
+
+  test('formats an area label with value and unit', () => {
+    expect(formatAreaLabel(12.34, 'metric')).toBe('12.3m²')
+    expect(formatAreaLabel(1, 'imperial')).toBe('10.8ft²')
+    expect(formatAreaLabel(12.34, 'metric', 2)).toBe('12.34m²')
   })
 })

--- a/packages/editor/src/lib/measurements.ts
+++ b/packages/editor/src/lib/measurements.ts
@@ -32,6 +32,24 @@ export function getLinearUnitLabel(unit: LinearUnit): string {
   return unit === 'imperial' ? 'ft' : 'm'
 }
 
+const SQUARE_FEET_PER_SQUARE_METER = FEET_PER_METER * FEET_PER_METER
+
+export function squareMetersToAreaUnit(squareMeters: number, unit: LinearUnit): number {
+  return unit === 'imperial' ? squareMeters * SQUARE_FEET_PER_SQUARE_METER : squareMeters
+}
+
+export function getAreaUnitLabel(unit: LinearUnit): string {
+  return unit === 'imperial' ? 'ft²' : 'm²'
+}
+
+export function formatAreaLabel(
+  squareMeters: number,
+  unit: LinearUnit,
+  fractionDigits = 1,
+): string {
+  return `${squareMetersToAreaUnit(squareMeters, unit).toFixed(fractionDigits)}${getAreaUnitLabel(unit)}`
+}
+
 export function formatLinearMeasurement(meters: number, unit: LinearUnit): string {
   if (!Number.isFinite(meters)) return '--'
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@pascal-app/lingo": "^0.1.0",
+    "@pascal-app/lingo": "^0.2.0",
     "zod": "^4.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Follow-up to #472. Two small, targeted changes.

## 1. Unit-label consistency (fix)
#472 made every length **input** honor the metric/imperial preference. This closes the two remaining **area** surfaces that were still hardcoded to `m²`:

- **Load-build import dialog** — the "Floor area" stat (`formatFloorArea`) now converts value + label to the active unit.
- **Auto-generated default names** for zones, slabs, and ceilings (e.g. `Zone (12.3m²)`). These are *live* display fallbacks (`{name || defaultName}`, recomputed each render), so they now live-update on toggle — `Zone (129.2ft²)` in imperial.

Adds shared `squareMetersToAreaUnit` / `getAreaUnitLabel` / `formatAreaLabel` helpers to `lib/measurements` (with tests), and routes the existing site-panel Area readout through them (replacing an inline `10.7639…` magic constant).

Audited the full UI: all other length/area readouts (site-panel perimeter + vertices, floorplan 2D area + linear dimension labels) were already unit-aware.

## 2. Bump `@pascal-app/lingo` 0.1.0 → 0.2.0 (chore)
API-compatible with our usage (`parseQuantity`, `quantity`, `Kind`). 0.2.0 only adds i18n/locale entrypoints; no imported symbols changed.

**Verification**
- `@pascal-app/editor` + `@pascal-app/mcp` typecheck ✅
- All 31 measurement tests pass, including the `AMBIGUOUS_NUMBER → error` escalate guard ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting and a minor dependency bump; no auth, persistence, or geometry logic changes.
> 
> **Overview**
> Extends the metric/imperial preference to **area** surfaces that were still fixed to `m²`, building on length-input work from #472.
> 
> New helpers in `lib/measurements` — `squareMetersToAreaUnit`, `getAreaUnitLabel`, and `formatAreaLabel` (with tests) — centralize conversion and labeling. The **load-build** dialog’s floor-area stat, the **site panel** property-line area readout (replacing an inline conversion constant), and **auto-generated default names** for zones, slabs, and ceilings now read `useViewer`’s `unit`, so values and labels update when the toggle changes.
> 
> Also bumps **`@pascal-app/lingo`** from `0.1.0` to `0.2.0` in `packages/editor`, `packages/mcp`, and the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8476a991f48fc9b24445131f27929c9b19e68f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->