### PR TITLE
fix(viewer): drive the frame loop with a timer when ?disable=draw

### DIFF
--- a/packages/viewer/src/components/viewer/frame-limiter.tsx
+++ b/packages/viewer/src/components/viewer/frame-limiter.tsx
@@ -6,6 +6,20 @@ type FrameLimiterProps = {
   fps?: number
 }
 
+// `?disable=draw` (see post-processing.tsx): the page renders no real frames,
+// and Chromium's no-damage scheduler then throttles requestAnimationFrame to
+// 1Hz on Linux (measured in the headless bake worker — every useFrame system
+// ticked once per second and a heavy scene took 300+ seconds to settle). A
+// plain timer is never throttled on a visible page, so drive the loop with
+// setInterval instead of rAF when nothing is drawn.
+const DRAW_DISABLED =
+  typeof window !== 'undefined' &&
+  new Set(
+    (new URLSearchParams(window.location.search).get('disable') ?? '')
+      .split(',')
+      .map((s) => s.trim()),
+  ).has('draw')
+
 const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
   const { advance, set, frameloop: initFrameloop, scene, clock } = useThree()
   const renderer = useThree((state) => state.gl)
@@ -18,6 +32,7 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     let then = 0
     let i = 0
     let raf: number | null = null
+    let timer: ReturnType<typeof setInterval> | null = null
     const interval = 1000 / fps
     function tick(t: DOMHighResTimeStamp) {
       raf = requestAnimationFrame(tick)
@@ -30,12 +45,22 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     }
     // Set frameloop to never, it will shut down the default render loop
     set({ frameloop: 'never' })
-    // Kick off custom render loop
-    raf = requestAnimationFrame(tick)
+    if (DRAW_DISABLED) {
+      timer = setInterval(() => {
+        i += interval / 1000
+        advance(i)
+      }, interval)
+    } else {
+      // Kick off custom render loop
+      raf = requestAnimationFrame(tick)
+    }
     // Restore initial setting
     return () => {
       if (raf) {
         cancelAnimationFrame(raf)
+      }
+      if (timer) {
+        clearInterval(timer)
       }
       set({ frameloop: initFrameloop })
     }


### PR DESCRIPTION
## What does this PR do?

Follow-up to #482. On Linux (the headless bake worker), Chromium's no-damage scheduler throttles `requestAnimationFrame` to **1Hz** when the page never submits a real frame — measured in the prod-image container: main thread fully idle, rAF gaps exactly 1017ms, so every `useFrame` system ticked once per second and a heavy scene needed 300+ seconds just to execute its ~300 frames of build work (and blew the capture deadline on the worker's slower cores). The #482 empty-scene clear prevents this on macOS but not on Linux.

Fix: when `?disable=draw` is active, `FrameLimiter` drives `advance()` from `setInterval` instead of rAF. Foreground-page timers are never throttled, so loop pacing is deterministic (the `fps` prop) regardless of compositor heuristics. The normal rendering path is unchanged (still rAF).

## How to test

1. `bun dev`, open `/bake/demo_office?disable=postFx,draw` — `window.__BAKE__` resolves in seconds (validated: 8.9s for a 200+-item scene, output in the normal byte range).
2. Any page without `draw` — unchanged (verified demo_1 normal render byte-equal).
3. Real proof is the prod worker post-merge: the office scene (`project_2VqMH2p0YduKVd3i`) should complete a headless CPU-only bake for the first time.

## Screenshots / screen recording

N/A — headless-only behavior.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the ?disable=draw code path; normal viewer rendering still uses rAF unchanged.
> 
> **Overview**
> When **`?disable=draw`** is set (headless bakes that skip real drawing), **`FrameLimiter`** now advances the R3F loop with **`setInterval`** at the configured **`fps`** instead of **`requestAnimationFrame`**.
> 
> On Linux, Chromium throttles rAF to ~1Hz when no real frames are submitted, which made **`useFrame`** systems crawl during bakes. Timers stay at full rate on a visible page, so build work can finish in seconds without changing the normal rAF path when drawing is enabled.
> 
> Cleanup cancels the interval on unmount alongside the existing rAF teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892eb62391dce96aa5da43f722f38a261d704695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->