### PR TITLE
fix(items): retry failed model loads, settle skipped items, keep exports clean

### DIFF
--- a/packages/nodes/src/item/renderer.tsx
+++ b/packages/nodes/src/item/renderer.tsx
@@ -36,7 +36,7 @@ import { useAnimations } from '@react-three/drei'
 import { Clone } from '@react-three/drei/core/Clone'
 import { useGLTF } from '@react-three/drei/core/Gltf'
 import { useFrame } from '@react-three/fiber'
-import { Suspense, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { AnimationAction, Group, Material, Mesh } from 'three'
 import { MathUtils } from 'three'
 import { positionLocal, smoothstep, time } from 'three/tsl'
@@ -181,6 +181,7 @@ const resolveItemMaterial = (
 const BrokenItemFallback = ({ node }: { node: ItemNode }) => {
   const handlers = useNodeEvents(node, 'item')
   const shading = useViewer((s) => s.shading)
+  const isExporting = useViewer((s) => s.isExporting)
   const [w, h, d] = node.asset.dimensions
   const material = useMemo(() => {
     const next = createDefaultMaterial('#ef4444', 1, shading) as MutableMaterial
@@ -191,6 +192,10 @@ const BrokenItemFallback = ({ node }: { node: ItemNode }) => {
     return next
   }, [shading])
 
+  // Debug affordance only — a bake must never ship the red placeholder box
+  // (observed baked into a prod artifact when an item GLB 504'd mid-capture).
+  if (isExporting) return null
+
   return (
     <mesh position-y={h / 2} {...handlers}>
       <boxGeometry args={[w, h, d]} />
@@ -199,10 +204,73 @@ const BrokenItemFallback = ({ node }: { node: ItemNode }) => {
   )
 }
 
+const MODEL_RETRY_DELAYS_MS = [1_000, 3_000]
+
+/**
+ * Load the item model with bounded retries. drei's `useGLTF` caches a rejected
+ * load by URL, so a transient fetch failure (e.g. a storage 504 under the bake
+ * page's asset-request burst) would otherwise stay broken for the whole
+ * session — clear the cache entry and re-mount. After the retries are
+ * exhausted the item settles as SKIPPED: it renders the debug box (nothing
+ * during exports) and lands in `useViewer.itemLoadFailures` so a bake host can
+ * record which items are missing from the artifact.
+ */
+const ModelWithRetry = ({ node, markSettled }: { node: ItemNode; markSettled: () => void }) => {
+  // `failures` counts boundary catches; `epoch` bumps after each cache clear
+  // to reset the boundary and re-mount the loader. The retry timer is owned by
+  // an effect (not the error handler) so StrictMode's synthetic
+  // unmount/remount re-arms it instead of silently discarding it.
+  const [failures, setFailures] = useState(0)
+  const [epoch, setEpoch] = useState(0)
+  const url = resolveCdnUrl(node.asset.src) || ''
+  const gaveUp = !url || failures > MODEL_RETRY_DELAYS_MS.length
+
+  const handleError = useCallback(() => setFailures((current) => current + 1), [])
+
+  useEffect(() => {
+    if (failures === 0 || gaveUp) return
+    const delay = MODEL_RETRY_DELAYS_MS[failures - 1] ?? 0
+    const timer = setTimeout(() => {
+      console.log(
+        `[item] retrying model load (${failures}/${MODEL_RETRY_DELAYS_MS.length}) ${url}`,
+      )
+      useGLTF.clear(url)
+      setEpoch((current) => current + 1)
+    }, delay)
+    return () => clearTimeout(timer)
+  }, [failures, gaveUp, url])
+
+  useEffect(() => {
+    if (!gaveUp) return
+    markSettled()
+    useViewer.getState().reportItemLoadFailure(node.id, url)
+    return () => useViewer.getState().clearItemLoadFailure(node.id)
+  }, [gaveUp, markSettled, node.id, url])
+
+  if (gaveUp) return <BrokenItemFallback node={node} />
+
+  return (
+    <ErrorBoundary fallback={<PreviewModel node={node} />} onError={handleError} resetKey={epoch}>
+      <Suspense fallback={<PreviewModel node={node} />}>
+        <ModelRenderer markSettled={markSettled} node={node} />
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+
 export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
   const ref = useRef<Group>(null!)
 
   useRegistry(storeNode.id, storeNode.type, ref)
+
+  // "Settled" = the model resolved, terminally failed (skipped), or was never
+  // expected. `ItemSystem` holds the dirty mark until then, so scene-ready
+  // (and headless bakes) wait for real item content instead of exporting the
+  // loading placeholder.
+  const markSettled = useCallback(() => {
+    const group = ref.current as (Group & { userData: Record<string, unknown> }) | null
+    if (group) group.userData.itemModelSettled = true
+  }, [])
 
   // Merge live drag overrides so the mesh transforms in real time during a
   // drag (e.g. the in-world rotate gizmo). The handle writes the in-flight
@@ -217,17 +285,17 @@ export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
   const roomClearPreview =
     (node as ItemNode & { roomClearPreview?: unknown }).roomClearPreview === true
 
+  useEffect(() => {
+    if (roomClearPreview) markSettled()
+  }, [roomClearPreview, markSettled])
+
   const content = (
     <group position={node.position} ref={ref} rotation={node.rotation} visible={node.visible}>
       {roomClearPreview ? (
         <ClearPreviewModel node={node} />
       ) : (
         <>
-          <ErrorBoundary fallback={<BrokenItemFallback node={node} />}>
-            <Suspense fallback={<PreviewModel node={node} />}>
-              <ModelRenderer node={node} />
-            </Suspense>
-          </ErrorBoundary>
+          <ModelWithRetry markSettled={markSettled} node={node} />
           {node.children?.map((childId) => (
             <NodeRenderer key={childId} nodeId={childId} />
           ))}
@@ -262,6 +330,9 @@ function getPreviewMaterial(shading: RenderShading): Material {
 
 const PreviewModel = ({ node }: { node: ItemNode }) => {
   const shading = useViewer((s) => s.shading)
+  const isExporting = useViewer((s) => s.isExporting)
+  // Loading placeholder — must never land in an exported GLB.
+  if (isExporting) return null
   return (
     <mesh material={getPreviewMaterial(shading)} position-y={node.asset.dimensions[1] / 2}>
       <boxGeometry
@@ -296,10 +367,16 @@ const multiplyScales = (
   b: [number, number, number],
 ): [number, number, number] => [a[0] * b[0], a[1] * b[1], a[2] * b[2]]
 
-const ModelRenderer = ({ node }: { node: ItemNode }) => {
+const ModelRenderer = ({ node, markSettled }: { node: ItemNode; markSettled?: () => void }) => {
   const { scene, nodes, animations } = useGLTF(resolveCdnUrl(node.asset.src) || '')
   const ref = useRef<Group>(null!)
   const { actions } = useAnimations(animations, ref)
+
+  // Mounting past the suspense gate means the GLB resolved — the item's build
+  // work is done (`ItemSystem` may clear its dirty mark, scene-ready may fire).
+  useEffect(() => {
+    markSettled?.()
+  }, [markSettled])
   const shading = useViewer((s) => s.shading)
   const textures = useViewer((s) => s.textures)
   const colorPreset = useViewer((s) => s.colorPreset)

--- a/packages/nodes/src/item/renderer.tsx
+++ b/packages/nodes/src/item/renderer.tsx
@@ -215,11 +215,20 @@ const MODEL_RETRY_DELAYS_MS = [1_000, 3_000]
  * during exports) and lands in `useViewer.itemLoadFailures` so a bake host can
  * record which items are missing from the artifact.
  */
-const ModelWithRetry = ({ node, markSettled }: { node: ItemNode; markSettled: () => void }) => {
+const ModelWithRetry = ({
+  node,
+  setSettled,
+}: {
+  node: ItemNode
+  setSettled: (value: boolean) => void
+}) => {
   // `failures` counts boundary catches; `epoch` bumps after each cache clear
   // to reset the boundary and re-mount the loader. The retry timer is owned by
   // an effect (not the error handler) so StrictMode's synthetic
-  // unmount/remount re-arms it instead of silently discarding it.
+  // unmount/remount re-arms it instead of silently discarding it. The host
+  // keys this component by asset URL, so a model swap starts from a clean
+  // retry budget — and the mount effect below un-settles the item so the new
+  // load is awaited too.
   const [failures, setFailures] = useState(0)
   const [epoch, setEpoch] = useState(0)
   const url = resolveCdnUrl(node.asset.src) || ''
@@ -228,17 +237,21 @@ const ModelWithRetry = ({ node, markSettled }: { node: ItemNode; markSettled: ()
   const handleError = useCallback(() => setFailures((current) => current + 1), [])
 
   useEffect(() => {
+    setSettled(false)
+  }, [setSettled])
+
+  useEffect(() => {
     if (failures === 0 || gaveUp) return
     const delay = MODEL_RETRY_DELAYS_MS[failures - 1] ?? 0
     const timer = setTimeout(() => {
-      console.log(
-        `[item] retrying model load (${failures}/${MODEL_RETRY_DELAYS_MS.length}) ${url}`,
-      )
+      console.log(`[item] retrying model load (${failures}/${MODEL_RETRY_DELAYS_MS.length}) ${url}`)
       useGLTF.clear(url)
       setEpoch((current) => current + 1)
     }, delay)
     return () => clearTimeout(timer)
   }, [failures, gaveUp, url])
+
+  const markSettled = useCallback(() => setSettled(true), [setSettled])
 
   useEffect(() => {
     if (!gaveUp) return
@@ -266,10 +279,11 @@ export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
   // "Settled" = the model resolved, terminally failed (skipped), or was never
   // expected. `ItemSystem` holds the dirty mark until then, so scene-ready
   // (and headless bakes) wait for real item content instead of exporting the
-  // loading placeholder.
-  const markSettled = useCallback(() => {
+  // loading placeholder. A model swap un-settles (ModelWithRetry's mount
+  // effect via its URL key) so the replacement load is awaited too.
+  const setSettled = useCallback((value: boolean) => {
     const group = ref.current as (Group & { userData: Record<string, unknown> }) | null
-    if (group) group.userData.itemModelSettled = true
+    if (group) group.userData.itemModelSettled = value
   }, [])
 
   // Merge live drag overrides so the mesh transforms in real time during a
@@ -286,8 +300,8 @@ export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
     (node as ItemNode & { roomClearPreview?: unknown }).roomClearPreview === true
 
   useEffect(() => {
-    if (roomClearPreview) markSettled()
-  }, [roomClearPreview, markSettled])
+    if (roomClearPreview) setSettled(true)
+  }, [roomClearPreview, setSettled])
 
   const content = (
     <group position={node.position} ref={ref} rotation={node.rotation} visible={node.visible}>
@@ -295,7 +309,7 @@ export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
         <ClearPreviewModel node={node} />
       ) : (
         <>
-          <ModelWithRetry markSettled={markSettled} node={node} />
+          <ModelWithRetry key={node.asset.src ?? 'no-src'} node={node} setSettled={setSettled} />
           {node.children?.map((childId) => (
             <NodeRenderer key={childId} nodeId={childId} />
           ))}

--- a/packages/viewer/src/components/error-boundary.tsx
+++ b/packages/viewer/src/components/error-boundary.tsx
@@ -6,6 +6,11 @@ interface ErrorBoundaryProps {
   fallback: ReactNode
   /** Tag for log lines so we can tell which boundary swallowed an error. */
   scope?: string
+  /** Notified once per caught error — lets the host schedule a retry. */
+  onError?: (error: Error) => void
+  /** Changing this key clears a caught error and re-mounts `children` — the
+   * retry half of `onError` (bump it after clearing whatever failed). */
+  resetKey?: unknown
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, { hasError: boolean }> {
@@ -19,6 +24,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, { hasError: boo
       error,
       info.componentStack,
     )
+    this.props.onError?.(error)
+  }
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false })
+    }
   }
   render() {
     return this.state.hasError ? this.props.fallback : this.props.children

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -49,6 +49,14 @@ type ViewerState = {
   isExporting: boolean
   setExporting: (value: boolean) => void
 
+  /** Item model loads that exhausted their retries — nodeId → asset URL. The
+   * scene renders without these items (they settle as skipped); a bake host
+   * can persist the map onto the artifact's metadata so a missing item is
+   * queryable instead of silently absent. Transient (never persisted). */
+  itemLoadFailures: Record<string, string>
+  reportItemLoadFailure: (nodeId: string, url: string) => void
+  clearItemLoadFailure: (nodeId: string) => void
+
   /** Suspend the render loop while the canvas is fully covered (e.g. studio gallery). */
   renderPaused: boolean
   setRenderPaused: (value: boolean) => void
@@ -244,6 +252,21 @@ const useViewer = create<ViewerState>()(
 
       isExporting: false,
       setExporting: (value) => set({ isExporting: value }),
+
+      itemLoadFailures: {},
+      reportItemLoadFailure: (nodeId, url) =>
+        set((state) =>
+          state.itemLoadFailures[nodeId] === url
+            ? state
+            : { itemLoadFailures: { ...state.itemLoadFailures, [nodeId]: url } },
+        ),
+      clearItemLoadFailure: (nodeId) =>
+        set((state) => {
+          if (!(nodeId in state.itemLoadFailures)) return state
+          const next = { ...state.itemLoadFailures }
+          delete next[nodeId]
+          return { itemLoadFailures: next }
+        }),
 
       renderPaused: false,
       setRenderPaused: (value) => set({ renderPaused: value }),

--- a/packages/viewer/src/systems/item/item-system.tsx
+++ b/packages/viewer/src/systems/item/item-system.tsx
@@ -53,6 +53,13 @@ export const ItemSystem = () => {
         }
       }
 
+      // Hold the mark until the model settles (loaded, terminally failed, or
+      // never expected — see ItemRenderer.markSettled). Registration alone
+      // isn't "built": clearing then would let scene-ready fire while GLBs are
+      // still downloading and a bake would export loading placeholders.
+      const settled = (mesh.userData as { itemModelSettled?: boolean }).itemModelSettled
+      if (!settled) return
+
       clearDirty(id as AnyNodeId)
     })
   }, 2)


### PR DESCRIPTION
## What does this PR do?

Makes item model loading resilient for both interactive use and headless bakes. Today a transient storage failure (observed in prod: Supabase 504s under the bake page's ~200-concurrent-request asset burst) permanently breaks an item for the session — drei's `useGLTF` caches the rejection — and worse, the red debug-box fallback gets **baked into the exported GLB** (observed in a prod artifact: 24-vert boxes with the red translucent material where 4 kettles should be).

- **Bounded retries** (1s/3s): clear the `useGLTF` cache entry and re-mount via a new `resetKey` on `ErrorBoundary`. The retry timer is effect-owned, keyed on failure count — StrictMode's synthetic unmount/remount re-arms it (an onError-scheduled timer dies silently in dev, verified).
- **Exhausted retries → item settles as skipped**: the debug box renders nothing while `isExporting`, and the failure is recorded in `useViewer.itemLoadFailures` (nodeId → url) so a bake host can persist which items are missing.
- **Scene-ready waits for item content**: `ItemSystem` now holds the dirty mark until the item settles (model mounted / terminally failed / never expected) instead of clearing at group registration — closing a race where a bake could export loading placeholders; the loading placeholder also hides during exports.

## How to test

1. `bun dev`, open a scene with items — loading placeholders, hover/selection, and slot materials behave as before.
2. Simulate a dead asset (devtools → block an item's model URL, reload): after ~5s (2 retries) the item shows the red debug box; the scene stays interactive.
3. Bake locally with the URL blocked: the exported GLB contains no debug box for that item and the bake completes; unblock, re-bake: item present.

Verified against a 200+-item prod scene: permanent 504 → exactly 3 fetch attempts then a clean skip; 504-once → retry heals, artifact byte-equivalent to intact; no-failure runs byte-identical (demo_1).

## Screenshots / screen recording

N/A — failure-path behavior; exported-GLB assertions above are the evidence.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes item load lifecycle and scene-ready gating used by headless GLB bakes; incorrect settlement timing could delay exports or omit items, but happy-path behavior is intended to stay byte-identical.
> 
> **Overview**
> Item GLB loading is now resilient to transient CDN/storage failures and headless bakes no longer capture debug or loading placeholders.
> 
> **`ModelWithRetry`** wraps item loads with bounded retries (1s / 3s): on failure it clears drei's `useGLTF` cache, bumps an `ErrorBoundary` `resetKey`, and re-mounts. After retries are exhausted the item **settles as skipped**—the red debug box stays in dev but renders **nothing** when `isExporting`; failures are recorded in **`useViewer.itemLoadFailures`** (nodeId → URL) for bake metadata.
> 
> **Scene-ready / bake timing:** `ItemRenderer` sets `userData.itemModelSettled` when the model mounts, fails terminally, or isn't needed (e.g. room-clear preview). **`ItemSystem`** only clears the dirty mark once settled, so scene-ready and exports wait for real geometry instead of grey loading boxes.
> 
> **Export hygiene:** `PreviewModel` and `BrokenItemFallback` return `null` during export. **`ErrorBoundary`** gains `onError` and `resetKey` to support the retry flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b032cc2dafc73f8a88ee4b01f130242b2976a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->