### PR TITLE
fix(core): guard material-ref parsers against non-string values (Sentry MONOREPO-EDITOR-EM)

### DIFF
--- a/packages/core/src/material-library.test.ts
+++ b/packages/core/src/material-library.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test'
+import { getLibraryMaterialIdFromRef, getSceneMaterialIdFromRef } from './material-library'
+
+describe('material references', () => {
+  test('rejects malformed runtime values instead of calling string methods', () => {
+    const malformedRefs: unknown[] = [42, true, {}, []]
+
+    for (const ref of malformedRefs) {
+      expect(getLibraryMaterialIdFromRef(ref as string)).toBeNull()
+      expect(getSceneMaterialIdFromRef(ref as string)).toBeNull()
+    }
+  })
+})

--- a/packages/core/src/material-library.ts
+++ b/packages/core/src/material-library.ts
@@ -4187,13 +4187,14 @@ export function toSceneMaterialRef(id: string) {
 }
 
 export function getLibraryMaterialIdFromRef(materialRef?: string | null) {
-  if (!materialRef) return null
+  if (typeof materialRef !== 'string') return null
   if (!materialRef.startsWith(LIBRARY_MATERIAL_REF_PREFIX)) return null
   return materialRef.slice(LIBRARY_MATERIAL_REF_PREFIX.length)
 }
 
 export function getSceneMaterialIdFromRef(materialRef?: string | null): string | null {
-  if (!materialRef?.startsWith(SCENE_MATERIAL_REF_PREFIX)) return null
+  if (typeof materialRef !== 'string') return null
+  if (!materialRef.startsWith(SCENE_MATERIAL_REF_PREFIX)) return null
   return materialRef.slice(SCENE_MATERIAL_REF_PREFIX.length)
 }
 


### PR DESCRIPTION
## What
Add a `typeof materialRef !== 'string'` guard to `getLibraryMaterialIdFromRef` and `getSceneMaterialIdFromRef` in `packages/core/src/material-library.ts`.

## Why
Both functions only guarded against null/undefined before calling `.startsWith()`:
```ts
if (!materialRef) return null
if (!materialRef.startsWith(PREFIX)) return null   // throws if materialRef is a number/object
```
When a **non-string** material ref reaches them (a legacy or malformed wall material slot ref), `.startsWith` is undefined -> `TypeError: e.startsWith is not a function`.

Stack originates in wall material resolution: `packages/viewer/src/systems/wall/wall-materials.ts` -> `parseMaterialRef(ref)` -> `getLibraryMaterialIdFromRef`.

- Sentry: **MONOREPO-EDITOR-EM** - new (first seen 7/8), 16 events / 2 users. Catching it before it grows.

## Safety
`typeof x !== 'string'` narrows to `string`, so `.startsWith`/`.slice` remain valid; return type unchanged (non-string already mapped to `null`). Behaviour for real string refs is identical.

## Verification
`tsc --noEmit` on @pascal-app/core: exit 0. biome check: clean.

_Opened by nightly Sentry triage. Do not auto-merge - review first._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change in ref parsing; string behavior is unchanged and failures degrade to null like other invalid refs.
> 
> **Overview**
> Hardens **library** and **scene** material ref parsing so malformed runtime values (numbers, booleans, objects) return `null` instead of throwing when `.startsWith` is invoked.
> 
> `getLibraryMaterialIdFromRef` and `getSceneMaterialIdFromRef` now bail out with `typeof materialRef !== 'string'` before prefix checks; scene parsing no longer relies on optional chaining alone on a possibly non-string ref. Valid string refs behave the same.
> 
> Adds a small Bun test that asserts both helpers return `null` for common non-string inputs, covering the wall material path that goes through `parseMaterialRef`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b770d09aad7ade2f6cb0b0eda1d9990313bea4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->