### PR TITLE
Preload the selected tool inspector

### DIFF
--- a/packages/editor/src/components/tools/tool-manager.tsx
+++ b/packages/editor/src/components/tools/tool-manager.tsx
@@ -43,7 +43,12 @@ function getRegistryTool(tool: Tool | null): ComponentType | null {
   if (!def?.tool) return null
   const cached = lazyToolCache.get(def.tool)
   if (cached) return cached
-  const Comp = lazy(def.tool as () => Promise<{ default: ComponentType }>)
+  const Comp = lazy(async () => {
+    // A placed node is selected immediately. Resolve its custom inspector with
+    // the tool so that selection cannot introduce a second async boundary.
+    const [module] = await Promise.all([def.tool!(), def.parametrics?.customPanel?.()])
+    return module as { default: ComponentType }
+  })
   lazyToolCache.set(def.tool, Comp)
   return Comp
 }


### PR DESCRIPTION
## Summary

- preload a registry tool's custom inspector in the same lazy boundary as the tool
- keep the loader cached by the existing tool contribution
- prevent selecting a newly placed node from discovering a second UI chunk

## Verification

- `bunx biome check packages/editor/src/components/tools/tool-manager.tsx`
- `bun run --cwd packages/core build && bun run --cwd packages/editor check-types`
- `bun check`
- private host reconnect scenario: queued placement, retry, peer convergence, and undo passed in an isolated two-browser run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file lazy-loading change with no auth, data, or API surface impact; main effect is faster inspector readiness after placement.
> 
> **Overview**
> Registry build tools now **fetch the kind’s `parametrics.customPanel` chunk in parallel** with the tool module inside the existing `React.lazy` loader in `getRegistryTool`, instead of loading only `def.tool`.
> 
> That keeps the same `lazyToolCache` keyed by `def.tool`, but avoids a **second async boundary** when a newly placed node is selected right away and the inspector would otherwise lazy-load the custom panel separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2129eed0c28e2d67e1bf8f419fa3b2eb783e3a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->