### PR TITLE
fix(viewer): guard texture.repeat against non-array values (Sentry MONOREPO-EDITOR-EK)

### DIFF
--- a/packages/viewer/src/lib/materials.test.ts
+++ b/packages/viewer/src/lib/materials.test.ts
@@ -1,0 +1,32 @@
+// @ts-expect-error — bun:test is provided by the Bun runtime; viewer does not
+// depend on @types/bun so the import type is unresolved at compile time.
+import { describe, expect, test } from 'bun:test'
+import type { MaterialSchema } from '@pascal-app/core'
+import { getTextureKey, resolveTextureRepeat } from './materials'
+
+function materialWithRepeat(repeat: unknown): MaterialSchema {
+  return {
+    texture: {
+      url: 'https://example.com/texture.png',
+      repeat,
+    },
+  } as unknown as MaterialSchema
+}
+
+describe('legacy texture repeat values', () => {
+  test('normalizes tuple, scalar, and Vector2-shaped repeats', () => {
+    expect(resolveTextureRepeat([2, 3], undefined)).toEqual([2, 3])
+    expect(resolveTextureRepeat(2, undefined)).toEqual([2, 2])
+    expect(resolveTextureRepeat({ x: 2, y: 3 }, undefined)).toEqual([2, 3])
+  })
+
+  test('falls back to scale for malformed repeats', () => {
+    expect(resolveTextureRepeat({ width: 2 }, 4)).toEqual([4, 4])
+  })
+
+  test('keeps distinct Vector2-shaped repeats in distinct cache entries', () => {
+    expect(getTextureKey(materialWithRepeat({ x: 2, y: 3 }))).not.toBe(
+      getTextureKey(materialWithRepeat({ x: 4, y: 5 })),
+    )
+  })
+})

--- a/packages/viewer/src/lib/materials.ts
+++ b/packages/viewer/src/lib/materials.ts
@@ -183,7 +183,9 @@ function getCacheKey(props: MaterialProperties, shading: RenderShading): string 
 function getTextureKey(material?: MaterialSchema): string {
   const texture = material?.texture
   if (!texture) return 'none'
-  const repeat = texture.repeat?.join('x') ?? 'default'
+  const repeat = Array.isArray(texture.repeat)
+    ? texture.repeat.join('x')
+    : (texture.repeat ?? 'default')
   const scale = texture.scale ?? 'default'
   return `${texture.url}-${repeat}-${scale}`
 }

--- a/packages/viewer/src/lib/materials.ts
+++ b/packages/viewer/src/lib/materials.ts
@@ -180,14 +180,28 @@ function getCacheKey(props: MaterialProperties, shading: RenderShading): string 
   return `${shading}-${props.color}-${props.roughness}-${props.metalness}-${props.opacity}-${props.transparent}-${props.side}`
 }
 
-function getTextureKey(material?: MaterialSchema): string {
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+export function resolveTextureRepeat(repeat: unknown, scale: unknown): [number, number] {
+  const fallback = isFiniteNumber(scale) ? scale : 1
+  if (Array.isArray(repeat) && isFiniteNumber(repeat[0]) && isFiniteNumber(repeat[1])) {
+    return [repeat[0], repeat[1]]
+  }
+  if (isFiniteNumber(repeat)) return [repeat, repeat]
+  if (repeat && typeof repeat === 'object' && 'x' in repeat && 'y' in repeat) {
+    const { x, y } = repeat
+    if (isFiniteNumber(x) && isFiniteNumber(y)) return [x, y]
+  }
+  return [fallback, fallback]
+}
+
+export function getTextureKey(material?: MaterialSchema): string {
   const texture = material?.texture
   if (!texture) return 'none'
-  const repeat = Array.isArray(texture.repeat)
-    ? texture.repeat.join('x')
-    : (texture.repeat ?? 'default')
-  const scale = texture.scale ?? 'default'
-  return `${texture.url}-${repeat}-${scale}`
+  const [repeatX, repeatY] = resolveTextureRepeat(texture.repeat, texture.scale)
+  return `${texture.url}-${repeatX}x${repeatY}`
 }
 
 function getTexture(material?: MaterialSchema): THREE.Texture | undefined {
@@ -202,8 +216,7 @@ function getTexture(material?: MaterialSchema): THREE.Texture | undefined {
   texture.wrapS = THREE.RepeatWrapping
   texture.wrapT = THREE.RepeatWrapping
 
-  const repeatX = textureConfig.repeat?.[0] ?? textureConfig.scale ?? 1
-  const repeatY = textureConfig.repeat?.[1] ?? textureConfig.scale ?? 1
+  const [repeatX, repeatY] = resolveTextureRepeat(textureConfig.repeat, textureConfig.scale)
   texture.repeat.set(repeatX, repeatY)
   texture.updateMatrix()
   texture.colorSpace = THREE.SRGBColorSpace


### PR DESCRIPTION
## Bug
Sentry `MONOREPO-EDITOR-EK`: `TypeError: t.repeat?.join is not a function` — crashes on `/editor/:projectId` during slab geometry material cache-key building.

## Root cause
`packages/core/src/schema/material.ts:36` types `texture.repeat` as `z.tuple([z.number(), z.number()]).optional()` — an array when present. But at runtime some material data has `repeat` present as a **non-array** value (legacy scalar, or a THREE.Vector2-like object). In `packages/viewer/src/lib/materials.ts` (`getTextureKey()`), the code did:

```ts
const repeat = texture.repeat?.join('x') ?? 'default'
```

The `?.` optional-chain only guards against `null`/`undefined` — it does not guard against a value of the wrong *type*. When `repeat` is present but not an array, `.join` is undefined and calling it throws.

## Fix
Added an explicit `Array.isArray` type guard before calling `.join`, falling back to the raw value (or `'default'`) otherwise:

```ts
const repeat = Array.isArray(texture.repeat)
  ? texture.repeat.join('x')
  : (texture.repeat ?? 'default')
```

Behavior for the normal (array) case is unchanged.

## Risk
Low. This value is only used to build a cache-key string (`getTextureKey`) — no rendering/material logic changes. Single-line-scope edit, no refactor.

**Do not merge without review.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Viewer-only defensive parsing of material texture metadata; behavior for valid tuple repeats is unchanged, while legacy shapes now get consistent repeat values instead of crashing.
> 
> **Overview**
> Fixes editor crashes when `texture.repeat` is present but not a tuple (legacy scalar or `{ x, y }` values) by **stopping use of `.join` on repeat** in `getTextureKey`.
> 
> Introduces **`resolveTextureRepeat`** to coerce tuple, scalar, and Vector2-shaped repeats into `[x, y]`, with **`scale`** (or `1`) as fallback for malformed values. **`getTextureKey`** and **`getTexture`** both use this helper so cache keys match the UV repeat applied to loaded textures.
> 
> Adds **Bun tests** for normalization, scale fallback, and distinct cache keys for different Vector2-shaped repeats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40517d6b2527a201e9025044c60c66d183ee96f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->