### PR TITLE
fix(viewer): kick render on focus and visibility resume

### DIFF
--- a/packages/viewer/src/components/viewer/frame-limiter.tsx
+++ b/packages/viewer/src/components/viewer/frame-limiter.tsx
@@ -37,19 +37,29 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     let timer: ReturnType<typeof setInterval> | null = null
     let sizeSynced = false
     const interval = 1000 / fps
+    function syncSize() {
+      if (sizeSynced) return
+      renderer.setPixelRatio(dpr)
+      renderer.setSize(size.width, size.height, false)
+      sizeSynced = true
+    }
     function tick(t: DOMHighResTimeStamp) {
       raf = requestAnimationFrame(tick)
-      if (!sizeSynced) {
-        renderer.setPixelRatio(dpr)
-        renderer.setSize(size.width, size.height, false)
-        sizeSynced = true
-      }
+      syncSize()
       elapsed = t - then
       if (elapsed > interval) {
         advance(i)
         i += elapsed / 1000 - (elapsed % interval) / 1000
         then = t - (elapsed % interval)
       }
+    }
+    function kick() {
+      syncSize()
+      i += 1 / 1000
+      advance(i)
+    }
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible') kick()
     }
     // Set frameloop to never, it will shut down the default render loop
     set({ frameloop: 'never' })
@@ -61,6 +71,11 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     } else {
       // Kick off custom render loop
       raf = requestAnimationFrame(tick)
+      // rAF can stall while a tab is hidden, unfocused, or occluded. With the
+      // default loop disabled, force one current frame as soon as it resumes.
+      document.addEventListener('visibilitychange', onVisibilityChange)
+      window.addEventListener('focus', kick)
+      window.addEventListener('pageshow', kick)
     }
     // Restore initial setting
     return () => {
@@ -70,6 +85,9 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
       if (timer) {
         clearInterval(timer)
       }
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('focus', kick)
+      window.removeEventListener('pageshow', kick)
       set({ frameloop: initFrameloop })
     }
   }, [advance, dpr, fps, initFrameloop, renderPaused, renderer, set, size.height, size.width])


### PR DESCRIPTION
## Summary
- force one render on visible, focus, and pageshow resume events
- synchronize renderer size before a resume kick, including first paint
- preserve the timer-driven `?disable=draw` bake path without extra resume listeners

## Why
With `frameloop="never"`, the custom rAF loop is the only normal render driver. Browsers may throttle it while a tab is hidden, unfocused, or occluded, leaving the canvas blank or stale until another interaction. This ports the valid contribution from #291/#439 onto the current timer/rAF implementation.

Supersedes #291 and #439.
Fixes #275.
Closes #196.

## Validation
- `bun run check`
- `bun run check-types`
- `bun run build`

Co-authored with @mvanhorn.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized viewer render-loop behavior with proper listener cleanup; bake/timer path unchanged.
> 
> **Overview**
> Fixes **stale or blank WebGL canvas** when the user returns to a tab that uses a custom `requestAnimationFrame` loop with `frameloop: 'never'`.
> 
> **FrameLimiter** now registers **`visibilitychange`**, **`focus`**, and **`pageshow`** handlers (only on the normal rAF path, not `?disable=draw`) that call a shared **`kick()`** to **`syncSize()`** once and **`advance()`** one frame so the scene repaints immediately after the browser throttles rAF while hidden or unfocused. Renderer sizing is centralized in **`syncSize()`** and used from both the rAF tick and resume kicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dda767ebf367b020daab666ca2c14be69898c70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->