### PR TITLE
fix(editor): compass needle follows align-north in 3D-only view

### DIFF
--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -5082,6 +5082,7 @@ export function FloorplanPanel({
     useEditor.getState().navigationSyncPose,
   )
   const compassNeedleRef = useRef<SVGSVGElement | null>(null)
+  const hiddenCompassAnimationRef = useRef<number | null>(null)
   const levelId = useViewer((state) => state.selection.levelId)
   const buildingId = useViewer((state) => state.selection.buildingId)
   const selectedZoneId = useViewer((state) => state.selection.zoneId)
@@ -6560,8 +6561,50 @@ export function FloorplanPanel({
     }
   }, [syncFloorplanViewportToNavigationPose, isFloorplanOpen])
 
+  const cancelHiddenCompassAnimation = useCallback(() => {
+    if (hiddenCompassAnimationRef.current !== null) {
+      cancelAnimationFrame(hiddenCompassAnimationRef.current)
+      hiddenCompassAnimationRef.current = null
+    }
+  }, [])
+
+  // Align-north while the panel is hidden publishes a single '2d' pose that
+  // the 3D camera applies through the echo-suppressed pending-pose path — it
+  // never publishes '3d' frames back, so the needle must animate itself.
+  // Same time constant as the 2D view animation and the camera's effective
+  // smoothTime, so all three stay visually in step.
+  const animateHiddenCompassNeedle = useCallback(
+    (targetDeg: number) => {
+      cancelHiddenCompassAnimation()
+      let last = performance.now()
+      const tick = (now: number) => {
+        hiddenCompassAnimationRef.current = null
+        if (isFloorplanOpenRef.current) {
+          return
+        }
+        const deltaMs = now - last
+        last = now
+        const currentDeg = latestFloorplanUserRotationDegRef.current
+        const decay = Math.exp(-deltaMs / FLOORPLAN_VIEW_ANIMATION_TIME_CONSTANT_MS)
+        let nextDeg = targetDeg - (targetDeg - currentDeg) * decay
+        if (Math.abs(targetDeg - nextDeg) < 0.05) {
+          nextDeg = targetDeg
+        }
+        latestFloorplanUserRotationDegRef.current = nextDeg
+        if (compassNeedleRef.current) {
+          compassNeedleRef.current.style.transform = `rotate(${nextDeg}deg)`
+        }
+        if (nextDeg !== targetDeg) {
+          hiddenCompassAnimationRef.current = requestAnimationFrame(tick)
+        }
+      }
+      hiddenCompassAnimationRef.current = requestAnimationFrame(tick)
+    },
+    [cancelHiddenCompassAnimation],
+  )
+
   useEffect(() => {
-    return useEditor.subscribe((state) => {
+    const unsubscribe = useEditor.subscribe((state) => {
       const pose = state.navigationSyncPose
       if (!pose || latestNavigationSyncPoseRef.current?.revision === pose.revision) {
         return
@@ -6569,25 +6612,40 @@ export function FloorplanPanel({
 
       latestNavigationSyncPoseRef.current = pose
 
-      if (pose.source === '3d') {
-        if (!isFloorplanOpenRef.current) {
+      if (!isFloorplanOpenRef.current) {
+        const nextDeg = floorplanRotationFromCameraAzimuth(
+          pose.azimuth,
+          latestFloorplanUserRotationDegRef.current,
+        )
+        if (pose.source === '3d') {
           // Panel hidden — drive the compass needle imperatively without
           // triggering React state (setViewport) that would re-render the
-          // full floorplan SVG every camera frame.
-          const nextDeg = floorplanRotationFromCameraAzimuth(
-            pose.azimuth,
-            latestFloorplanUserRotationDegRef.current,
-          )
+          // full floorplan SVG every camera frame. The live camera stream
+          // owns the needle, so any local animation yields to it.
+          cancelHiddenCompassAnimation()
           latestFloorplanUserRotationDegRef.current = nextDeg
           if (compassNeedleRef.current) {
             compassNeedleRef.current.style.transform = `rotate(${nextDeg}deg)`
           }
-          return
+        } else {
+          animateHiddenCompassNeedle(nextDeg)
         }
+        return
+      }
+
+      if (pose.source === '3d') {
         syncFloorplanViewportToNavigationPose(pose)
       }
     })
-  }, [syncFloorplanViewportToNavigationPose])
+    return () => {
+      unsubscribe()
+      cancelHiddenCompassAnimation()
+    }
+  }, [
+    syncFloorplanViewportToNavigationPose,
+    animateHiddenCompassNeedle,
+    cancelHiddenCompassAnimation,
+  ])
 
   // When the panel is hidden the imperative path owns the compass needle.
   // React re-renders can overwrite the needle's inline transform with stale
@@ -7378,8 +7436,8 @@ export function FloorplanPanel({
   const alignFloorplanViewToNorth = useCallback(() => {
     if (!isFloorplanOpenRef.current) {
       // Panel hidden — derive from the live 3D camera pose and publish
-      // directly. The compass animates via the imperative subscription as
-      // the 3D camera transitions.
+      // directly. The pose subscription picks this '2d' pose up and animates
+      // the needle locally (the camera transition suppresses '3d' echoes).
       const pose = latestNavigationSyncPoseRef.current
       if (!pose) return
       const currentRotation = latestFloorplanUserRotationDegRef.current


### PR DESCRIPTION
## What does this PR do?

Fixes the compass needle staying frozen when clicking align-north while only the 3D view is visible (2D panel hidden). The hidden-panel align-north branch publishes a single `'2d'` navigation pose that the camera applies through the echo-suppressed pending-pose path — no `'3d'` poses ever flow back, so the needle subscription (which only reacted to `'3d'` poses) never moved it. In 2D and split view the open floorplan animates its own rotation, which is why those worked.

The fix drives the needle with a local rAF exponential-decay animation when a `'2d'` pose arrives while the panel is hidden, using the same 90 ms time constant as the 2D view animation and the camera's effective smoothTime, so camera and needle stay visually in step. A live `'3d'` pose (e.g. the user grabs the camera mid-transition) cancels the local animation and hands the needle back to the camera stream.

## How to test

1. `bun dev`, open a scene, and close the 2D floorplan panel so only the 3D view is visible.
2. Orbit the camera off-north, then click the compass. Expected: the camera rotates to north AND the needle animates smoothly to vertical in step with it.
3. Click the compass, then immediately drag to orbit mid-transition. Expected: the needle follows the live camera without snapping.
4. Regression: repeat align-north in split view and in 2D-only view — behavior unchanged (instant, in sync).

## Screenshots / screen recording

N/A — 15-second behavior fix; reviewer steps above reproduce it directly.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized floorplan/compass navigation-sync behavior with no security or data impact; split and 2D-only paths are unchanged when the panel is open.
> 
> **Overview**
> When the floorplan panel is closed, **align-north** only publishes a `'2d'` navigation pose (the camera moves without returning `'3d'` frames), so the compass needle no longer updates if the subscription only handled `'3d'` poses.
> 
> The hidden-panel branch now reacts to **both** pose sources: `'3d'` still drives the needle imperatively and **cancels** any in-flight local animation; `'2d'` triggers a **requestAnimationFrame** exponential-decay rotation on the needle (same **90 ms** time constant as the 2D view animation). Subscription cleanup cancels that animation on unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbcc7051739ecdac3c1a47df1a9069bab45a7e12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->