### PR TITLE
editor: default sidebar to build tab, drop to select on panel close

### DIFF
--- a/packages/editor/src/components/editor/editor-layout-mobile.tsx
+++ b/packages/editor/src/components/editor/editor-layout-mobile.tsx
@@ -159,6 +159,11 @@ export function EditorLayoutMobile({
       const expandedThreshold = Math.max(SHEET_HANDLE_PX, defaultPx * 0.5)
       if (current > expandedThreshold) {
         sheetRef.current?.snapTo(SHEET_HANDLE_PX)
+        // Closing the sheet disarms any build tool back to select
+        const { mode, setMode } = useEditor.getState()
+        if (mode === 'build') {
+          setMode('select')
+        }
       } else {
         sheetRef.current?.snapTo(defaultPx)
       }

--- a/packages/editor/src/components/editor/editor-layout-v2.tsx
+++ b/packages/editor/src/components/editor/editor-layout-v2.tsx
@@ -52,6 +52,15 @@ function LeftColumn({
     }
   }, [activePanel])
 
+  // Closing (collapsing) the sidebar disarms any build tool back to select
+  useEffect(() => {
+    if (!isCollapsed) return
+    const { mode, setMode } = useEditor.getState()
+    if (mode === 'build') {
+      setMode('select')
+    }
+  }, [isCollapsed])
+
   const handleResizerDown = useCallback(
     (e: React.PointerEvent) => {
       e.preventDefault()

--- a/packages/editor/src/store/use-editor.tsx
+++ b/packages/editor/src/store/use-editor.tsx
@@ -66,7 +66,7 @@ import {
 } from '../lib/snapping-mode'
 import useInteractionScope from './use-interaction-scope'
 
-const DEFAULT_ACTIVE_SIDEBAR_PANEL = 'ai'
+const DEFAULT_ACTIVE_SIDEBAR_PANEL = 'build'
 const DEFAULT_FLOORPLAN_PANE_RATIO = 0.5
 const MIN_FLOORPLAN_PANE_RATIO = 0.15
 const MAX_FLOORPLAN_PANE_RATIO = 0.85


### PR DESCRIPTION
## What does this PR do?

Two sidebar-behavior fixes:

- **Build tab is the default panel** when opening a project (was the AI/chat tab). `DEFAULT_ACTIVE_SIDEBAR_PANEL` is persisted, so browsers that already stored `'ai'` keep it until the user switches tabs once; fresh sessions land on Build.
- **Closing the sidebar drops back to select mode.** Collapsing the panel (rail click or drag-collapse on desktop, sheet close on mobile) previously left the last build tool armed — the cursor kept placing walls/items with the panel closed. Both collapse paths now reset `mode: 'build'` → `'select'` (which also clears the tool).

## How to test

1. `bun dev`, open a project in a fresh browser profile (or clear the `pascal-editor-ui-preferences` localStorage key) — the **Build** tab is open and the wall tool is armed.
2. Click the Build rail icon to collapse the sidebar — the build tool disarms and the editor is in select mode (click elements to select; no placement ghost follows the cursor).
3. Reopen the Build tab — the first build tool re-arms. Drag the sidebar edge below the collapse threshold — same reset to select.
4. On a mobile viewport, tap the active tab to close the sheet — same reset.

## Screenshots / screen recording

N/A — interaction change; behavior is covered by the steps above (verified end-to-end with Playwright against the community host app: store reads `{activeSidebarPanel: 'build', mode: 'build', tool: 'wall'}` on open, `{mode: 'select', tool: null}` after collapse).

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor UI and mode state only; no persistence schema changes beyond the default for new layout prefs.
> 
> **Overview**
> **Opens the Build sidebar by default** instead of AI/chat by changing `DEFAULT_ACTIVE_SIDEBAR_PANEL` to `'build'`. Sessions with no saved preference land on Build; existing `localStorage` values (e.g. `'ai'`) are unchanged until the user picks another tab.
> 
> **Resets build mode when the sidebar is hidden** so placement tools do not stay armed with the panel closed. Desktop collapses (rail re-click or drag below threshold) run a `useEffect` on `isCollapsed` that calls `setMode('select')` when `mode === 'build'`. Mobile does the same when the bottom sheet is toggled closed on the active tab. Leaving build mode still clears the active tool via existing `setMode` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9b9889e00e3fc8b59c5869f1b919bbd2b17370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->