### PR TITLE
fix(mcp): keep store receiver bound in scene event operations

### DIFF
--- a/packages/mcp/src/operations/scene-operations.test.ts
+++ b/packages/mcp/src/operations/scene-operations.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type { SceneGraph } from '@pascal-app/core/clone-scene-graph'
+import { SqliteSceneStore } from '../storage/sqlite-scene-store'
+import { createSceneOperations } from './scene-operations'
+
+function makeGraph(): SceneGraph {
+  return {
+    nodes: {
+      site_abc: {
+        object: 'node',
+        id: 'site_abc',
+        type: 'site',
+        parentId: null,
+        visible: true,
+        metadata: {},
+      },
+    } as SceneGraph['nodes'],
+    rootNodeIds: ['site_abc'] as SceneGraph['rootNodeIds'],
+  }
+}
+
+describe('SceneOperationsFacade scene events', () => {
+  let rootDir: string
+  let store: SqliteSceneStore
+
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pascal-scene-ops-test-'))
+    store = new SqliteSceneStore({ databasePath: path.join(rootDir, 'pascal.db') })
+  })
+
+  afterEach(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true })
+  })
+
+  // Regression: appendSceneEvent/listSceneEvents were detached from the store
+  // before invocation, so `this` was undefined inside store methods that rely
+  // on it (e.g. SqliteSceneStore.withWriteTransaction).
+  test('appendSceneEvent and listSceneEvents preserve the store receiver', async () => {
+    const operations = createSceneOperations({ store })
+    const graph = makeGraph()
+    const meta = await store.save({ id: 'live', name: 'Live', graph })
+
+    const appended = await operations.appendSceneEvent({
+      sceneId: meta.id,
+      version: meta.version,
+      kind: 'save_scene',
+      graph,
+    })
+    expect(appended?.sceneId).toBe(meta.id)
+
+    const events = await operations.listSceneEvents(meta.id)
+    expect(events.map((event) => event.kind)).toEqual(['save_scene'])
+  })
+
+  test('appendSceneEvent returns null and listSceneEvents throws when the store lacks scene events', async () => {
+    const operations = createSceneOperations({
+      store: {
+        ...store,
+        backend: 'sqlite',
+        appendSceneEvent: undefined,
+        listSceneEvents: undefined,
+      } as never,
+    })
+
+    expect(
+      await operations.appendSceneEvent({
+        sceneId: 'live',
+        version: 1,
+        kind: 'save_scene',
+        graph: makeGraph(),
+      }),
+    ).toBeNull()
+    await expect(operations.listSceneEvents('live')).rejects.toThrow('scene_events_unavailable')
+  })
+})

--- a/packages/mcp/src/operations/scene-operations.test.ts
+++ b/packages/mcp/src/operations/scene-operations.test.ts
@@ -32,6 +32,7 @@ describe('SceneOperationsFacade scene events', () => {
   })
 
   afterEach(async () => {
+    store.close()
     await fs.rm(rootDir, { recursive: true, force: true })
   })
 

--- a/packages/mcp/src/operations/scene-operations.ts
+++ b/packages/mcp/src/operations/scene-operations.ts
@@ -296,17 +296,17 @@ class SceneOperationsFacade implements SceneOperations {
   }
 
   async appendSceneEvent(options: SceneEventAppendOptions): Promise<SceneEvent | null> {
-    const append = this.requireStore().appendSceneEvent
-    if (!append) return null
-    return append(options)
+    const store = this.requireStore()
+    if (!store.appendSceneEvent) return null
+    return store.appendSceneEvent(options)
   }
 
   async listSceneEvents(id: string, options?: SceneEventListOptions): Promise<SceneEvent[]> {
-    const list = this.requireStore().listSceneEvents
-    if (!list) {
+    const store = this.requireStore()
+    if (!store.listSceneEvents) {
       throw new Error('scene_events_unavailable')
     }
-    return list(id, options)
+    return store.listSceneEvents(id, options)
   }
 
   private requireBridge(): SceneBridge {


### PR DESCRIPTION
## Summary

`SceneOperationsFacade.appendSceneEvent` and `listSceneEvents` detached the store methods from the store instance before invoking them:

```ts
const append = this.requireStore().appendSceneEvent
if (!append) return null
return append(options) // `this` is undefined inside the store method
```

For store implementations that rely on `this` — `SqliteSceneStore` calls `this.withWriteTransaction(...)` inside `appendSceneEvent` — the detached call crashes with:

```
TypeError: undefined is not an object (evaluating 'this.withWriteTransaction')
```

Because the underlying SQLite write happens inside the transaction helper that never runs (append) or runs after the row insert (depending on path), every `save_scene`, `create_from_template`, and live-sync mutation routed through the MCP facade reported this error to the client even when the scene row itself had been persisted, making the MCP server unusable for headless scene building.

## Reproduction

Run any scene save through the `pascal-mcp` CLI under Bun (e.g. connect an MCP client and call `save_scene`, or any template/live-sync tool that appends scene events). The tool call returns `undefined is not an object (evaluating 'this.withWriteTransaction')`.

## Fix

Invoke the optional methods on the store instance so the receiver stays bound:

```ts
const store = this.requireStore()
if (!store.appendSceneEvent) return null
return store.appendSceneEvent(options)
```

Same change for `listSceneEvents`.

## Tests

Added `packages/mcp/src/operations/scene-operations.test.ts`:

- a facade-level regression test that appends/lists scene events through `createSceneOperations` backed by a real `SqliteSceneStore` — this fails with the exact `TypeError` above before the fix and passes after;
- a test covering the fallback behavior when the store does not implement scene events (`appendSceneEvent` → `null`, `listSceneEvents` → `scene_events_unavailable`).

`bun test` in `packages/mcp`: 295 pass, 0 fail. `bun check` reports no findings in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to method invocation plus tests; no auth, schema, or API contract changes beyond restoring intended behavior.
> 
> **Overview**
> Fixes a **receiver binding bug** in `SceneOperationsFacade` where `appendSceneEvent` and `listSceneEvents` copied store methods to locals and called them unbound, breaking `SqliteSceneStore` (which uses `this.withWriteTransaction`).
> 
> The facade now calls **`store.appendSceneEvent(options)`** and **`store.listSceneEvents(id, options)`** on the store instance so `this` stays correct. Behavior when the store omits those methods is unchanged (`null` / `scene_events_unavailable`).
> 
> Adds **`scene-operations.test.ts`** with a regression test against a real `SqliteSceneStore` plus coverage for stores without scene-event APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d7b3d4e66803bdea17d2d5f561487164f31cddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->