### PR TITLE
fix(viewer): harden WebGPU slab recovery

### DIFF
--- a/packages/nodes/src/slab/__tests__/geometry.test.ts
+++ b/packages/nodes/src/slab/__tests__/geometry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { SlabNode } from '@pascal-app/core'
+import { Mesh } from 'three'
+import { buildSlabGeometry } from '../geometry'
+
+describe('buildSlabGeometry', () => {
+  test('copies the primary UVs into uv2 for every slab mesh', () => {
+    const slab = SlabNode.parse({
+      polygon: [
+        [0, 0],
+        [2, 0],
+        [2, 2],
+        [0, 2],
+      ],
+    })
+
+    const group = buildSlabGeometry(slab, undefined, 'solid', false)
+    const meshes = group.children.filter((child): child is Mesh => child instanceof Mesh)
+
+    expect(meshes).toHaveLength(2)
+    for (const mesh of meshes) {
+      const uv = mesh.geometry.getAttribute('uv')
+      const uv2 = mesh.geometry.getAttribute('uv2')
+
+      expect(uv2).toBeDefined()
+      expect(uv2.itemSize).toBe(2)
+      expect(uv2.count).toBe(uv.count)
+      expect(Array.from(uv2.array)).toEqual(Array.from(uv.array))
+    }
+  })
+})

--- a/packages/nodes/src/slab/geometry.ts
+++ b/packages/nodes/src/slab/geometry.ts
@@ -127,7 +127,10 @@ function splitSlabFacesByFacing(geometry: BufferGeometry): {
   const build = (data: { pos: number[]; uv: number[] }) => {
     const geo = new BufferGeometry()
     geo.setAttribute('position', new Float32BufferAttribute(data.pos, 3))
-    if (data.uv.length > 0) geo.setAttribute('uv', new Float32BufferAttribute(data.uv, 2))
+    if (data.uv.length > 0) {
+      geo.setAttribute('uv', new Float32BufferAttribute(data.uv, 2))
+      geo.setAttribute('uv2', new Float32BufferAttribute(data.uv.slice(), 2))
+    }
     geo.computeVertexNormals()
     return geo
   }

--- a/packages/viewer/src/components/viewer/post-processing.tsx
+++ b/packages/viewer/src/components/viewer/post-processing.tsx
@@ -755,6 +755,8 @@ const PostProcessingPasses = ({
       }
     } catch (error) {
       hasPipelineErrorRef.current = true
+      // A failed MRT pass may leave its target bound; clear it before the fallback render.
+      ;(renderer as any).setRenderTarget?.(null)
       console.error('[viewer/post-processing] Render pass failed.', {
         retryCount: retryCountRef.current,
         rendererCtor: (renderer as any).constructor?.name,


### PR DESCRIPTION
## Summary

- copy slab primary UVs into a dedicated uv2 attribute after face splitting
- reset the renderer target when an MRT post-processing pass throws
- add a regression test covering uv2 on both slab meshes

This ports the two still-relevant fixes from #464 onto current main and credits Connor Soohoo in the commit. The empty-roof part of #464 is already superseded by the broader export hardening in #466.

## Verification

- bun test src/slab/__tests__/geometry.test.ts src/slab/__tests__/definition.test.ts (from packages/nodes)
- bun run check
- bun run check-types
- bun run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches per-frame WebGPU render error handling and slab GPU geometry attributes; limited scope but affects viewer stability when MRT passes fail.
> 
> **Overview**
> Hardens **WebGPU** rendering for slabs and post-processing recovery paths.
> 
> When slab geometry is split into top/side meshes, **`splitSlabFacesByFacing`** now duplicates primary **`uv`** into **`uv2`** on both sub-geometries (same pattern as columns/roofs), so node-material / MRT pipelines don’t hit missing **`uv2`** bindings. A regression test asserts **`uv2`** matches **`uv`** on both slab meshes from **`buildSlabGeometry`**.
> 
> If the WebGPU **MRT** post-processing **`render()`** throws, the viewer calls **`setRenderTarget(null)`** before disposing the pipeline and retrying/falling back, so a stuck MRT target doesn’t poison the direct **`renderer.render`** fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30a024957b216a17b347acccac37200cc6b5c6f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->