### PR TITLE
Adjustments pass: three 0.185, undo/cancel semantics, guide & panel fixes

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -32,7 +32,7 @@
     "react-dom": "^19.2.4",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
-    "three": "^0.184.0",
+    "three": "^0.185.0",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/apps/ifc-converter/next-env.d.ts
+++ b/apps/ifc-converter/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/ifc-converter/package.json
+++ b/apps/ifc-converter/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^19.2.4",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
-    "three": "^0.184.0",
+    "three": "^0.185.0",
     "web-ifc": "^0.0.77",
     "zod": "^4.3.5"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "react-dom": "^19.2.4",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1",
-        "three": "^0.184.0",
+        "three": "^0.185.0",
         "zod": "^4.3.5",
       },
       "devDependencies": {
@@ -83,7 +83,7 @@
         "react-dom": "^19.2.4",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1",
-        "three": "^0.184.0",
+        "three": "^0.185.0",
         "web-ifc": "^0.0.77",
         "zod": "^4.3.5",
       },
@@ -119,7 +119,7 @@
         "@react-three/drei": "^10",
         "@react-three/fiber": "^9",
         "react": "^18 || ^19",
-        "three": "^0.184",
+        "three": "^0.185",
       },
     },
     "packages/editor": {
@@ -179,7 +179,7 @@
         "next": ">=15",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
-        "three": "^0.184",
+        "three": "^0.185",
       },
     },
     "packages/eslint-config": {
@@ -256,7 +256,7 @@
         "@react-three/fiber": "^9",
         "lucide-react": "^1",
         "react": "^18 || ^19",
-        "three": "^0.184",
+        "three": "^0.185",
         "zustand": "^5",
       },
     },
@@ -276,7 +276,7 @@
         "@types/react": "^19.2.2",
         "@types/three": "^0.184.0",
         "react": "^19",
-        "three": "^0.184",
+        "three": "^0.185",
         "typescript": "6.0.3",
         "zod": "^4",
         "zustand": "^5",
@@ -287,7 +287,7 @@
         "@pascal-app/viewer": "*",
         "@react-three/fiber": "^9",
         "react": "^18 || ^19",
-        "three": "^0.184",
+        "three": "^0.185",
         "zod": "^4",
         "zustand": "^5",
       },
@@ -333,7 +333,7 @@
         "@react-three/drei": "^10",
         "@react-three/fiber": "^9",
         "react": "^18 || ^19",
