### PR TITLE
editor: smart unit suffix — dim on focus, yield to explicit units

### DIFF
--- a/packages/editor/src/components/ui/controls/metric-control.tsx
+++ b/packages/editor/src/components/ui/controls/metric-control.tsx
@@ -330,7 +330,16 @@ export function MetricControl({
               type="text"
               value={inputValue}
             />
-            {displayUnit && <span className="ml-[1px] text-muted-foreground">{displayUnit}</span>}
+            {displayUnit && (
+              <span
+                className={cn(
+                  'ml-[1px] transition-opacity duration-150',
+                  hint ? 'opacity-0' : 'text-muted-foreground/40',
+                )}
+              >
+                {displayUnit}
+              </span>
+            )}
           </div>
         ) : (
           <div

--- a/packages/editor/src/components/ui/controls/slider-control.tsx
+++ b/packages/editor/src/components/ui/controls/slider-control.tsx
@@ -329,7 +329,16 @@ export function SliderControl({
               type="text"
               value={inputValue}
             />
-            {displayUnit && <span className="ml-[1px] text-muted-foreground">{displayUnit}</span>}
+            {displayUnit && (
+              <span
+                className={cn(
+                  'ml-[1px] transition-opacity duration-150',
+                  hint ? 'opacity-0' : 'text-muted-foreground/40',
+                )}
+              >
+                {displayUnit}
+              </span>
+            )}
           </>
         ) : (
           <div


### PR DESCRIPTION
## What does this PR do?

Reduces confusion in unit-typed inputs now that Lingo accepts explicit units (`5 ft` in a meters field). Previously the static `m` suffix stayed fully visible next to such a draft, reading as "5 ft m". Now, in both `SliderControl` and `MetricControl`:

- **Editing, bare number/empty:** the suffix dims to 40% opacity — it signals the default unit a bare number commits as.
- **Editing, explicit unit typed:** the suffix fades out (150ms opacity, no layout jump) and the existing `= 1.52 m` Lingo hint is the unit feedback.
- **Unparseable draft:** suffix stays dimmed (the field reverts on commit).
- **At rest:** unchanged.

The show/hide predicate is `hint !== null`, so it can never disagree with `measurementHint`'s plain-number guard.

## How to test

1. `bun dev`, select a wall and open the inspector.
2. Click a length value: suffix dims. Type `5` — suffix stays dimmed. Enter commits 5 m.
3. Type `5 ft` — suffix fades out as soon as the draft isn't a plain number; the `= 1.52 m` hint appears. Enter commits 1.52 m and the normal suffix returns.
4. Type garbage (`abc`) — suffix stays dimmed; Enter reverts the field.
5. Repeat in a stair/elevator panel (MetricControl) and on a `%`/unitless field (dim only, never hides).
6. Toggle imperial and verify the same behavior with the `ft` suffix.

## Screenshots / screen recording

N/A — will add a clip if requested (subtle opacity-only change).

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inspector-only opacity styling on unit suffixes during text edit; no parsing, commit, or stored-value logic changes.
> 
> **Overview**
> **MetricControl** and **SliderControl** now treat the inline `displayUnit` suffix differently while the value field is focused, so typed measurements like `5 ft` in a meters field no longer read as “5 ft m”.
> 
> During edit mode, a bare number or empty draft keeps the suffix visible but **dimmed** (`text-muted-foreground/40`) to signal the default unit a plain number commits as. When `measurementHint` is active (explicit unit / non–plain-number draft that parses), the suffix **fades out** over 150ms (`opacity-0` when `hint` is set), leaving the `= … m` hint as the unit feedback. **At-rest** display is unchanged.
> 
> The hide/show rule matches `hint !== null`, aligned with `measurementHint`’s plain-number guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b4b267a40b453dc1b2903ee4e35bcaa7d150e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->