### PR TITLE
fix(viewer): wall-clock scene-ready cap + skip unreachable dirty nodes

### DIFF
--- a/packages/viewer/src/components/viewer/index.tsx
+++ b/packages/viewer/src/components/viewer/index.tsx
@@ -249,11 +249,22 @@ function ToneMappingExposure() {
 }
 
 function hasPendingSceneBuildWork() {
-  const { dirtyNodes, nodes } = useScene.getState()
+  const { dirtyNodes, nodes, rootNodeIds } = useScene.getState()
 
   for (const id of dirtyNodes) {
     const node = nodes[id]
     if (!node) continue
+    // Unreachable nodes (orphaned by a broken detach: the parent doesn't list
+    // them in `children`, or no parent and not a root) never render — every
+    // renderer enumerates the parent's `children` array — so no system will
+    // ever build them or clear their mark. They must not hold scene-ready
+    // hostage (observed in prod scene data: two dangling windows kept every
+    // bake of that scene waiting out the full readiness cap).
+    const parent = node.parentId ? nodes[node.parentId as AnyNodeId] : undefined
+    const reachable = parent
+      ? (parent as { children?: string[] }).children?.includes(id) === true
+      : rootNodeIds.includes(id)
+    if (!reachable) continue
     const def = nodeRegistry.get(node.type)
     if (def?.geometry || def?.capabilities?.floorPlaced || DIRTY_BUILD_KINDS.has(node.type)) {
       return true
@@ -272,13 +283,16 @@ function hasCommittedSceneRoot() {
 function SceneReadyTracker({
   onSceneReadyChange,
   sceneReadyKey,
+  sceneReadyMaxWaitMs,
 }: {
   onSceneReadyChange?: (ready: boolean) => void
   sceneReadyKey?: string | number | null
+  sceneReadyMaxWaitMs?: number
 }) {
   const readyRef = useRef(false)
   const settledFramesRef = useRef(0)
   const waitedFramesRef = useRef(0)
+  const waitStartRef = useRef<number | null>(null)
   const onSceneReadyChangeRef = useRef(onSceneReadyChange)
 
   useEffect(() => {
@@ -290,6 +304,7 @@ function SceneReadyTracker({
     readyRef.current = false
     settledFramesRef.current = 0
     waitedFramesRef.current = 0
+    waitStartRef.current = null
     onSceneReadyChangeRef.current?.(false)
   }, [sceneReadyKey])
 
@@ -297,10 +312,16 @@ function SceneReadyTracker({
     if (!(onSceneReadyChangeRef.current && !readyRef.current)) return
 
     waitedFramesRef.current += 1
-    if (
-      waitedFramesRef.current < SCENE_READY_MAX_WAIT_FRAMES &&
-      (!hasCommittedSceneRoot() || hasPendingSceneBuildWork())
-    ) {
+    waitStartRef.current ??= performance.now()
+    // Give-up cap so a permanently-dirty node can't block readiness forever.
+    // The frame-count default assumes display-rate frames; a host whose frame
+    // cadence is decoupled from wall time (the headless bake page's timer-driven
+    // loop runs 180 frames in 3.6s — faster than a cold item download) passes
+    // `sceneReadyMaxWaitMs` to make the cap wall-clock instead.
+    const capReached = sceneReadyMaxWaitMs
+      ? performance.now() - waitStartRef.current >= sceneReadyMaxWaitMs
+      : waitedFramesRef.current >= SCENE_READY_MAX_WAIT_FRAMES
+    if (!capReached && (!hasCommittedSceneRoot() || hasPendingSceneBuildWork())) {
       settledFramesRef.current = 0
       return
     }
@@ -346,6 +367,13 @@ interface ViewerProps {
   sceneReadyKey?: string | number | null
   onSceneReadyChange?: (ready: boolean) => void
   /**
+   * Wall-clock give-up cap for scene readiness, replacing the default
+   * frame-count cap. Set it on hosts whose frame cadence is decoupled from
+   * real time (the headless bake page's timer-driven loop runs the default
+   * 180-frame cap in ~3.6s — shorter than a cold item-model download).
+   */
+  sceneReadyMaxWaitMs?: number
+  /**
    * Skip the TSL post-processing pipeline (SSGI/denoise/ink/outline) and render
    * the scene directly. For headless/capture surfaces (the bake page) where
    * frame quality is irrelevant: on a software-rasterised worker the pipeline
@@ -379,6 +407,7 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
     isolate,
     sceneReadyKey,
     onSceneReadyChange,
+    sceneReadyMaxWaitMs,
     disablePostFx = false,
   },
   ref,
@@ -527,7 +556,11 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
       <ViewerCamera />
       <GPUDeviceWatcher />
       <ToneMappingExposure />
-      <SceneReadyTracker onSceneReadyChange={onSceneReadyChange} sceneReadyKey={sceneReadyKey} />
+      <SceneReadyTracker
+        onSceneReadyChange={onSceneReadyChange}
+        sceneReadyKey={sceneReadyKey}
+        sceneReadyMaxWaitMs={sceneReadyMaxWaitMs}
+      />
 
       <ErrorBoundary fallback={null} scope="viewer-scene">
         {/* <directionalLight position={[10, 10, 5]} intensity={0.5} castShadow


### PR DESCRIPTION
## What does this PR do?

Two readiness fixes surfaced by the first successful headless CPU-only bake (which completed in 80s — but exported with 33 items missing, caught by the new `skippedItems` metadata):

1. **`sceneReadyMaxWaitMs` Viewer prop** — the 180-*frame* give-up cap silently assumed display-rate frames (~3s interactive). The bake page's timer loop (`?disable=draw`, #483) runs 180 frames in 3.6s of wall time — shorter than a cold item download, so the cap fired and the export raced ahead of content. The prop replaces the frame cap with a wall-clock one; hosts that don't pass it keep the exact current behavior.
2. **Unreachable dirty nodes no longer block readiness** — found real prod scene data with two windows whose `parentId` points at a level that doesn't list them in `children` (dangling nodes from some old detach flow). Nothing ever renders/builds an unreachable node, so its dirty mark lives forever and held every bake of that scene to the full cap. `hasPendingSceneBuildWork` now skips nodes not reachable via their parent's `children` array (or roots).

## How to test

1. `bun dev`, open `/bake/demo_1?disable=postFx,draw` — resolves fast, as before.
2. Editor surfaces: unchanged (no `sceneReadyMaxWaitMs` passed → same 180-frame cap).
3. Validated on the 200+-item office scene (`?disable=postFx,draw` + the companion bake-page change): settles **organically in ~2s**, exports the complete 35MB artifact, zero skipped items; with an item URL 504'd once, the bake now waits through the retry and includes the item.

## Screenshots / screen recording

N/A — readiness timing behavior.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when hosts signal scene-ready (export/capture timing) and ignore dirty marks on graph-unreachable nodes; wrong reachability logic could declare ready while real content is still building, though the existing settled-frame and cap behavior remains.
> 
> **Overview**
> Fixes **scene readiness** getting stuck or firing too early during headless bakes and on scenes with broken graph links.
> 
> **Unreachable dirty nodes** no longer count as pending build work: `hasPendingSceneBuildWork` treats a node as reachable only if its parent lists it in `children` or it is in `rootNodeIds`, so orphaned dirty nodes cannot block `onSceneReadyChange` until the give-up cap.
> 
> **Optional wall-clock give-up** via new Viewer prop `sceneReadyMaxWaitMs`: when set, `SceneReadyTracker` uses elapsed time instead of the default 180-frame cap—intended for timer-driven hosts (e.g. bake page) where 180 frames is shorter in wall time than slow async work like item downloads. Hosts that omit the prop keep the existing frame-based cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00459d062794cdb44831ae1c98bc7521a2d12b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->