-        "three": "^0.184",
+        "three": "^0.185",
       },
     },
     "tooling/typescript": {
@@ -345,7 +345,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "0.184.1",
-    "three": "0.184.0",
+    "three": "0.185.1",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -1816,7 +1816,7 @@
 
     "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
 
-    "three": ["three@0.184.0", "", {}, "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="],
+    "three": ["three@0.185.1", "", {}, "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg=="],
 
     "three-bvh-csg": ["three-bvh-csg@0.0.18", "", { "peerDependencies": { "three": ">=0.179.0", "three-mesh-bvh": ">=0.9.7" } }, "sha512-M3GCZMmGFgASGuDf+YMamM83nVlD/vdwzVHcYbFxgW+g1S7/nKPiuY00YVHOMbjmJPh8mLevGZL65ItHUuGt2w=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/three": "0.184.1",
-    "three": "0.184.0"
+    "three": "0.185.1"
   },
   "optionalDependencies": {
     "@tailwindcss/oxide-darwin-arm64": "4.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
     "@react-three/drei": "^10",
     "@react-three/fiber": "^9",
     "react": "^18 || ^19",
-    "three": "^0.184"
+    "three": "^0.185"
   },
   "dependencies": {
     "dedent": "^1.7.1",

--- a/packages/core/src/store/use-scene.ts
+++ b/packages/core/src/store/use-scene.ts
@@ -1066,14 +1066,6 @@ const useScene: UseSceneStore = create<SceneState>()(
           }
         }
 
-        set({
-          nodes: cleanedNodes,
-          rootNodeIds,
-          dirtyNodes: new Set<AnyNodeId>(),
-          collections: extra?.collections ?? {},
-          materials,
-        })
-
         const normalizedRootNodeIds = normalizeRootNodeIds(cleanedNodes, rootNodeIds)
         const reachableNodeIds = collectReachableNodeIds(cleanedNodes, normalizedRootNodeIds)
         if (normalizedRootNodeIds.length > 0) {
@@ -1084,6 +1076,10 @@ const useScene: UseSceneStore = create<SceneState>()(
           }
         }
 
+        // Single tracked `set`: with zundo, every tracked write pushes the
+        // pre-write state onto `pastStates`. Writing the scene in two steps
+        // (as this used to) exposed a half-normalized intermediate state —
+        // and the pre-load (possibly empty) state — as undo targets.
         set({
           nodes: cleanedNodes,
           rootNodeIds: normalizedRootNodeIds,
@@ -1296,6 +1292,12 @@ let prevNodesSnapshot: Record<AnyNodeId, AnyNode> | null = null
 
 export function clearSceneHistory() {
   resetSceneHistoryPauseDepth()
+  // Resetting the pause-depth counter without resuming would strand the
+  // temporal store in `isTracking: false` if a pause window was active when
+  // the scene was (re)loaded — every edit after the load would then be
+  // invisible to undo. Resume unconditionally so the cleared history starts
+  // tracking from the loaded baseline.
+  useScene.temporal.getState().resume()
   useScene.temporal.getState().clear()
   prevPastLength = 0
   prevFutureLength = 0

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -18,7 +18,7 @@
     "next": ">=15",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19",
-    "three": "^0.184"
+    "three": "^0.185"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/editor/src/components/editor-2d/floorplan-group-move.tsx
+++ b/packages/editor/src/components/editor-2d/floorplan-group-move.tsx
@@ -21,6 +21,7 @@ import { create } from 'zustand'
 import { GROUP_MOVE_DRAG_LABEL, GROUP_ROTATE_DRAG_LABEL } from '../../lib/contextual-help'
 import { applyFloorplanAlignment } from '../../lib/floorplan/apply-alignment'
 import { clientToPlan } from '../../lib/floorplan/plan-coords'
+import { isHistoryShortcut } from '../../lib/history'
 import { sfxEmitter } from '../../lib/sfx-bus'
 import useAlignmentGuides from '../../store/use-alignment-guides'
 import useEditor, {
@@ -363,7 +364,8 @@ export function startFloorplanGroupMove(
       cancel()
       return
     }
-    if (e.key !== 'Escape') return
+    // ⌘Z mid-gesture cancels like Escape — never a history jump under a live pointer.
+    if (e.key !== 'Escape' && !isHistoryShortcut(e)) return
     e.preventDefault()
     e.stopPropagation()
     swallowNextClick()
@@ -536,7 +538,8 @@ export function startFloorplanGroupRotate(event: {
       cancel()
       return
     }
-    if (e.key !== 'Escape') return
+    // ⌘Z mid-gesture cancels like Escape — never a history jump under a live pointer.
+    if (e.key !== 'Escape' && !isHistoryShortcut(e)) return
     e.preventDefault()
     e.stopPropagation()
     swallowNextClick()

--- a/packages/editor/src/components/editor-2d/floorplan-registry-move-overlay.tsx
+++ b/packages/editor/src/components/editor-2d/floorplan-registry-move-overlay.tsx
@@ -18,6 +18,7 @@ import {
 import { useViewer } from '@pascal-app/viewer'
 import { useEffect } from 'react'
 import { commitFreshPlacementSubtree } from '../../lib/fresh-planar-placement'
+import { isHistoryShortcut } from '../../lib/history'
 import { isFreshPlacementMetadata, stripPlacementMetadataFlags } from '../../lib/placement-metadata'
 import { resolvePlanarCursorPosition } from '../../lib/planar-cursor-placement'
 import { movementSfxStepKey } from '../../lib/sfx/movement-tick'
@@ -358,7 +359,13 @@ export function FloorplanRegistryMoveOverlay() {
           sfxEmitter.emit('sfx:item-rotate')
           return
         }
-        if (event.key !== 'Escape') return
+        if (event.key !== 'Escape' && !isHistoryShortcut(event)) return
+        if (isHistoryShortcut(event)) {
+          // ⌘Z mid-move cancels like Escape — keep it from reaching the
+          // global undo arm (this handler is capture-phase, that one bubbles).
+          event.preventDefault()
+          event.stopImmediatePropagation()
+        }
         // Claim teardown ownership so the 3D move tool's cleanup skips
         // its own restore — without this, both sides would race to
         // write the same baseline, harmless but wasteful.
@@ -701,31 +708,36 @@ export function FloorplanRegistryMoveOverlay() {
     }
 
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setMovingNodeOrigin('2d')
-        if (isFreshPlacement) {
-          emitter.emit('tool:cancel')
-          const temporal = useScene.temporal.getState()
-          const wasTracking = (temporal as { isTracking?: boolean }).isTracking !== false
-          if (wasTracking) temporal.pause()
-          useScene.getState().deleteNode(movingNode.id as AnyNodeId)
-          if (wasTracking) temporal.resume()
-        }
-        for (const relatedEntry of relatedEntries) {
-          relatedEntry.removeAttribute('transform')
-        }
-        useAlignmentGuides.getState().clear()
-        setMovingNode(null)
+      if (event.key !== 'Escape' && !isHistoryShortcut(event)) return
+      if (isHistoryShortcut(event)) {
+        // ⌘Z mid-move cancels like Escape — keep it from reaching the
+        // global undo arm (this handler is capture-phase, that one bubbles).
+        event.preventDefault()
+        event.stopImmediatePropagation()
       }
+      setMovingNodeOrigin('2d')
+      if (isFreshPlacement) {
+        emitter.emit('tool:cancel')
+        const temporal = useScene.temporal.getState()
+        const wasTracking = (temporal as { isTracking?: boolean }).isTracking !== false
+        if (wasTracking) temporal.pause()
+        useScene.getState().deleteNode(movingNode.id as AnyNodeId)
+        if (wasTracking) temporal.resume()
+      }
+      for (const relatedEntry of relatedEntries) {
+        relatedEntry.removeAttribute('transform')
+      }
+      useAlignmentGuides.getState().clear()
+      setMovingNode(null)
     }
 
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onPointerUp)
-    window.addEventListener('keydown', onKey)
+    window.addEventListener('keydown', onKey, true)
     return () => {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onPointerUp)
-      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('keydown', onKey, true)
       for (const relatedEntry of relatedEntries) {
         relatedEntry.removeAttribute('transform')
       }

--- a/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
+++ b/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
@@ -2999,14 +2999,17 @@ const ROTATION_WEDGE_SEGMENTS = 48
  * is in plan coords; the chip counter-rotates `sceneRotationDeg` so it reads
  * horizontally regardless of the building's on-screen orientation.
  */
-function RotationAngleOverlay({
+export function RotationAngleOverlay({
   overlay,
   palette,
   unitsPerPixel,
   sceneRotationDeg,
 }: {
   overlay: RotationOverlayState
-  palette: FloorplanPalette
+  palette: Pick<
+    FloorplanPalette,
+    'measurementLabelBackground' | 'measurementLabelText' | 'measurementStroke'
+  >
   unitsPerPixel: number
   sceneRotationDeg: number
 }): React.ReactElement {

--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -3224,18 +3224,17 @@ function FloorplanGuideImage({
           }}
           onPointerDown={(event) => {
             if (event.button === 0) {
-              // A locked guide never starts a drag, so let the pointer-down
-              // bubble to the <svg> root — box select then arms exactly as on
-              // empty canvas. A non-drag release still fires onClick (a
-              // committed box-select drag swallows the trailing click), so
-              // click-to-select → panel → unlock keeps working.
-              if (isLocked) {
+              // Only a selected, unlocked guide consumes the pointer-down (it
+              // starts a translate drag). Every other guide lets it bubble to
+              // the <svg> root so box select arms exactly as on empty canvas.
+              // A non-drag release still fires onClick (a committed box-select
+              // drag swallows the trailing click), so click-to-select → panel
+              // keeps working for locked and unselected guides alike.
+              if (isLocked || !isSelected) {
                 return
               }
               event.stopPropagation()
-              if (isSelected) {
-                onGuideTranslateStart(guide, event)
-              }
+              onGuideTranslateStart(guide, event)
             }
           }}
           pointerEvents="all"

--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -3149,8 +3149,16 @@ function FloorplanGuideImage({
           }}
           onPointerDown={(event) => {
             if (event.button === 0) {
+              // A locked guide never starts a drag, so let the pointer-down
+              // bubble to the <svg> root — box select then arms exactly as on
+              // empty canvas. A non-drag release still fires onClick (a
+              // committed box-select drag swallows the trailing click), so
+              // click-to-select → panel → unlock keeps working.
+              if (isLocked) {
+                return
+              }
               event.stopPropagation()
-              if (isSelected && !isLocked) {
+              if (isSelected) {
                 onGuideTranslateStart(guide, event)
               }
             }

--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -126,7 +126,10 @@ import { FloorplanDraftLayer } from '../editor-2d/renderers/floorplan-draft-laye
 import { FloorplanGeometryRenderer } from '../editor-2d/renderers/floorplan-geometry-renderer'
 import { FloorplanMarqueeLayer } from '../editor-2d/renderers/floorplan-marquee-layer'
 import { FloorplanPlacementPreviewLayer } from '../editor-2d/renderers/floorplan-placement-preview-layer'
-import { FloorplanRegistryLayer } from '../editor-2d/renderers/floorplan-registry-layer'
+import {
+  FloorplanRegistryLayer,
+  RotationAngleOverlay,
+} from '../editor-2d/renderers/floorplan-registry-layer'
 import { FloorplanStairLayer } from '../editor-2d/renderers/floorplan-stair-layer'
 import { FloorplanVoronoiLayer } from '../editor-2d/renderers/floorplan-voronoi-layer'
 import { buildSvgPolylinePath, formatPolygonPath, getArcPlanPoint } from '../editor-2d/svg-paths'
@@ -1409,6 +1412,44 @@ function buildGuideRotationDraft(
     position: toPlanPointFromSvgPoint(interaction.centerSvg),
     scale: interaction.scale,
     rotation: getGuideSceneRotationFromSvgRotation(snappedRotationSvg),
+  }
+}
+
+/** Live rotation readout for a guide rotate drag — feeds the registry
+ *  layer's wedge + degree chip so guides read the same as every other
+ *  rotate affordance. Sweeps from the grabbed corner's bearing at grab to
+ *  its current (snapped) bearing; suppressed below ~0.5° so a fresh grab
+ *  doesn't flash a zero-width sliver. */
+function buildGuideRotationReadout(
+  interaction: GuideInteractionState | null,
+  draft: GuideTransformDraft | null,
+) {
+  if (
+    !(
+      interaction &&
+      draft &&
+      interaction.mode === 'rotate' &&
+      draft.guideId === interaction.guideId
+    )
+  ) {
+    return null
+  }
+
+  const delta = normalizeAngle(getGuideSvgRotation(draft.rotation) - interaction.rotationSvg)
+  if (Math.abs(delta) < 0.0087) {
+    return null
+  }
+
+  const width = getGuideWidth(interaction.scale)
+  const height = getGuideHeight(width, interaction.aspectRatio)
+  const startAngle = interaction.rotationSvg + interaction.cornerBaseAngle
+
+  return {
+    pivot: [interaction.centerSvg.x, interaction.centerSvg.y] as const,
+    startAngle,
+    endAngle: startAngle + delta,
+    radius: Math.hypot(width, height) / 2,
+    sweep: Math.abs(delta),
   }
 }
 
@@ -5625,6 +5666,10 @@ export function FloorplanPanel({
   const activeGuideInteractionMode = guideTransformDraft
     ? (guideInteractionRef.current?.mode ?? null)
     : null
+  const guideRotationReadout = buildGuideRotationReadout(
+    guideInteractionRef.current,
+    guideTransformDraft,
+  )
   const floorplanWalls = useMemo(() => walls.map(getFloorplanWall), [walls])
   const wallMiterData = useMemo(() => calculateLevelMiters(floorplanWalls), [floorplanWalls])
   const wallById = useMemo(() => new Map(walls.map((wall) => [wall.id, wall] as const)), [walls])
@@ -11391,6 +11436,19 @@ export function FloorplanPanel({
                   rotationModifierPressed={rotationModifierPressed}
                   sceneRotationDeg={floorplanSceneRotationDeg}
                   showHandles={canInteractWithGuides && guideUi[selectedGuide.id]?.locked !== true}
+                />
+              )}
+
+              {guideRotationReadout && (
+                <RotationAngleOverlay
+                  overlay={guideRotationReadout}
+                  palette={{
+                    measurementLabelBackground: isDark ? '#0f172a' : '#ffffff',
+                    measurementLabelText: isDark ? '#e2e8f0' : '#171717',
+                    measurementStroke: palette.measurementStroke,
+                  }}
+                  sceneRotationDeg={floorplanSceneRotationDeg}
+                  unitsPerPixel={floorplanUnitsPerPixel}
                 />
               )}
 

--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -86,6 +86,7 @@ import {
   worldToFloorplanLocalPoint,
 } from '../../lib/floorplan'
 import { guideEmitter } from '../../lib/guide-events'
+import { measurementHint, parseMeasurement } from '../../lib/measurement-parser'
 import { formatLinearMeasurement, linearUnitToMeters } from '../../lib/measurements'
 import { sfxEmitter } from '../../lib/sfx-bus'
 import { SITE_BOUNDARY_DRAG_LABEL } from '../../lib/site-boundary'
@@ -2734,6 +2735,39 @@ function convertReferenceLengthToMeters(value: number, unit: ReferenceScaleUnit)
     default:
       return value
   }
+}
+
+const REFERENCE_SCALE_LINGO_UNIT: Record<ReferenceScaleUnit, 'm' | 'cm' | 'ft' | 'in'> = {
+  meters: 'm',
+  centimeters: 'cm',
+  feet: 'ft',
+  inches: 'in',
+}
+
+/** Lingo-parse the free-text real-length input in the dropdown's unit — a
+ * bare number means the dropdown unit, while `180cm`, `1m80` or `5'11"`
+ * override it. Returns `null` when the text isn't a readable length. */
+function parseReferenceScaleLength(raw: string, unit: ReferenceScaleUnit): number | null {
+  const unitId = REFERENCE_SCALE_LINGO_UNIT[unit]
+  return parseMeasurement(
+    raw,
+    { kind: 'length', unitId },
+    { bareUnit: unitId, system: unit === 'feet' || unit === 'inches' ? 'us' : 'metric' },
+  )
+}
+
+function referenceScaleLengthHint(raw: string, unit: ReferenceScaleUnit): string | null {
+  const unitId = REFERENCE_SCALE_LINGO_UNIT[unit]
+  return measurementHint(
+    raw,
+    { kind: 'length', unitId },
+    {
+      bareUnit: unitId,
+      system: unit === 'feet' || unit === 'inches' ? 'us' : 'metric',
+      displayUnit: unitId,
+      precision: 2,
+    },
+  )
 }
 
 function getReferenceScaleUnitLabel(unit: ReferenceScaleUnit) {
@@ -7292,8 +7326,8 @@ export function FloorplanPanel({
       return
     }
 
-    const displayLength = Number(referenceScaleValue)
-    if (!(displayLength > 0)) {
+    const displayLength = parseReferenceScaleLength(referenceScaleValue, referenceScaleUnit)
+    if (!(displayLength && displayLength > 0)) {
       return
     }
 
@@ -10926,7 +10960,8 @@ export function FloorplanPanel({
   const floorplanNavigationCursor =
     isPanning || isRotatingFloorplan ? 'grabbing' : isSpacePanPressed ? 'grab' : null
   const isFloorplanNavigationOverlayVisible = isSpacePanPressed || isPanning || isRotatingFloorplan
-  const pendingReferenceDisplayLength = Number(referenceScaleValue)
+  const pendingReferenceDisplayLength =
+    parseReferenceScaleLength(referenceScaleValue, referenceScaleUnit) ?? Number.NaN
   const pendingReferenceRealLengthMeters =
     pendingReferenceScale && pendingReferenceDisplayLength > 0
       ? convertReferenceLengthToMeters(pendingReferenceDisplayLength, referenceScaleUnit)
@@ -10942,9 +10977,14 @@ export function FloorplanPanel({
   const referenceScaleInputError =
     referenceScaleValue.trim() === ''
       ? 'Enter the real length of the line.'
-      : pendingReferenceDisplayLength > 0
-        ? null
-        : 'Length must be greater than 0.'
+      : Number.isNaN(pendingReferenceDisplayLength)
+        ? `Enter a length like 3.5, 180cm or 5'11".`
+        : pendingReferenceDisplayLength > 0
+          ? null
+          : 'Length must be greater than 0.'
+  const referenceScaleHint = referenceScaleInputError
+    ? null
+    : referenceScaleLengthHint(referenceScaleValue, referenceScaleUnit)
   return (
     <div
       className="pointer-events-auto flex h-full w-full flex-col overflow-hidden bg-background/95"
@@ -11058,16 +11098,9 @@ export function FloorplanPanel({
                     'h-9 rounded-lg border bg-background px-3 text-sm outline-none transition focus:border-foreground/40',
                     referenceScaleInputError ? 'border-destructive/60' : 'border-border',
                   )}
-                  inputMode="decimal"
-                  onBlur={() => {
-                    const value = Number(referenceScaleValue)
-                    if (!(value > 0)) {
-                      setReferenceScaleValue('0.0001')
-                    }
-                  }}
                   onChange={(event) => setReferenceScaleValue(event.target.value)}
-                  step="any"
-                  type="number"
+                  placeholder={`e.g. 3.5, 180cm or 5'11"`}
+                  type="text"
                   value={referenceScaleValue}
                 />
                 <select
@@ -11090,6 +11123,7 @@ export function FloorplanPanel({
                 )}
               >
                 {referenceScaleInputError ??
+                  referenceScaleHint ??
                   'Any decimal works. Use the known real length, not the drawn value.'}
               </span>
             </label>

--- a/packages/editor/src/components/editor/group-move-3d.ts
+++ b/packages/editor/src/components/editor/group-move-3d.ts
@@ -15,6 +15,7 @@ import {
 import { useViewer } from '@pascal-app/viewer'
 import { type Camera, Plane, type Raycaster, Vector2, Vector3 } from 'three'
 import { GROUP_MOVE_DRAG_LABEL } from '../../lib/contextual-help'
+import { isHistoryShortcut } from '../../lib/history'
 import { sfxEmitter } from '../../lib/sfx-bus'
 import useAlignmentGuides from '../../store/use-alignment-guides'
 import useEditor, {
@@ -380,7 +381,8 @@ export function armGroupMove3d(args: {
       cancel()
       return
     }
-    if (e.key !== 'Escape') return
+    // ⌘Z mid-move cancels like Escape — never a history jump under a live pointer.
+    if (e.key !== 'Escape' && !isHistoryShortcut(e)) return
     e.preventDefault()
     e.stopPropagation()
     swallowNextClick()

--- a/packages/editor/src/components/editor/group-rotate-handle.tsx
+++ b/packages/editor/src/components/editor/group-rotate-handle.tsx
@@ -15,6 +15,7 @@ import { createPortal, type ThreeEvent, useThree } from '@react-three/fiber'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { OrthographicCamera, Plane, Vector2, Vector3 } from 'three'
 import { GROUP_MOVE_DRAG_LABEL, GROUP_ROTATE_DRAG_LABEL } from '../../lib/contextual-help'
+import { isHistoryShortcut } from '../../lib/history'
 import { sfxEmitter } from '../../lib/sfx-bus'
 import useEditor from '../../store/use-editor'
 import useInteractionScope, {
@@ -301,6 +302,7 @@ function GroupRotateHandleInner({ ids, meshEpoch }: { ids: string[]; meshEpoch: 
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       window.removeEventListener('pointercancel', onCancel)
+      window.removeEventListener('keydown', onKeyDown, true)
       if (document.body.style.cursor === 'grabbing') document.body.style.cursor = ''
       useScene.temporal.getState().resume()
       useViewer.getState().setInputDragging(false)
@@ -347,6 +349,16 @@ function GroupRotateHandleInner({ ids, meshEpoch }: { ids: string[]; meshEpoch: 
       cleanup()
     }
 
+    // Escape / ⌘Z abort the rotate — capture phase so they win over the global
+    // use-keyboard arms (⌘Z must never history-jump under a live pointer).
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' && !isHistoryShortcut(e)) return
+      e.preventDefault()
+      e.stopPropagation()
+      swallowNextClick()
+      onCancel()
+    }
+
     dragCleanupRef.current = () => {
       clearLivePreviews()
       cleanup()
@@ -357,6 +369,7 @@ function GroupRotateHandleInner({ ids, meshEpoch }: { ids: string[]; meshEpoch: 
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
     window.addEventListener('pointercancel', onCancel)
+    window.addEventListener('keydown', onKeyDown, true)
   }
 
   return createPortal(

--- a/packages/editor/src/components/editor/group-rotate-handle.tsx
+++ b/packages/editor/src/components/editor/group-rotate-handle.tsx
@@ -159,6 +159,7 @@ function GroupRotateHandleInner({ ids, meshEpoch }: { ids: string[]; meshEpoch: 
   }
 
   const activate = (event: ThreeEvent<PointerEvent>) => {
+    if (event.button !== 0) return
     event.stopPropagation()
     suppressBoxSelectForPointer(event)
 

--- a/packages/editor/src/components/editor/handles/use-handle-drag.ts
+++ b/packages/editor/src/components/editor/handles/use-handle-drag.ts
@@ -110,6 +110,9 @@ export function useHandleDrag(args: UseHandleDragArgs) {
   useEffect(() => () => dragCleanupRef.current?.(), [])
 
   return (event: ThreeEvent<PointerEvent>) => {
+    // Only the primary button starts a handle gesture — right/middle-drag
+    // belongs to the camera, so let it propagate untouched.
+    if (event.button !== 0) return
     event.stopPropagation()
     suppressBoxSelectForPointer(event)
 

--- a/packages/editor/src/components/editor/handles/use-handle-drag.ts
+++ b/packages/editor/src/components/editor/handles/use-handle-drag.ts
@@ -12,6 +12,7 @@ import { useViewer } from '@pascal-app/viewer'
 import { type ThreeEvent, useThree } from '@react-three/fiber'
 import { useEffect, useRef } from 'react'
 import { type Camera, type Object3D, type Plane, type Ray, Vector2, type Vector3 } from 'three'
+import { isHistoryShortcut } from '../../../lib/history'
 import { sfxEmitter } from '../../../lib/sfx-bus'
 import { suppressBoxSelectForPointer } from '../../tools/select/box-select-state'
 
@@ -188,6 +189,7 @@ export function useHandleDrag(args: UseHandleDragArgs) {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       window.removeEventListener('pointercancel', onCancel)
+      window.removeEventListener('keydown', onKeyDown, true)
       if (document.body.style.cursor === cursor) {
         document.body.style.cursor = ''
       }
@@ -225,9 +227,20 @@ export function useHandleDrag(args: UseHandleDragArgs) {
       cleanup()
     }
 
+    // Escape / ⌘Z abort the drag — capture phase so they win over the global
+    // use-keyboard arms (⌘Z must never history-jump under a live pointer).
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' && !isHistoryShortcut(e)) return
+      e.preventDefault()
+      e.stopPropagation()
+      swallowNextClick()
+      onCancel()
+    }
+
     dragCleanupRef.current = cleanup
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
     window.addEventListener('pointercancel', onCancel)
+    window.addEventListener('keydown', onKeyDown, true)
   }
 }

--- a/packages/editor/src/components/editor/thumbnail-generator.tsx
+++ b/packages/editor/src/components/editor/thumbnail-generator.tsx
@@ -7,8 +7,10 @@ import {
   GRID_LAYER,
   getSceneTheme,
   horizonHazeColor,
+  packNormalToRGB,
   SSGI_PARAMS,
   snapLevelsToTruePositions,
+  unpackRGBToNormal,
   useViewer,
 } from '@pascal-app/viewer'
 import type { CameraControls } from '@react-three/drei'
@@ -20,10 +22,8 @@ import { ssgi } from 'three/addons/tsl/display/SSGINode.js'
 import { denoise } from 'three/examples/jsm/tsl/display/DenoiseNode.js'
 import { fxaa } from 'three/examples/jsm/tsl/display/FXAANode.js'
 import {
-  colorToDirection,
   convertToTexture,
   diffuseColor,
-  directionToColor,
   float,
   mix,
   mrt,
@@ -105,7 +105,7 @@ export const ThumbnailGenerator = ({ onThumbnailCapture }: ThumbnailGeneratorPro
           mrt({
             output,
             diffuseColor,
-            normal: directionToColor(normalView),
+            normal: packNormalToRGB(normalView),
           }),
         )
 
@@ -116,7 +116,7 @@ export const ThumbnailGenerator = ({ onThumbnailCapture }: ThumbnailGeneratorPro
         scenePass.getTexture('diffuseColor').type = UnsignedByteType
         scenePass.getTexture('normal').type = UnsignedByteType
 
-        const sceneNormal = sample((uv) => colorToDirection(scenePassNormal.sample(uv)))
+        const sceneNormal = sample((uv) => unpackRGBToNormal(scenePassNormal.sample(uv)))
 
         const giPass = ssgi(scenePassColor, scenePassDepth, sceneNormal, cam as any)
         giPass.sliceCount.value = SSGI_PARAMS.sliceCount
@@ -131,8 +131,10 @@ export const ThumbnailGenerator = ({ onThumbnailCapture }: ThumbnailGeneratorPro
         giPass.useScreenSpaceSampling.value = SSGI_PARAMS.useScreenSpaceSampling
         giPass.useTemporalFiltering = SSGI_PARAMS.useTemporalFiltering
 
-        const giTexture = (giPass as any).getTextureNode()
-        const aoAsRgb = vec4(giTexture.a, giTexture.a, giTexture.a, float(1))
+        // r185: SSGI's AO lives in its own single-channel texture (getAONode)
+        // rather than the alpha of one packed rgba texture.
+        const aoTexture = (giPass as any).getAONode()
+        const aoAsRgb = vec4(aoTexture.r, aoTexture.r, aoTexture.r, float(1))
         const denoisePass = denoise(aoAsRgb, scenePassDepth, sceneNormal, cam)
         denoisePass.index.value = 0
         denoisePass.radius.value = 4

--- a/packages/editor/src/components/editor/wall-move-side-handles.tsx
+++ b/packages/editor/src/components/editor/wall-move-side-handles.tsx
@@ -32,6 +32,7 @@ import {
 } from 'three'
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
 import { MeshBasicNodeMaterial } from 'three/webgpu'
+import { isHistoryShortcut } from '../../lib/history'
 import { endpointReshapeScope } from '../../lib/interaction/scope'
 import { sfxEmitter } from '../../lib/sfx-bus'
 import useEditor from '../../store/use-editor'
@@ -498,6 +499,7 @@ function WallHeightArrowHandle({ wall }: { wall: WallNode }) {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       window.removeEventListener('pointercancel', onCancel)
+      window.removeEventListener('keydown', onKeyDown, true)
       if (document.body.style.cursor === 'ns-resize') {
         document.body.style.cursor = ''
       }
@@ -527,10 +529,21 @@ function WallHeightArrowHandle({ wall }: { wall: WallNode }) {
       cleanup()
     }
 
+    // Escape / ⌘Z abort the drag — capture phase so they win over the global
+    // use-keyboard arms (⌘Z must never history-jump under a live pointer).
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' && !isHistoryShortcut(e)) return
+      e.preventDefault()
+      e.stopPropagation()
+      swallowNextClick()
+      onCancel()
+    }
+
     dragCleanupRef.current = cleanup
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
     window.addEventListener('pointercancel', onCancel)
+    window.addEventListener('keydown', onKeyDown, true)
   }
 
   return (

--- a/packages/editor/src/components/editor/wall-move-side-handles.tsx
+++ b/packages/editor/src/components/editor/wall-move-side-handles.tsx
@@ -331,6 +331,7 @@ function WallCornerLeaderHandle({ wall, endpoint }: { wall: WallNode; endpoint: 
   }, [])
 
   const activateEndpointMove = (event: ThreeEvent<PointerEvent>) => {
+    if (event.button !== 0) return
     event.stopPropagation()
     suppressBoxSelectForPointer(event)
     sfxEmitter.emit('sfx:item-pick')
@@ -435,6 +436,7 @@ function WallHeightArrowHandle({ wall }: { wall: WallNode }) {
   const handleY = wallHeight + HEIGHT_HANDLE_OFFSET
 
   const activateHeightResize = (event: ThreeEvent<PointerEvent>) => {
+    if (event.button !== 0) return
     event.stopPropagation()
     suppressBoxSelectForPointer(event)
     const levelObject = wall.parentId ? sceneRegistry.nodes.get(wall.parentId) : null
@@ -607,6 +609,7 @@ function WallMoveArrowHandle({ wall, handle }: { wall: WallNode; handle: WallMov
   useEffect(() => () => arrowMaterial.dispose(), [arrowMaterial])
 
   const activateWallMove = (event: ThreeEvent<PointerEvent>) => {
+    if (event.button !== 0) return
     event.stopPropagation()
     suppressBoxSelectForPointer(event)
     document.body.style.cursor = 'grabbing'
@@ -696,6 +699,7 @@ function FenceMoveArrowHandle({ fence, handle }: { fence: FenceNode; handle: Wal
   useEffect(() => () => arrowMaterial.dispose(), [arrowMaterial])
 
   const activateFenceMove = (event: ThreeEvent<PointerEvent>) => {
+    if (event.button !== 0) return
     event.stopPropagation()
     suppressBoxSelectForPointer(event)
     document.body.style.cursor = 'grabbing'

--- a/packages/editor/src/components/systems/roof/roof-edit-system.tsx
+++ b/packages/editor/src/components/systems/roof/roof-edit-system.tsx
@@ -1250,6 +1250,7 @@ function RoofTrimHandles() {
   }
 
   const startDrag = (side: RoofTrimSide, event: ThreeEvent<PointerEvent>) => {
+    if (event.button !== 0) return
     event.stopPropagation()
     const source = sceneRegistry.nodes.get(segment.id)
     if (!source) return

--- a/packages/editor/src/components/systems/roof/roof-edit-system.tsx
+++ b/packages/editor/src/components/systems/roof/roof-edit-system.tsx
@@ -31,6 +31,7 @@ import * as THREE from 'three'
 import { mergeVertices } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
 import { LineBasicNodeMaterial, MeshBasicNodeMaterial } from 'three/webgpu'
 import { EDITOR_LAYER } from '../../../lib/constants'
+import { isHistoryShortcut } from '../../../lib/history'
 import { getHoveredRoofSegmentOutlineProxyName } from '../../../lib/roof-hover-outline-proxy'
 import useInteractionScope, { useMovingNode } from '../../../store/use-interaction-scope'
 import { swallowNextClick } from '../../editor/handles/use-handle-drag'
@@ -1341,6 +1342,7 @@ function RoofTrimHandles() {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       window.removeEventListener('pointercancel', onCancel)
+      window.removeEventListener('keydown', onKeyDown, true)
       if (
         document.body.style.cursor === 'ew-resize' ||
         document.body.style.cursor === 'ns-resize' ||
@@ -1379,10 +1381,21 @@ function RoofTrimHandles() {
       cleanup()
     }
 
+    // Escape / ⌘Z abort the trim drag — capture phase so they win over the
+    // global use-keyboard arms (⌘Z must never history-jump mid-gesture).
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' && !isHistoryShortcut(e)) return
+      e.preventDefault()
+      e.stopPropagation()
+      swallowNextClick()
+      onCancel()
+    }
+
     dragCleanupRef.current = cleanup
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
     window.addEventListener('pointercancel', onCancel)
+    window.addEventListener('keydown', onKeyDown, true)
   }
 
   const renderTrimPlane = (

--- a/packages/editor/src/components/ui/panels/panel-manager.tsx
+++ b/packages/editor/src/components/ui/panels/panel-manager.tsx
@@ -29,6 +29,7 @@ import useEditor from '../../../store/use-editor'
 import { MobilePanelSheet } from './mobile-panel-sheet'
 import { MobileSelectionBar } from './mobile-selection-bar'
 import { getNodeDisplay } from './node-display'
+import { resetDesktopInspectorCollapsed } from './panel-wrapper'
 import { ParametricInspector } from './parametric-inspector'
 import { ReferencePanel } from './reference-panel'
 
@@ -185,6 +186,27 @@ export function PanelManager({ inspectorFooter }: { inspectorFooter?: React.Reac
     const id = selectedIds[0]
     return id ? (s.nodes[id as AnyNodeId] ?? null) : null
   })
+
+  // Node and reference selection are mutually exclusive: selecting a guide
+  // clears the node selection (handleGuideSelect), but node selection never
+  // cleared a lingering reference — so clicking a wall with a floorplan
+  // selected kept showing the reference panel. Clear the stale reference the
+  // moment a scene selection appears.
+  const setSelectedReferenceId = useEditor((s) => s.setSelectedReferenceId)
+  useEffect(() => {
+    if (selectedIds.length > 0 || selectedZoneId) {
+      setSelectedReferenceId(null)
+    }
+  }, [selectedIds, selectedZoneId, setSelectedReferenceId])
+
+  // The inspector's expanded state is shared across panel swaps, but a fresh
+  // selection after everything was deselected should open collapsed again.
+  const hasAnySelection = selectedIds.length > 0 || Boolean(selectedZoneId) || Boolean(selectedReferenceId)
+  useEffect(() => {
+    if (!hasAnySelection) {
+      resetDesktopInspectorCollapsed()
+    }
+  }, [hasAnySelection])
 
   if (isMobile) {
     if (selectedReferenceId) {

--- a/packages/editor/src/components/ui/panels/panel-wrapper.tsx
+++ b/packages/editor/src/components/ui/panels/panel-wrapper.tsx
@@ -19,6 +19,13 @@ const DRAG_MARGIN = 8
 const CLICK_SLOP = 4
 let desktopInspectorCollapsed = true
 
+/** Forget the shared expanded state. Called when the last selection clears so
+ * a fresh selection opens the inspector collapsed — the sharing is only meant
+ * to survive swaps between panels (roof ↔ segment), not a close/reopen. */
+export function resetDesktopInspectorCollapsed() {
+  desktopInspectorCollapsed = true
+}
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), Math.max(min, max))
 }

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
@@ -1,4 +1,4 @@
-import { emitter, useScene, validateBuildJson } from '@pascal-app/core'
+import { clearSceneHistory, emitter, useScene, validateBuildJson } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import { TreeView, VisualJson } from '@visual-json/react'
 import { Camera, Download, Map as MapIcon, Save, Trash2, Upload } from 'lucide-react'
@@ -267,6 +267,9 @@ export function SettingsPanel({
       parsed.nodes as Parameters<typeof setScene>[0],
       parsed.rootNodeIds as Parameters<typeof setScene>[1],
     )
+    // An import is a scene load: it becomes the undo floor. Without this,
+    // undo could step back into the pre-import scene state.
+    clearSceneHistory()
     resetSelection()
     setPhase('site')
     setPendingImport(null)
@@ -274,6 +277,9 @@ export function SettingsPanel({
 
   const handleResetToDefault = () => {
     clearScene()
+    // Same floor rule as import — undo after a reset must not resurrect the
+    // old scene (or land on the empty intermediate `unloadScene` state).
+    clearSceneHistory()
     resetSelection()
     setPhase('structure')
     selectDefaultBuildingAndLevel()

--- a/packages/editor/src/hooks/use-keyboard.ts
+++ b/packages/editor/src/hooks/use-keyboard.ts
@@ -115,7 +115,12 @@ const cancelInteractionForHistoryShortcut = () => {
   return (
     _toolCancelConsumed ||
     isActive(useInteractionScope.getState().scope) ||
-    useViewer.getState().inputDragging
+    useViewer.getState().inputDragging ||
+    // Paused history means a gesture session is live (draft placement, adopted
+    // move, …) even when no scope/drag flag is set — the preset/item draft
+    // cycle keeps temporal paused for the whole session, and a history jump
+    // against a paused store would land on a stale baseline anyway.
+    !useScene.temporal.getState().isTracking
   )
 }
 

--- a/packages/editor/src/hooks/use-keyboard.ts
+++ b/packages/editor/src/hooks/use-keyboard.ts
@@ -23,6 +23,7 @@ import { resolveDirectManipulationNode } from '../lib/direct-manipulation'
 import { toggleDoorOpenState } from '../lib/door-interaction'
 import { guideEmitter } from '../lib/guide-events'
 import { runRedo, runUndo } from '../lib/history'
+import { isActive } from '../lib/interaction/scope'
 import {
   copySelectedNodesToEditorClipboard,
   pasteEditorClipboardToLevel,
@@ -96,6 +97,26 @@ function rotateGroupSelection(direction: 1 | -1): boolean {
 let _toolCancelConsumed = false
 export const markToolCancelConsumed = () => {
   _toolCancelConsumed = true
+}
+
+// ⌘Z pressed mid-interaction (moving a node, drawing a wall, mid-placement…)
+// reads as "abort this action", not history undo — route it through the same
+// cancel path as Escape and report whether anything was in flight so the
+// undo/redo arms know to skip the history jump. Pointer drags that only
+// listen for their own capture-phase keydown never reach here — they
+// stopPropagation first (see isHistoryShortcut call sites).
+const cancelInteractionForHistoryShortcut = () => {
+  if (useEditor.getState().referenceScaleActiveGuideId) {
+    guideEmitter.emit('guide:cancel-reference-scale')
+    return true
+  }
+  _toolCancelConsumed = false
+  emitter.emit('tool:cancel')
+  return (
+    _toolCancelConsumed ||
+    isActive(useInteractionScope.getState().scope) ||
+    useViewer.getState().inputDragging
+  )
 }
 
 export const useKeyboard = ({
@@ -323,10 +344,12 @@ export const useKeyboard = ({
       } else if (e.key === 'z' && (e.metaKey || e.ctrlKey)) {
         if (isVersionPreviewMode) return
         e.preventDefault()
+        if (cancelInteractionForHistoryShortcut()) return
         runUndo()
       } else if (e.key === 'Z' && e.shiftKey && (e.metaKey || e.ctrlKey)) {
         if (isVersionPreviewMode) return
         e.preventDefault()
+        if (cancelInteractionForHistoryShortcut()) return
         runRedo()
       } else if (e.key === 'ArrowUp' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()

--- a/packages/editor/src/hooks/use-keyboard.ts
+++ b/packages/editor/src/hooks/use-keyboard.ts
@@ -99,12 +99,38 @@ export const markToolCancelConsumed = () => {
   _toolCancelConsumed = true
 }
 
+// Escape's fall-through when no tool consumed the cancel: drop back to the
+// select tool (keeping building/level context) and close panels. Tools like
+// preset/item placement rely on this — they pass no coordinator onCancel, and
+// it is the mode switch unmounting them that destroys the draft.
+const exitToSelectAfterUnconsumedCancel = () => {
+  const currentPhase = useEditor.getState().phase
+  const currentStructureLayer = useEditor.getState().structureLayer
+
+  useInteractionScope.getState().endIf((sc) => sc.kind === 'reshaping' && sc.reshape === 'hole')
+
+  // From zone mode, return to structure select
+  if (currentPhase === 'structure' && currentStructureLayer === 'zones') {
+    useEditor.getState().setStructureLayer('elements')
+    useEditor.getState().setMode('select')
+  } else {
+    // Return to the default select tool while keeping the active building/level context.
+    useEditor.getState().setMode('select')
+  }
+
+  useEditor.getState().setFloorplanSelectionTool('click')
+
+  // Clear selections to close UI panels, but KEEP the active building and level context.
+  useViewer.getState().setSelection({ selectedIds: [], zoneId: null })
+  useEditor.getState().setSelectedReferenceId(null)
+}
+
 // ⌘Z pressed mid-interaction (moving a node, drawing a wall, mid-placement…)
-// reads as "abort this action", not history undo — route it through the same
-// cancel path as Escape and report whether anything was in flight so the
-// undo/redo arms know to skip the history jump. Pointer drags that only
-// listen for their own capture-phase keydown never reach here — they
-// stopPropagation first (see isHistoryShortcut call sites).
+// reads as "abort this action", not history undo — behave exactly like Escape
+// and report whether anything was in flight so the undo/redo arms know to
+// skip the history jump. Pointer drags that only listen for their own
+// capture-phase keydown never reach here — they stopPropagation first (see
+// isHistoryShortcut call sites).
 const cancelInteractionForHistoryShortcut = () => {
   if (useEditor.getState().referenceScaleActiveGuideId) {
     guideEmitter.emit('guide:cancel-reference-scale')
@@ -112,8 +138,8 @@ const cancelInteractionForHistoryShortcut = () => {
   }
   _toolCancelConsumed = false
   emitter.emit('tool:cancel')
-  return (
-    _toolCancelConsumed ||
+  if (_toolCancelConsumed) return true
+  if (
     isActive(useInteractionScope.getState().scope) ||
     useViewer.getState().inputDragging ||
     // Paused history means a gesture session is live (draft placement, adopted
@@ -121,7 +147,14 @@ const cancelInteractionForHistoryShortcut = () => {
     // cycle keeps temporal paused for the whole session, and a history jump
     // against a paused store would land on a stale baseline anyway.
     !useScene.temporal.getState().isTracking
-  )
+  ) {
+    // A gesture is live but nothing consumed the cancel: finish it the way
+    // Escape does — the mode switch is what actually cancels tools that hook
+    // their teardown to unmount (preset/item placement).
+    exitToSelectAfterUnconsumedCancel()
+    return true
+  }
+  return false
 }
 
 export const useKeyboard = ({
@@ -259,27 +292,7 @@ export const useKeyboard = ({
         // Only switch to select mode if no tool had an active mid-action to cancel.
         // (e.g. mid-wall draw or mid-slab polygon should only cancel the action, not exit the tool)
         if (!_toolCancelConsumed) {
-          const currentPhase = useEditor.getState().phase
-          const currentStructureLayer = useEditor.getState().structureLayer
-
-          useInteractionScope
-            .getState()
-            .endIf((sc) => sc.kind === 'reshaping' && sc.reshape === 'hole')
-
-          // From zone mode, return to structure select
-          if (currentPhase === 'structure' && currentStructureLayer === 'zones') {
-            useEditor.getState().setStructureLayer('elements')
-            useEditor.getState().setMode('select')
-          } else {
-            // Return to the default select tool while keeping the active building/level context.
-            useEditor.getState().setMode('select')
-          }
-
-          useEditor.getState().setFloorplanSelectionTool('click')
-
-          // Clear selections to close UI panels, but KEEP the active building and level context.
-          useViewer.getState().setSelection({ selectedIds: [], zoneId: null })
-          useEditor.getState().setSelectedReferenceId(null)
+          exitToSelectAfterUnconsumedCancel()
         }
       } else if (e.key === '1' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()

--- a/packages/editor/src/lib/history.ts
+++ b/packages/editor/src/lib/history.ts
@@ -19,3 +19,12 @@ export function runRedo() {
   useScene.temporal.getState().redo()
   refreshSceneAfterHistoryJump()
 }
+
+/**
+ * ⌘Z / ⌘⇧Z (undo/redo). Pointer-drag sessions intercept these in the capture
+ * phase and cancel the gesture instead — mid-drag, "undo" means "abort what my
+ * mouse is doing", never a history jump under a live pointer.
+ */
+export function isHistoryShortcut(e: KeyboardEvent) {
+  return (e.metaKey || e.ctrlKey) && (e.key === 'z' || e.key === 'Z')
+}

--- a/packages/editor/src/lib/scene.ts
+++ b/packages/editor/src/lib/scene.ts
@@ -1,6 +1,12 @@
 'use client'
 
-import { nodeRegistry, resolveLevelId, sceneRegistry, useScene } from '@pascal-app/core'
+import {
+  clearSceneHistory,
+  nodeRegistry,
+  resolveLevelId,
+  sceneRegistry,
+  useScene,
+} from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import useEditor, {
   hasCustomPersistedEditorUiState,
@@ -384,6 +390,12 @@ export function applySceneGraphToEditor(sceneGraph?: SceneGraph | null) {
   } else {
     useScene.getState().clearScene()
   }
+
+  // The loaded scene is the undo floor. Loading records history entries of
+  // its own (`unloadScene` + `setScene`/`clearScene` are tracked writes), so
+  // without this reset a few Ctrl+Z presses could step past the load into the
+  // pre-load — often empty — state and wipe the whole project.
+  clearSceneHistory()
 
   syncEditorSelectionFromCurrentScene()
 }

--- a/packages/nodes/package.json
+++ b/packages/nodes/package.json
@@ -30,7 +30,7 @@
     "@react-three/fiber": "^9",
     "lucide-react": "^1",
     "react": "^18 || ^19",
-    "three": "^0.184",
+    "three": "^0.185",
     "zustand": "^5"
   },
   "devDependencies": {

--- a/packages/plugin-trees/package.json
+++ b/packages/plugin-trees/package.json
@@ -27,7 +27,7 @@
     "@pascal-app/viewer": "*",
     "@react-three/fiber": "^9",
     "react": "^18 || ^19",
-    "three": "^0.184",
+    "three": "^0.185",
     "zod": "^4",
     "zustand": "^5"
   },
@@ -41,7 +41,7 @@
     "@types/react": "^19.2.2",
     "@types/three": "^0.184.0",
     "react": "^19",
-    "three": "^0.184",
+    "three": "^0.185",
     "typescript": "6.0.3",
     "zod": "^4",
     "zustand": "^5"

--- a/packages/plugin-trees/src/wind-node.ts
+++ b/packages/plugin-trees/src/wind-node.ts
@@ -1,5 +1,5 @@
 import type { Color, Material, Side, Texture } from 'three'
-import { cos, Fn, float, instanceIndex, positionLocal, sin, time, uv } from 'three/tsl'
+import { cos, Fn, float, instanceIndex, positionGeometry, sin, time, uv } from 'three/tsl'
 import { MeshStandardNodeMaterial } from 'three/webgpu'
 
 /**
@@ -24,7 +24,7 @@ const LEAF_FREQUENCY = 1.2
 const LEAF_STRENGTH = 0.3
 
 const leafFlutter = Fn(() => {
-  const p = positionLocal.toVar()
+  const p = positionGeometry.toVar()
   const offset = float(instanceIndex).mul(0.7).add(p.x.add(p.z).mul(0.3))
   const t = time.mul(LEAF_FREQUENCY)
   const wave = sin(t.add(offset))
@@ -43,7 +43,7 @@ const STEM_FREQUENCY = 1.3
 const STEM_STRENGTH = 0.05
 
 const stemBend = Fn(() => {
-  const p = positionLocal.toVar()
+  const p = positionGeometry.toVar()
   const h = p.y.max(0)
   const phase = float(instanceIndex).mul(0.618)
   const t = time.mul(STEM_FREQUENCY).add(phase)

--- a/packages/plugin-trees/src/wind-node.ts
+++ b/packages/plugin-trees/src/wind-node.ts
@@ -1,5 +1,5 @@
 import type { Color, Material, Side, Texture } from 'three'
-import { cos, Fn, float, instanceIndex, positionGeometry, sin, time, uv } from 'three/tsl'
+import { cos, Fn, float, instanceIndex, positionLocal, sin, time, uv } from 'three/tsl'
 import { MeshStandardNodeMaterial } from 'three/webgpu'
 
 /**
@@ -24,7 +24,7 @@ const LEAF_FREQUENCY = 1.2
 const LEAF_STRENGTH = 0.3
 
 const leafFlutter = Fn(() => {
-  const p = positionGeometry.toVar()
+  const p = positionLocal.toVar()
   const offset = float(instanceIndex).mul(0.7).add(p.x.add(p.z).mul(0.3))
   const t = time.mul(LEAF_FREQUENCY)
   const wave = sin(t.add(offset))
@@ -43,7 +43,7 @@ const STEM_FREQUENCY = 1.3
 const STEM_STRENGTH = 0.05
 
 const stemBend = Fn(() => {
-  const p = positionGeometry.toVar()
+  const p = positionLocal.toVar()
   const h = p.y.max(0)
   const phase = float(instanceIndex).mul(0.618)
   const t = time.mul(STEM_FREQUENCY).add(phase)

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -26,7 +26,7 @@
     "@react-three/drei": "^10",
     "@react-three/fiber": "^9",
     "react": "^18 || ^19",
-    "three": "^0.184"
+    "three": "^0.185"
   },
   "dependencies": {
     "three-bvh-csg": "^0.0.18",

--- a/packages/viewer/src/components/viewer/index.tsx
+++ b/packages/viewer/src/components/viewer/index.tsx
@@ -446,6 +446,14 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
 
   const isDark = useViewer((state) => getSceneTheme(state.sceneTheme).appearance === 'dark')
   const transparentBackground = useViewer((state) => state.transparentBackground)
+  // The shadows toggle drives `renderer.shadowMap.enabled` (via the Canvas
+  // `shadows` prop) rather than the lights' `castShadow`: toggling castShadow
+  // off disposes the shadow map's GPU texture but three r184's WebGPU node
+  // cache keeps the shadows-on builder state that references it, so toggling
+  // back on reuses destroyed resources and every frame submit fails with a
+  // GPUValidationError. Disabling at the renderer level rebuilds materials
+  // without disposing anything, so the round-trip is safe.
+  const shadowsEnabled = useViewer((state) => state.shadows)
   useLayoutEffect(() => {
     if (transparent === undefined) return
 
@@ -549,7 +557,7 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
       }}
       shadows={{
         type: THREE.PCFShadowMap,
-        enabled: true,
+        enabled: shadowsEnabled,
       }}
     >
       <FrameLimiter fps={50} />

--- a/packages/viewer/src/components/viewer/lights.tsx
+++ b/packages/viewer/src/components/viewer/lights.tsx
@@ -244,8 +244,16 @@ export function Lights() {
   return (
     <>
       {theme.lights.map((light, index) => (
+        // The user-facing shadows toggle must NOT flip `castShadow` at runtime:
+        // three r184's WebGPU node cache keys builder state by castShadow, but
+        // evicts with the post-toggle key, so flipping off disposes the shadow
+        // map's GPU texture while the shadows-on cache entry (still referencing
+        // it) survives. Re-enabling then reuses that stale state and every
+        // submit fails ("Invalid CommandBuffer ... renderContext_N"). The
+        // toggle is applied via `renderer.shadowMap.enabled` (Canvas `shadows`
+        // prop in viewer/index.tsx), which round-trips without disposing.
         <directionalLight
-          castShadow={Boolean(light.castShadow) && !SHADOWS_DISABLED && shadows}
+          castShadow={Boolean(light.castShadow) && !SHADOWS_DISABLED}
           key={`${index}-${light.position.join(',')}`}
           position={light.position}
           ref={(ref) => {
@@ -256,7 +264,7 @@ export function Lights() {
           shadow-normalBias={0.3}
           shadow-radius={2}
         >
-          {light.castShadow && !SHADOWS_DISABLED && shadows ? (
+          {light.castShadow && !SHADOWS_DISABLED ? (
             <orthographicCamera
               attach="shadow-camera"
               bottom={-shadowCameraSize}

--- a/packages/viewer/src/components/viewer/post-processing.tsx
+++ b/packages/viewer/src/components/viewer/post-processing.tsx
@@ -5,9 +5,7 @@ import { ssgi } from 'three/addons/tsl/display/SSGINode.js'
 import { denoise } from 'three/examples/jsm/tsl/display/DenoiseNode.js'
 import {
   add,
-  colorToDirection,
   diffuseColor,
-  directionToColor,
   float,
   mix,
   mrt,
@@ -34,6 +32,7 @@ import { inkedEdges } from '../../lib/ink-edges'
 import { GRID_LAYER, OVERLAY_LAYER, SCENE_LAYER, ZONE_LAYER } from '../../lib/layers'
 import { mergedOutline } from '../../lib/merged-outline-node'
 import { getSceneTheme } from '../../lib/scene-themes'
+import { packNormalToRGB, unpackRGBToNormal } from '../../lib/tsl-compat'
 import useViewer from '../../store/use-viewer'
 
 // Scene-referred grade applied before the output tone mapping (AgX). AgX rolls
@@ -423,7 +422,7 @@ const PostProcessingPasses = ({
           mrt({
             output,
             diffuseColor,
-            normal: directionToColor(normalView),
+            normal: packNormalToRGB(normalView),
           }),
         )
         scenePassDepth = scenePass.getTextureNode('depth')
@@ -431,7 +430,7 @@ const PostProcessingPasses = ({
         const normalTexture = scenePass.getTexture('normal')
         normalTexture.type = UnsignedByteType
         // Extract normal from color-encoded texture (SSGI consumes the node form)
-        sceneNormal = sample((uv) => colorToDirection(scenePassNormal.sample(uv)))
+        sceneNormal = sample((uv) => unpackRGBToNormal(scenePassNormal.sample(uv)))
       }
 
       if (ssgiEnabled) {
@@ -452,14 +451,16 @@ const PostProcessingPasses = ({
         giPass.useScreenSpaceSampling.value = SSGI_PARAMS.useScreenSpaceSampling
         giPass.useTemporalFiltering = SSGI_PARAMS.useTemporalFiltering
 
-        const giTexture = (giPass as any).getTextureNode()
+        // r185: SSGI renders AO and GI into two separate textures (R8 + RG11B10)
+        // exposed via getAONode()/getGINode() instead of one rgba texture.
+        const aoTexture = (giPass as any).getAONode()
 
-        const gi = giPass.rgb
+        const gi = (giPass as any).getGINode().rgb
         let ao: any
         if (denoiseEnabled) {
           // DenoiseNode only denoises RGB — alpha is passed through unchanged.
-          // SSGI packs AO into alpha, so we remap it into RGB before denoising.
-          const aoAsRgb = vec4(giTexture.a, giTexture.a, giTexture.a, float(1))
+          // SSGI's AO is a single red channel, so we remap it into RGB before denoising.
+          const aoAsRgb = vec4(aoTexture.r, aoTexture.r, aoTexture.r, float(1))
           const denoisePass = denoise(aoAsRgb, scenePassDepth, sceneNormal, camera)
           denoisePass.index.value = 0
           denoisePass.radius.value = 4
@@ -467,7 +468,7 @@ const PostProcessingPasses = ({
         } else {
           // Diagnostic path: feed raw noisy SSGI AO straight through. Will
           // look grainy — that's the point, it isolates denoise cost.
-          ao = giTexture.a
+          ao = aoTexture.r
         }
 
         // AO is a near/mid-field cue like the ink: fade it out with raw depth

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -110,7 +110,7 @@ export {
 } from './lib/scene-themes'
 export { packNormalToRGB, unpackRGBToNormal } from './lib/tsl-compat'
 export { useItemLightPool } from './store/use-item-light-pool'
-export { default as useViewer } from './store/use-viewer'
+export { applyCountryUnitDefault, default as useViewer } from './store/use-viewer'
 export { CeilingSystem } from './systems/ceiling/ceiling-system'
 export {
   createColumnBoxGeometry,

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -107,6 +107,7 @@ export {
   SCENE_THEMES,
   type SceneTheme,
 } from './lib/scene-themes'
+export { packNormalToRGB, unpackRGBToNormal } from './lib/tsl-compat'
 export { useItemLightPool } from './store/use-item-light-pool'
 export { default as useViewer } from './store/use-viewer'
 export { CeilingSystem } from './systems/ceiling/ceiling-system'

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -69,6 +69,7 @@ export {
   collectIsolationSubtree,
   isIsolationActive,
 } from './lib/isolation'
+export { ensureKtx2Support } from './lib/ktx2-loader'
 export { GRID_LAYER, OVERLAY_LAYER, SCENE_LAYER, ZONE_LAYER } from './lib/layers'
 export {
   applyMaterialPresetToMaterials,

--- a/packages/viewer/src/lib/ink-edges.ts
+++ b/packages/viewer/src/lib/ink-edges.ts
@@ -1,15 +1,6 @@
-import {
-  abs,
-  colorToDirection,
-  float,
-  max,
-  min,
-  mix,
-  screenSize,
-  screenUV,
-  smoothstep,
-  vec2,
-} from 'three/tsl'
+import { abs, float, max, min, mix, screenSize, screenUV, smoothstep, vec2 } from 'three/tsl'
+
+import { unpackRGBToNormal } from './tsl-compat'
 
 // Screen-space ink outline (SketchUp / Moebius look). Reads the scene-pass
 // depth + normal MRT and inks two signals:
@@ -62,11 +53,11 @@ export function inkedEdges({
   // ≈ metres of step / near (near≈0.1): ~5cm starts a line, ~25cm solid.
   const depthEdge = smoothstep(float(0.5), float(2.5), depthMetric).mul(noiseGate)
 
-  const nC = colorToDirection(normalTex.sample(uvN)).normalize()
-  const nR = colorToDirection(normalTex.sample(uvN.add(vec2(px.x, 0)))).normalize()
-  const nL = colorToDirection(normalTex.sample(uvN.sub(vec2(px.x, 0)))).normalize()
-  const nU = colorToDirection(normalTex.sample(uvN.add(vec2(0, px.y)))).normalize()
-  const nD = colorToDirection(normalTex.sample(uvN.sub(vec2(0, px.y)))).normalize()
+  const nC = unpackRGBToNormal(normalTex.sample(uvN)).normalize()
+  const nR = unpackRGBToNormal(normalTex.sample(uvN.add(vec2(px.x, 0)))).normalize()
+  const nL = unpackRGBToNormal(normalTex.sample(uvN.sub(vec2(px.x, 0)))).normalize()
+  const nU = unpackRGBToNormal(normalTex.sample(uvN.add(vec2(0, px.y)))).normalize()
+  const nD = unpackRGBToNormal(normalTex.sample(uvN.sub(vec2(0, px.y)))).normalize()
   // Ink is a near/mid-field affordance: fade it out with raw depth so the
   // horizon (the infinite ground disc vanishing against the backdrop) and
   // other far-field depth cliffs never draw a line across the sky junction.

--- a/packages/viewer/src/lib/ktx2-loader.ts
+++ b/packages/viewer/src/lib/ktx2-loader.ts
@@ -122,6 +122,22 @@ ktx2Loader.setTranscoderPath('https://cdn.jsdelivr.net/gh/pmndrs/drei-assets@mas
 const configuredRenderers = new WeakSet<object>()
 const warnedRenderers = new WeakSet<object>()
 
+let resolveKtx2Ready: () => void
+const ktx2ReadyPromise = new Promise<void>((resolve) => {
+  resolveKtx2Ready = resolve
+})
+
+/**
+ * Resolves once `detectSupport` has succeeded for any renderer. `.ktx2` loads
+ * issued before that point would throw inside KTX2Loader ("Missing
+ * initialization with `.detectSupport( renderer )`"), so texture loaders await
+ * this instead of failing — covers materials created while the renderer is
+ * still initializing (e.g. a standalone capture canvas).
+ */
+export function whenKtx2Ready(): Promise<void> {
+  return ktx2ReadyPromise
+}
+
 /** Returns true once support has been detected for this renderer (KTX2 safe to load). */
 export function ensureKtx2Support(renderer: unknown): boolean {
   const key = renderer as object | null
@@ -130,6 +146,7 @@ export function ensureKtx2Support(renderer: unknown): boolean {
   try {
     ;(ktx2Loader as unknown as { detectSupport: (r: unknown) => void }).detectSupport(renderer)
     configuredRenderers.add(key)
+    resolveKtx2Ready()
     return true
   } catch (error) {
     // Some WebGPU flows can transiently call this before backend init; don't

--- a/packages/viewer/src/lib/materials.ts
+++ b/packages/viewer/src/lib/materials.ts
@@ -15,7 +15,7 @@ import { float, mix, positionViewDirection, transformedNormalView } from 'three/
 import { MeshLambertNodeMaterial, MeshStandardNodeMaterial } from 'three/webgpu'
 
 import { resolveCdnUrl } from './asset-url'
-import { isKtx2Url, ktx2Loader } from './ktx2-loader'
+import { isKtx2Url, ktx2Loader, whenKtx2Ready } from './ktx2-loader'
 import { getSceneTheme } from './scene-themes'
 
 export type RenderShading = 'solid' | 'rendered'
@@ -308,8 +308,17 @@ async function loadPresetTexture(
   const existingPromise = textureLoadPromises.get(cacheKey)
   if (existingPromise) return existingPromise
 
-  const promise = pickTextureLoader(resolvedPath)
-    .loadAsync(resolvedPath)
+  // `.ktx2` loads wait for `detectSupport` (KTX2Loader.load throws before it) —
+  // materials can be created while a capture canvas's renderer is still
+  // initializing, and failing here would cache the material permanently
+  // texture-less (white).
+  const load = isKtx2Url(resolvedPath)
+    ? whenKtx2Ready().then(() =>
+        (ktx2Loader as unknown as THREE.TextureLoader).loadAsync(resolvedPath),
+      )
+    : textureLoader.loadAsync(resolvedPath)
+
+  const promise = load
     .then((texture) => {
       applyTextureProperties(texture, props, slot)
       setTextureCacheKey(texture, cacheKey)

--- a/packages/viewer/src/lib/tsl-compat.ts
+++ b/packages/viewer/src/lib/tsl-compat.ts
@@ -1,0 +1,16 @@
+import * as TSL from 'three/tsl'
+
+/**
+ * three runs at 0.185 but @types/three is pinned at 0.184: the 0.185 typings
+ * make tsgo's type inference allocate unboundedly (microsoft/typescript-go
+ * #2125 class) and OOM the machine. r185 renamed directionToColor /
+ * colorToDirection to packNormalToRGB / unpackRGBToNormal — re-export the new
+ * runtime names under the old names' signatures. Delete this file (and the
+ * @types/three pin) once tsgo handles the 0.185 types; the `typeof` references
+ * to the removed old names will fail the build as a reminder.
+ */
+export const packNormalToRGB = (TSL as unknown as { packNormalToRGB: typeof TSL.directionToColor })
+  .packNormalToRGB
+export const unpackRGBToNormal = (
+  TSL as unknown as { unpackRGBToNormal: typeof TSL.colorToDirection }
+).unpackRGBToNormal

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -79,6 +79,10 @@ type ViewerState = {
 
   unit: 'metric' | 'imperial'
   setUnit: (unit: 'metric' | 'imperial') => void
+  /** True once the user explicitly picked a unit. Until then `unit` is a
+   * locale-derived default and is not persisted, so the default can keep
+   * tracking the browser locale across sessions. */
+  unitExplicit: boolean
 
   levelMode: 'stacked' | 'exploded' | 'solo' | 'manual'
   setLevelMode: (mode: 'stacked' | 'exploded' | 'solo' | 'manual') => void
@@ -165,6 +169,7 @@ type PersistedViewerState = Partial<
     | 'edges'
     | 'shadows'
     | 'unit'
+    | 'unitExplicit'
     | 'levelMode'
     | 'wallMode'
     | 'projectPreferences'
@@ -178,6 +183,63 @@ const EDGE_MODES = ['off', 'soft', 'strong'] as const
 const UNITS = ['metric', 'imperial'] as const
 const LEVEL_MODES = ['stacked', 'exploded', 'solo', 'manual'] as const
 const WALL_MODES = ['up', 'cutaway', 'down', 'translucent'] as const
+
+// Countries still on imperial/US customary units: United States, Liberia, Myanmar.
+const IMPERIAL_REGIONS = ['US', 'LR', 'MM']
+
+// IANA zones for those countries. The timezone tracks the OS clock (actual
+// location), unlike navigator.language where en-US is a common default for
+// users far outside the US.
+const IMPERIAL_TIMEZONES = new Set([
+  'America/New_York',
+  'America/Detroit',
+  'America/Kentucky/Louisville',
+  'America/Kentucky/Monticello',
+  'America/Indiana/Indianapolis',
+  'America/Indiana/Vincennes',
+  'America/Indiana/Winamac',
+  'America/Indiana/Marengo',
+  'America/Indiana/Petersburg',
+  'America/Indiana/Vevay',
+  'America/Indiana/Tell_City',
+  'America/Indiana/Knox',
+  'America/Chicago',
+  'America/Menominee',
+  'America/North_Dakota/Center',
+  'America/North_Dakota/New_Salem',
+  'America/North_Dakota/Beulah',
+  'America/Denver',
+  'America/Boise',
+  'America/Phoenix',
+  'America/Los_Angeles',
+  'America/Anchorage',
+  'America/Juneau',
+  'America/Sitka',
+  'America/Metlakatla',
+  'America/Yakutat',
+  'America/Nome',
+  'America/Adak',
+  'Pacific/Honolulu',
+  'America/Puerto_Rico',
+  'Pacific/Guam',
+  'Africa/Monrovia', // Liberia
+  'Asia/Yangon', // Myanmar
+  'Asia/Rangoon', // Myanmar (legacy alias)
+])
+
+function detectDefaultUnit(): ViewerState['unit'] {
+  if (typeof navigator === 'undefined') return 'metric'
+  try {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    if (timeZone) return IMPERIAL_TIMEZONES.has(timeZone) ? 'imperial' : 'metric'
+    // No timezone available: fall back to an explicit locale region subtag
+    // only (never maximize() — it turns a bare "en" into region US).
+    const region = new Intl.Locale(navigator.language).region
+    return region && IMPERIAL_REGIONS.includes(region) ? 'imperial' : 'metric'
+  } catch {
+    return 'metric'
+  }
+}
 
 function pickString<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
   return typeof value === 'string' && allowed.includes(value as T) ? (value as T) : fallback
@@ -226,7 +288,9 @@ function normalizePersistedViewerState(value: unknown): PersistedViewerState {
     colorPreset: pickString<ColorPreset>(state.colorPreset, COLOR_PRESETS, 'clay'),
     edges: pickString<EdgeMode>(state.edges, EDGE_MODES, 'soft'),
     shadows: typeof state.shadows === 'boolean' ? state.shadows : true,
-    unit: pickString<ViewerState['unit']>(state.unit, UNITS, 'metric'),
+    unit: pickString<ViewerState['unit']>(state.unit, UNITS, detectDefaultUnit()),
+    unitExplicit:
+      typeof state.unit === 'string' && UNITS.includes(state.unit as ViewerState['unit']),
     levelMode: pickString<ViewerState['levelMode']>(state.levelMode, LEVEL_MODES, 'stacked'),
     wallMode: pickString<ViewerState['wallMode']>(state.wallMode, WALL_MODES, 'up'),
     projectPreferences: normalizeProjectPreferences(state.projectPreferences),
@@ -295,8 +359,9 @@ const useViewer = create<ViewerState>()(
       shadows: true,
       setShadows: (shadows) => set({ shadows }),
 
-      unit: 'metric',
-      setUnit: (unit) => set({ unit }),
+      unit: detectDefaultUnit(),
+      unitExplicit: false,
+      setUnit: (unit) => set({ unit, unitExplicit: true }),
 
       levelMode: 'stacked',
       setLevelMode: (mode) => set({ levelMode: mode }),
@@ -431,7 +496,7 @@ const useViewer = create<ViewerState>()(
         colorPreset: state.colorPreset,
         edges: state.edges,
         shadows: state.shadows,
-        unit: state.unit,
+        ...(state.unitExplicit ? { unit: state.unit } : {}),
         levelMode: state.levelMode,
         wallMode: state.wallMode,
         projectPreferences: state.projectPreferences,

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -505,4 +505,17 @@ const useViewer = create<ViewerState>()(
   ),
 )
 
+/** Apply an authoritative country code (e.g. IP-derived by the host app) as
+ * the unit default. Stronger signal than the timezone heuristic used at store
+ * creation, but still a default: it never overrides an explicit user choice
+ * and is not persisted (the unit only sticks once the user touches the
+ * toggle). */
+export function applyCountryUnitDefault(country: string | null | undefined) {
+  if (!country) return
+  const state = useViewer.getState()
+  if (state.unitExplicit) return
+  const unit = IMPERIAL_REGIONS.includes(country.toUpperCase()) ? 'imperial' : 'metric'
+  if (state.unit !== unit) useViewer.setState({ unit })
+}
+
 export default useViewer


### PR DESCRIPTION
## What does this PR do?

Bug-fix and adjustments pass across viewer + editor, plus the three.js migration:

**three.js 184 → 185** (`acb9c55a`)
- Runtime bumped to 0.185.1 (TSL renames `directionToColor`/`colorToDirection` → `packNormalToRGB`/`unpackRGBToNormal`, SSGI's packed rgba output split into separate AO/GI textures). Note: wind-node keeps `positionLocal` — it was never removed in r185, and swapping it for `positionGeometry` discards instance transforms (`edc4e2f4`).
- `@types/three` stays **pinned at 0.184.1**: the 0.185 typings send tsgo's inference into unbounded allocation (microsoft/typescript-go#2125 class — ~70GB/90s, OOM-kills the machine). `viewer/lib/tsl-compat.ts` bridges the two renamed TSL exports; drop it and the pin together once tsgo copes.

**Undo vs. gestures**
- ⌘Z pressed mid-interaction (moving, drawing, placing, dragging a handle) now cancels the gesture exactly like Escape instead of history-jumping under a live pointer. Covers tool:cancel consumers, scope-tracked drags, and draft placement (detected via paused temporal history).
- Handle drags that only knew `pointercancel` (resize/height/rotate handles, wall side handles, roof trim, group rotate) gain capture-phase Escape/⌘Z cancel — fixing Escape for them too.
- Undo history floored at scene load (`92e7b4ef`) — undo can no longer wipe a freshly-loaded project.

**Viewer fixes**
- Shadows toggle flips `renderer.shadowMap.enabled` instead of per-light `castShadow` (r184 WebGPU cache-eviction crash) (`b3283366`).
- `.ktx2` preset-texture loads gate on `detectSupport` via `whenKtx2Ready()` — fabric/leather slots no longer capture white in standalone-canvas thumbnails (`c9aef1fc`).
- Measurement-unit default derived from timezone/locale until the user picks one (`f51cd858`), plus `applyCountryUnitDefault` for hosts with an authoritative IP-derived country (`3158ec7a`).

**Editor / 2D floorplan**
- Right-click no longer starts handle drags (`117c59db`).
- Box select arms over any guide image that won't itself drag (locked or unselected) (`cd830279`, `3b07955b`).
- Live rotation readout (wedge + degree chip) while rotating a guide image (`daf01b96`).
- Guide set-scale dialog accepts lingo free-text (`5'11"`, `180cm`, `1m80`) with a `= 1.80 m` hint (`84a1c4f5`).
- Selecting a scene node clears a lingering reference selection (the floorplan panel no longer sticks); the inspector's expanded state resets once everything is deselected (`5488cae5`).

## How to test

1. `bun dev`, open a scene — verify it renders on WebGPU with no `LightsNode`/`GPUValidationError` console errors (three 0.185).
2. Rotate an item with a handle, press ⌘Z mid-drag → drag reverts, no undo. Same for Escape. Arm a preset placement, ⌘Z → ghost cancels, back to select; ⌘Z again → normal undo.
3. Draw a wall, ⌘Z mid-draw → draft clears, tool stays armed.
4. Display settings → shadows off, then on → no WebGPU crash.
5. 2D floorplan with a guide image: marquee-drag starting on the guide → box select arms; click → selects; rotate with corner handles → live degree readout; set scale → type `5'11"` → hint shows `= 1.80 m`.
6. Select a guide (floorplan), then click a wall → wall panel replaces the reference panel immediately.
7. Fresh browser profile: unit default follows timezone (US → imperial); picking a unit manually sticks.
8. Item thumbnail capture with a fabric/leather slot material → material renders (not white).

## Screenshots / screen recording

N/A — verified live in the hosting app (Wawa House renders clean on WebGPU post-migration); happy to attach clips on request.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core scene undo (zundo), WebGPU rendering (three 0.185 + shadows/SSGI), and widespread gesture keyboard handling; changes are targeted but affect critical editor and viewer paths.
> 
> **Overview**
> Bumps **three.js** to **0.185** across apps and packages (lockfile + root override), with viewer/editor post-processing and thumbnails updated for r185 TSL normal packing (`packNormalToRGB` / `unpackRGBToNormal` via `tsl-compat`) and SSGI’s split AO/GI outputs instead of a single packed texture.
> 
> **Undo and in-flight gestures** are reworked: ⌘Z/⌘⇧Z during moves, handle drags, and paused-history placement cancels like Escape (capture-phase handlers + shared `isHistoryShortcut`), and global keyboard routing skips history when an interaction is active. Scene load/import/reset now calls **`clearSceneHistory()`** after `setScene`/`clearScene`, with **`setScene` doing one tracked write** after normalization and **`clearSceneHistory` resuming** temporal tracking so undo is floored at the loaded baseline.
> 
> **Viewer**: shadows toggle drives **`renderer.shadowMap.enabled`** (not per-light `castShadow`) to avoid r184 WebGPU validation failures; **`.ktx2`** loads wait on **`whenKtx2Ready()`** after `detectSupport`; default **metric/imperial** follows timezone/locale until the user sets a unit (`applyCountryUnitDefault` for hosts).
> 
> **Editor / floorplan**: primary-button-only handle activation; live **guide rotation wedge**; reference-scale **lingo length** input; guide pointer-down only consumes events when selected+unlocked (box select on guide images); selecting scene nodes clears stale reference selection and resets inspector collapse; settings import/reset clear undo history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc4e2f489806286053f99b22a348b08f65d5aad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
