### PR TITLE
fix(items): don't clobber a same-commit settled flag (cached-model race)

### DIFF
--- a/packages/nodes/src/item/renderer.tsx
+++ b/packages/nodes/src/item/renderer.tsx
@@ -217,10 +217,10 @@ const MODEL_RETRY_DELAYS_MS = [1_000, 3_000]
  */
 const ModelWithRetry = ({
   node,
-  setSettled,
+  settleControl,
 }: {
   node: ItemNode
-  setSettled: (value: boolean) => void
+  settleControl: SettleControl
 }) => {
   // `failures` counts boundary catches; `epoch` bumps after each cache clear
   // to reset the boundary and re-mount the loader. The retry timer is owned by
@@ -236,9 +236,14 @@ const ModelWithRetry = ({
 
   const handleError = useCallback(() => setFailures((current) => current + 1), [])
 
+  // Un-settle ONLY when the URL actually changed. A cached model mounts in the
+  // SAME commit as this wrapper, and React runs child effects first — a blind
+  // `settle(false)` here would clobber the child's just-written settled flag
+  // and the item would stay "pending" forever (observed on the bake worker,
+  // whose shared warm HTTP cache makes most models mount synchronously).
   useEffect(() => {
-    setSettled(false)
-  }, [setSettled])
+    settleControl.unsettleForUrl(url)
+  }, [settleControl, url])
 
   useEffect(() => {
     if (failures === 0 || gaveUp) return
@@ -251,7 +256,7 @@ const ModelWithRetry = ({
     return () => clearTimeout(timer)
   }, [failures, gaveUp, url])
 
-  const markSettled = useCallback(() => setSettled(true), [setSettled])
+  const markSettled = useCallback(() => settleControl.settle(url), [settleControl, url])
 
   useEffect(() => {
     if (!gaveUp) return
@@ -271,6 +276,15 @@ const ModelWithRetry = ({
   )
 }
 
+type SettleControl = {
+  /** The model for `url` is resolved (or terminally skipped) — build work done. */
+  settle: (url: string) => void
+  /** A load for `url` is starting; drop the settled flag unless it was already
+   *  settled for this same URL (a cached model settles in the same commit,
+   *  child-effect-first — that write must win). */
+  unsettleForUrl: (url: string) => void
+}
+
 export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
   const ref = useRef<Group>(null!)
 
@@ -281,10 +295,24 @@ export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
   // (and headless bakes) wait for real item content instead of exporting the
   // loading placeholder. A model swap un-settles (ModelWithRetry's mount
   // effect via its URL key) so the replacement load is awaited too.
-  const setSettled = useCallback((value: boolean) => {
-    const group = ref.current as (Group & { userData: Record<string, unknown> }) | null
-    if (group) group.userData.itemModelSettled = value
-  }, [])
+  const settleControl = useMemo<SettleControl>(
+    () => ({
+      settle: (url) => {
+        const group = ref.current as (Group & { userData: Record<string, unknown> }) | null
+        if (!group) return
+        group.userData.itemModelSettled = true
+        group.userData.itemModelSettledUrl = url
+      },
+      unsettleForUrl: (url) => {
+        const group = ref.current as (Group & { userData: Record<string, unknown> }) | null
+        if (!group) return
+        if (group.userData.itemModelSettled && group.userData.itemModelSettledUrl === url) return
+        group.userData.itemModelSettled = false
+        group.userData.itemModelSettledUrl = url
+      },
+    }),
+    [],
+  )
 
   // Merge live drag overrides so the mesh transforms in real time during a
   // drag (e.g. the in-world rotate gizmo). The handle writes the in-flight
@@ -300,8 +328,8 @@ export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
     (node as ItemNode & { roomClearPreview?: unknown }).roomClearPreview === true
 
   useEffect(() => {
-    if (roomClearPreview) setSettled(true)
-  }, [roomClearPreview, setSettled])
+    if (roomClearPreview) settleControl.settle('room-clear-preview')
+  }, [roomClearPreview, settleControl])
 
   const content = (
     <group position={node.position} ref={ref} rotation={node.rotation} visible={node.visible}>
@@ -309,7 +337,11 @@ export const ItemRenderer = ({ node: storeNode }: { node: ItemNode }) => {
         <ClearPreviewModel node={node} />
       ) : (
         <>
-          <ModelWithRetry key={node.asset.src ?? 'no-src'} node={node} setSettled={setSettled} />
+          <ModelWithRetry
+            key={node.asset.src ?? 'no-src'}
+            node={node}
+            settleControl={settleControl}
+          />
           {node.children?.map((childId) => (
             <NodeRenderer key={childId} nodeId={childId} />
           ))}


### PR DESCRIPTION
## What does this PR do?

Fixes the effect-ordering race behind tonight's slow office bake: a **cached** item model mounts in the same commit as `ModelWithRetry`, child effects run first (`settled=true`), and the wrapper's mount effect then stomped it back to `false` permanently. The item renders and exports fine — the artifact was complete — but its dirty mark never clears, so scene-ready waits out the full `sceneReadyMaxWaitMs` cap and the bake page falsely reports the loaded items as skipped.

Only the bake worker hits this (shared warm HTTP context → synchronous cached mounts); every fresh-browser local test loads via suspense and settles after the wrapper's effect, which is why it validated clean locally.

The settled flag is now URL-stamped: `unsettleForUrl` is a no-op when the flag is already settled **for the same URL** (the cached same-commit case), and still resets on a genuine model swap (the URL-keyed remount keeps the retry-budget reset).

## How to test

1. `bun dev`, `/bake/demo_office?disable=postFx,draw` — settles organically (~2.5s), full artifact, `skippedItems` absent.
2. Real proof post-merge: a warm office-scene bake on the worker should settle in seconds instead of waiting the full 240s cap, with no false skips.

## Screenshots / screen recording

N/A.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scene-ready / bake gating via `itemModelSettled` in ItemSystem; behavior change is narrow but timing-sensitive for headless exports.
> 
> **Overview**
> Fixes a React effect-ordering bug where **cached** GLBs could render correctly but never clear the item “settled” dirty mark, so headless bakes waited until `sceneReadyMaxWaitMs` and falsely reported skips.
> 
> **`ItemRenderer`** replaces the boolean `setSettled` callback with a **`SettleControl`** that writes `itemModelSettled` together with **`itemModelSettledUrl`**. **`ModelWithRetry`** calls **`unsettleForUrl(url)`** on mount instead of always forcing unsettled — it is a no-op when the flag is already settled for that same URL (child `ModelRenderer` effect runs first on synchronous cache hits). Genuine asset swaps still reset because the component is keyed by URL.
> 
> **`settle(url)`** is used when the model resolves, on terminal load failure, and for room-clear preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab3db67ff265f98ef1cd19ce28b44b8ccece2356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->