### PR TITLE
fix: publish built-in nodes package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
           - core
           - viewer
           - editor
+          - nodes
           - mcp
           - ifc-converter
           - all
@@ -75,7 +76,7 @@ jobs:
           # peerDeps sync below must use shell vars, not env indirection.
           declare -A NEW_VERSIONS
 
-          for pkg in core viewer editor mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter; do
             if [ "$TARGET" = "$pkg" ] || [ "$TARGET" = "all" ]; then
               CUR=$(jq -r '.version' packages/$pkg/package.json)
               NEW=$(bump_version "$CUR")
@@ -90,9 +91,9 @@ jobs:
 
           # Sync inter-package references in peerDependencies and devDependencies.
           # Anything that references a bumped @pascal-app/* package is updated to ^NEW.
-          for pkg in core viewer editor mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter; do
             FILE=packages/$pkg/package.json
-            for dep in core viewer editor mcp ifc-converter; do
+            for dep in core viewer editor nodes mcp ifc-converter; do
               VAL="${NEW_VERSIONS[$dep]}"
               [ -z "$VAL" ] && continue
               jq --arg name "@pascal-app/$dep" --arg v "^$VAL" '
@@ -103,7 +104,7 @@ jobs:
           done
 
           echo "=== @pascal-app/* refs after sync ==="
-          for pkg in core viewer editor mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter; do
             echo "--- packages/$pkg/package.json ---"
             jq '{ peerDependencies: (.peerDependencies // {} | with_entries(select(.key | startswith("@pascal-app/")))), devDependencies: (.devDependencies // {} | with_entries(select(.key | startswith("@pascal-app/")))) }' packages/$pkg/package.json
           done
@@ -150,6 +151,21 @@ jobs:
           else
             npm publish --access public
             echo "📦 Published @pascal-app/editor@$EDITOR_VERSION"
+          fi
+
+      - name: Build & publish nodes
+        if: inputs.package == 'nodes' || inputs.package == 'all'
+        working-directory: packages/nodes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          bun run build
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            echo "🏜️ Dry run — would publish @pascal-app/nodes@$NODES_VERSION"
+            npm publish --dry-run --access public
+          else
+            npm publish --access public
+            echo "📦 Published @pascal-app/nodes@$NODES_VERSION"
           fi
 
       - name: Build & publish mcp
@@ -202,6 +218,10 @@ jobs:
           if [ -n "$EDITOR_VERSION" ]; then
             PKGS="$PKGS @pascal-app/editor@$EDITOR_VERSION"
             TAGS="$TAGS @pascal-app/editor@$EDITOR_VERSION"
+          fi
+          if [ -n "$NODES_VERSION" ]; then
+            PKGS="$PKGS @pascal-app/nodes@$NODES_VERSION"
+            TAGS="$TAGS @pascal-app/nodes@$NODES_VERSION"
           fi
           if [ -n "$MCP_VERSION" ]; then
             PKGS="$PKGS @pascal-app/mcp@$MCP_VERSION"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "release:viewer": "gh workflow run release.yml -f package=viewer -f bump=patch",
     "release:core": "gh workflow run release.yml -f package=core -f bump=patch",
     "release:editor": "gh workflow run release.yml -f package=editor -f bump=patch",
+    "release:nodes": "gh workflow run release.yml -f package=nodes -f bump=patch",
     "release:mcp": "gh workflow run release.yml -f package=mcp -f bump=patch",
     "release:minor": "gh workflow run release.yml -f package=all -f bump=minor",
     "release:major": "gh workflow run release.yml -f package=all -f bump=major"


### PR DESCRIPTION
## Summary
- add `nodes` as an explicit release target
- include `@pascal-app/nodes` in coordinated releases and dependency version syncing
- publish and tag the package alongside the other public editor packages

## Why
The built-in measurement tools merged in #505 depend on `@pascal-app/nodes`, but the package was absent from the release workflow, including the `all` path. Without this, npm consumers cannot receive the measurement implementation.

## Validation
- release workflow parses as YAML
- package manifests parse as JSON
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts` for `@pascal-app/nodes@0.1.0` (1,726 files, 1.08 MB)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release configuration only; no runtime app logic, with publish behavior mirroring existing packages.
> 
> **Overview**
> Wires **`@pascal-app/nodes`** into the manual release pipeline so npm consumers can get the built-in node package (e.g. measurement tools from #505).
> 
> The **`release.yml`** workflow now treats **`nodes`** like the other public packages: it appears as a **`package`** choice, joins version bump / peer & dev dependency sync loops, gets a **Build & publish nodes** step (`bun run build` + `npm publish`, with dry-run support), and is included in release **commit messages and git tags** via **`NODES_VERSION`**.
> 
> Root **`package.json`** adds **`release:nodes`** to trigger **`gh workflow run release.yml -f package=nodes -f bump=patch`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677289af70b37c614523fec14d131daa6c86be98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->