### PR TITLE
test(nodes): isolate cabinet regression suites

### DIFF
--- a/packages/nodes/src/cabinet/__tests__/geometry.test.ts
+++ b/packages/nodes/src/cabinet/__tests__/geometry.test.ts
@@ -2319,9 +2319,17 @@ describe('cabinet handles', () => {
       sceneApi: ReturnType<typeof sceneApiFixture>,
     ) => HandleDescriptor<CabinetNode>[]
     const depthHandles = buildHandles(source, fixture.sceneApi).filter(
-      (handle): handle is LinearResizeHandle<CabinetNode> =>
-        handle.kind === 'linear-resize' &&
-        handle.visible?.(source, fixture.sceneApi as never) !== false,
+      (handle): handle is LinearResizeHandle<CabinetNode> => {
+        if (
+          handle.kind !== 'linear-resize' ||
+          handle.visible?.(source, fixture.sceneApi as never) === false
+        ) {
+          return false
+        }
+        const targetId = handle.overrideTarget?.(source, fixture.sceneApi as never) ?? source.id
+        const target = fixture.sceneApi.get(targetId)
+        return target?.type === 'cabinet' && target.runTier === 'base'
+      },
     )
     return { ...fixture, depthHandles, source, thirdRun }
   }
@@ -2613,6 +2621,7 @@ describe('cabinet handles', () => {
       [run, ...modules].map((node) => [node.id as AnyNodeId, node as AnyNode]),
     ) as Record<AnyNodeId, AnyNode>
     const sceneApi = {
+      get: (id: AnyNodeId) => nodes[id],
       nodes: () => nodes,
     }
     const rotateHandle = (

--- a/packages/nodes/src/cabinet/__tests__/wall-depth-handles.test.ts
+++ b/packages/nodes/src/cabinet/__tests__/wall-depth-handles.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import type {
   AnyNode,
   AnyNodeId,
@@ -8,18 +8,9 @@ import type {
   LinearResizeHandle,
   SceneApi,
 } from '@pascal-app/core'
+import { cabinetDefinition, cabinetModuleDefinition } from '../definition'
 import { addCornerRun } from '../run-ops'
 import { CabinetModuleNode, CabinetNode } from '../schema'
-
-mock.module('../floorplan-move', () => ({ cabinetModuleFloorplanMoveTarget: () => null }))
-mock.module('../floorplan', () => ({
-  buildCabinetFloorplan: () => null,
-  buildCabinetModuleFloorplan: () => null,
-}))
-mock.module('../geometry', () => ({ buildCabinetGeometry: () => null }))
-mock.module('../paint', () => ({ cabinetPaint: {} }))
-
-const { cabinetDefinition, cabinetModuleDefinition } = await import('../definition')
 
 function wallDepthFixture() {
   const root = {

--- a/packages/nodes/src/wall/treatments.test.ts
+++ b/packages/nodes/src/wall/treatments.test.ts
@@ -1,14 +1,7 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import type { WallNode, WallTrimConfig } from '@pascal-app/core'
 import { buildWallTreatmentLevelData } from './treatment-level-data'
-
-mock.module('@pascal-app/viewer', () => ({
-  baseMaterial: () => undefined,
-  createMaterialFromPresetRef: () => undefined,
-  resolveMaterialRef: () => undefined,
-}))
-
-const { buildTrimGeometry, wallTreatmentProudOffsets } = await import('./treatments')
+import { buildTrimGeometry, wallTreatmentProudOffsets } from './treatments'
 
 function wall(id: string, start: [number, number], end: [number, number]): WallNode {
   return {


### PR DESCRIPTION
## Summary

- remove process-global module mocks that made cabinet and wall test outcomes depend on test ordering
- scope chained-cabinet handle assertions to base runs while preserving the intended wall-depth handles
- complete the rotation test SceneApi fixture for the current handle traversal contract

## Verification

- `bun check`
- `bun test` — 2,477 passed, 1 skipped, 0 failed
- focused cabinet geometry, wall-depth handle, and wall treatment suites — 106 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code touched; risk is limited to possible test flakiness if real imports pull in heavier dependencies.
> 
> **Overview**
> Cabinet and wall regression tests no longer rely on `mock.module` / deferred dynamic imports for `definition`, `treatments`, or heavy cabinet subsystems—those suites import the real modules directly so they are less coupled to global Bun mocks.
> 
> In `geometry.test.ts`, **chained L-group** depth-handle collection now resolves each handle’s `overrideTarget` and keeps only **base-tier** cabinet runs (excluding wall-tier targets). The run-rotation test’s minimal `sceneApi` stub also implements **`get`** so handle lookup matches other fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f781807c28883d84132d348a7c8f6c32845815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->