### PR TITLE
fix(viewer): stack levels per building

### DIFF
--- a/packages/viewer/src/systems/level/level-stacking.test.ts
+++ b/packages/viewer/src/systems/level/level-stacking.test.ts
@@ -1,0 +1,48 @@
+// @ts-expect-error — bun:test is provided by the Bun runtime; viewer does not
+// include Bun ambient types in its production declaration build.
+import { describe, expect, test } from 'bun:test'
+import { getLevelStackPositions, type LevelStackEntry } from './level-stacking'
+
+describe('getLevelStackPositions', () => {
+  test('stacks levels within one building by level index', () => {
+    const entries: LevelStackEntry[] = [
+      { levelId: 'level_second', buildingId: 'building_a', index: 2, height: 3.4 },
+      { levelId: 'level_ground', buildingId: 'building_a', index: 0, height: 2.5 },
+      { levelId: 'level_first', buildingId: 'building_a', index: 1, height: 3.1 },
+    ]
+
+    expect(Object.fromEntries(getLevelStackPositions(entries))).toEqual({
+      level_ground: 0,
+      level_first: 2.5,
+      level_second: 5.6,
+    })
+  })
+
+  test('starts each building on its own ground plane', () => {
+    const entries: LevelStackEntry[] = [
+      { levelId: 'level_a0', buildingId: 'building_a', index: 0, height: 2.5 },
+      { levelId: 'level_b0', buildingId: 'building_b', index: 0, height: 3 },
+      { levelId: 'level_a1', buildingId: 'building_a', index: 1, height: 2.8 },
+      { levelId: 'level_b1', buildingId: 'building_b', index: 1, height: 3.2 },
+    ]
+
+    expect(Object.fromEntries(getLevelStackPositions(entries))).toEqual({
+      level_a0: 0,
+      level_b0: 0,
+      level_a1: 2.5,
+      level_b1: 3,
+    })
+  })
+
+  test('keeps orphan levels in one legacy stack', () => {
+    const entries: LevelStackEntry[] = [
+      { levelId: 'level_0', buildingId: null, index: 0, height: 2.7 },
+      { levelId: 'level_1', buildingId: null, index: 1, height: 3 },
+    ]
+
+    expect(Object.fromEntries(getLevelStackPositions(entries))).toEqual({
+      level_0: 0,
+      level_1: 2.7,
+    })
+  })
+})

--- a/packages/viewer/src/systems/level/level-stacking.test.ts
+++ b/packages/viewer/src/systems/level/level-stacking.test.ts
@@ -1,7 +1,26 @@
 // @ts-expect-error — bun:test is provided by the Bun runtime; viewer does not
 // include Bun ambient types in its production declaration build.
 import { describe, expect, test } from 'bun:test'
-import { getLevelStackPositions, type LevelStackEntry } from './level-stacking'
+import { getLevelBuildingId, getLevelStackPositions, type LevelStackEntry } from './level-stacking'
+
+describe('getLevelBuildingId', () => {
+  const buildings = [
+    { id: 'building_a', children: ['level_a0'] },
+    { id: 'building_b', children: ['level_b0'] },
+  ]
+
+  test('uses an explicit building parent', () => {
+    expect(getLevelBuildingId('level_a0', 'building_a', buildings)).toBe('building_a')
+  })
+
+  test('falls back to building children for legacy levels without a parentId', () => {
+    expect(getLevelBuildingId('level_b0', null, buildings)).toBe('building_b')
+  })
+
+  test('ignores a non-building parent before checking building children', () => {
+    expect(getLevelBuildingId('level_a0', 'site_main', buildings)).toBe('building_a')
+  })
+})
 
 describe('getLevelStackPositions', () => {
   test('stacks levels within one building by level index', () => {

--- a/packages/viewer/src/systems/level/level-stacking.ts
+++ b/packages/viewer/src/systems/level/level-stacking.ts
@@ -5,6 +5,19 @@ export type LevelStackEntry = {
   height: number
 }
 
+type BuildingOwnership = { id: string; children: readonly string[] }
+
+export function getLevelBuildingId(
+  levelId: string,
+  parentId: string | null,
+  buildings: readonly BuildingOwnership[],
+): string | null {
+  const directParent = parentId ? buildings.find((building) => building.id === parentId) : undefined
+  if (directParent) return directParent.id
+
+  return buildings.find((building) => building.children.includes(levelId))?.id ?? null
+}
+
 export function getLevelStackPositions(entries: readonly LevelStackEntry[]): Map<string, number> {
   const positions = new Map<string, number>()
   const cumulativeYByBuilding = new Map<string | null, number>()

--- a/packages/viewer/src/systems/level/level-stacking.ts
+++ b/packages/viewer/src/systems/level/level-stacking.ts
@@ -1,0 +1,19 @@
+export type LevelStackEntry = {
+  levelId: string
+  buildingId: string | null
+  index: number
+  height: number
+}
+
+export function getLevelStackPositions(entries: readonly LevelStackEntry[]): Map<string, number> {
+  const positions = new Map<string, number>()
+  const cumulativeYByBuilding = new Map<string | null, number>()
+
+  for (const entry of [...entries].sort((a, b) => a.index - b.index)) {
+    const baseY = cumulativeYByBuilding.get(entry.buildingId) ?? 0
+    positions.set(entry.levelId, baseY)
+    cumulativeYByBuilding.set(entry.buildingId, baseY + entry.height)
+  }
+
+  return positions
+}

--- a/packages/viewer/src/systems/level/level-system.tsx
+++ b/packages/viewer/src/systems/level/level-system.tsx
@@ -4,6 +4,7 @@ import type { Object3D } from 'three'
 import { lerp } from 'three/src/math/MathUtils.js'
 import { applyShadowOnly, clearShadowOnly } from '../../lib/shadow-only'
 import useViewer from '../../store/use-viewer'
+import { getLevelStackPositions } from './level-stacking'
 
 const EXPLODED_GAP = 5
 
@@ -19,31 +20,41 @@ export const LevelSystem = () => {
     const levelMode = useViewer.getState().levelMode
     const selectedLevel = useViewer.getState().selection.levelId
 
-    // Collect and sort levels by floor index so we can compute cumulative offsets.
+    // Collect level heights so each building can compute its own cumulative offsets.
     // Level 0 → Y=0, Level 1 → Y=height(0), Level 2 → Y=height(0)+height(1), etc.
     type LevelEntry = {
       levelId: string
+      buildingId: string | null
       index: number
+      height: number
       obj: NonNullable<ReturnType<typeof sceneRegistry.nodes.get>>
     }
     const entries: LevelEntry[] = []
     sceneRegistry.byType.level!.forEach((levelId) => {
       const obj = sceneRegistry.nodes.get(levelId)
-      const level = nodes[levelId as LevelNode['id']]
+      const level = nodes[levelId as LevelNode['id']] as LevelNode | undefined
       if (obj && level) {
-        entries.push({ levelId, index: (level as any).level ?? 0, obj })
+        entries.push({
+          levelId,
+          buildingId: level.parentId ?? null,
+          index: level.level,
+          height: getLevelHeight(
+            levelId,
+            nodes,
+            (wallId) => sceneRegistry.nodes.get(wallId)?.position.y,
+          ),
+          obj,
+        })
       }
     })
-    entries.sort((a, b) => a.index - b.index)
+    const stackPositions = getLevelStackPositions(entries)
 
-    // Walk sorted levels, accumulating base Y offsets
     const selectedIndex = selectedLevel
       ? entries.find((e) => e.levelId === selectedLevel)?.index
       : undefined
-    let cumulativeY = 0
     for (const { levelId, index, obj } of entries) {
-      const level = nodes[levelId as LevelNode['id']]
-      const baseY = cumulativeY
+      const level = nodes[levelId as LevelNode['id']] as LevelNode | undefined
+      const baseY = stackPositions.get(levelId) ?? 0
       const explodedExtra = levelMode === 'exploded' ? index * EXPLODED_GAP : 0
       const targetY = baseY + explodedExtra
 
@@ -65,12 +76,6 @@ export const LevelSystem = () => {
         }
         obj.visible = !hidden
       }
-
-      cumulativeY += getLevelHeight(
-        levelId,
-        nodes,
-        (wallId) => sceneRegistry.nodes.get(wallId)?.position.y,
-      )
     }
   }, 5) // Using a lower priority so it runs after transforms from other systems have settled
   return null

--- a/packages/viewer/src/systems/level/level-system.tsx
+++ b/packages/viewer/src/systems/level/level-system.tsx
@@ -1,10 +1,16 @@
-import { getLevelHeight, type LevelNode, sceneRegistry, useScene } from '@pascal-app/core'
+import {
+  type BuildingNode,
+  getLevelHeight,
+  type LevelNode,
+  sceneRegistry,
+  useScene,
+} from '@pascal-app/core'
 import { useFrame } from '@react-three/fiber'
 import type { Object3D } from 'three'
 import { lerp } from 'three/src/math/MathUtils.js'
 import { applyShadowOnly, clearShadowOnly } from '../../lib/shadow-only'
 import useViewer from '../../store/use-viewer'
-import { getLevelStackPositions } from './level-stacking'
+import { getLevelBuildingId, getLevelStackPositions } from './level-stacking'
 
 const EXPLODED_GAP = 5
 
@@ -30,13 +36,16 @@ export const LevelSystem = () => {
       obj: NonNullable<ReturnType<typeof sceneRegistry.nodes.get>>
     }
     const entries: LevelEntry[] = []
+    const buildings = Object.values(nodes).filter(
+      (node): node is BuildingNode => node?.type === 'building',
+    )
     sceneRegistry.byType.level!.forEach((levelId) => {
       const obj = sceneRegistry.nodes.get(levelId)
       const level = nodes[levelId as LevelNode['id']] as LevelNode | undefined
       if (obj && level) {
         entries.push({
           levelId,
-          buildingId: level.parentId ?? null,
+          buildingId: getLevelBuildingId(levelId, level.parentId, buildings),
           index: level.level,
           height: getLevelHeight(
             levelId,

--- a/packages/viewer/src/systems/level/level-utils.ts
+++ b/packages/viewer/src/systems/level/level-utils.ts
@@ -1,5 +1,11 @@
-import { getLevelHeight, type LevelNode, sceneRegistry, useScene } from '@pascal-app/core'
-import { getLevelStackPositions } from './level-stacking'
+import {
+  type BuildingNode,
+  getLevelHeight,
+  type LevelNode,
+  sceneRegistry,
+  useScene,
+} from '@pascal-app/core'
+import { getLevelBuildingId, getLevelStackPositions } from './level-stacking'
 
 /**
  * Instantly snaps all level Objects3D to their true stacked Y positions
@@ -25,13 +31,16 @@ export function snapLevelsToTruePositions(): () => void {
   }
 
   const entries: LevelEntry[] = []
+  const buildings = Object.values(nodes).filter(
+    (node): node is BuildingNode => node?.type === 'building',
+  )
   sceneRegistry.byType.level!.forEach((levelId) => {
     const obj = sceneRegistry.nodes.get(levelId)
     const level = nodes[levelId as LevelNode['id']] as LevelNode | undefined
     if (obj && level) {
       entries.push({
         levelId,
-        buildingId: level.parentId ?? null,
+        buildingId: getLevelBuildingId(levelId, level.parentId, buildings),
         index: level.level,
         height: getLevelHeight(
           levelId,

--- a/packages/viewer/src/systems/level/level-utils.ts
+++ b/packages/viewer/src/systems/level/level-utils.ts
@@ -1,4 +1,5 @@
 import { getLevelHeight, type LevelNode, sceneRegistry, useScene } from '@pascal-app/core'
+import { getLevelStackPositions } from './level-stacking'
 
 /**
  * Instantly snaps all level Objects3D to their true stacked Y positions
@@ -18,18 +19,30 @@ export function snapLevelsToTruePositions(): () => void {
   type LevelEntry = {
     obj: NonNullable<ReturnType<typeof sceneRegistry.nodes.get>>
     levelId: string
+    buildingId: string | null
     index: number
+    height: number
   }
 
   const entries: LevelEntry[] = []
   sceneRegistry.byType.level!.forEach((levelId) => {
     const obj = sceneRegistry.nodes.get(levelId)
-    const level = nodes[levelId as LevelNode['id']]
+    const level = nodes[levelId as LevelNode['id']] as LevelNode | undefined
     if (obj && level) {
-      entries.push({ levelId, index: (level as any).level ?? 0, obj })
+      entries.push({
+        levelId,
+        buildingId: level.parentId ?? null,
+        index: level.level,
+        height: getLevelHeight(
+          levelId,
+          nodes,
+          (wallId) => sceneRegistry.nodes.get(wallId)?.position.y,
+        ),
+        obj,
+      })
     }
   })
-  entries.sort((a, b) => a.index - b.index)
+  const stackPositions = getLevelStackPositions(entries)
 
   // Snapshot current Y and visibility so we can restore them after the render
   const snapshot = new Map(
@@ -37,15 +50,9 @@ export function snapLevelsToTruePositions(): () => void {
   )
 
   // Snap to true stacked positions and make all levels visible
-  let cumulativeY = 0
   for (const { levelId, obj } of entries) {
-    obj.position.y = cumulativeY
+    obj.position.y = stackPositions.get(levelId) ?? 0
     obj.visible = true
-    cumulativeY += getLevelHeight(
-      levelId,
-      nodes,
-      (wallId) => sceneRegistry.nodes.get(wallId)?.position.y,
-    )
   }
 
   return () => {


### PR DESCRIPTION
Fixes #511.

## What changed

- compute cumulative level heights independently for each building
- share the same stacking calculation between the live `LevelSystem` and the temporary true-position snap used by exports and thumbnails
- preserve the existing single stack for legacy orphan levels
- cover single-building, multi-building, and orphan-level cases with focused tests

## Why

`LevelSystem` previously sorted every registered level together and used one global cumulative Y offset. A second building's ground floor therefore started above the first building instead of on its own ground plane. The export/thumbnail helper duplicated the same global-stack behavior.

Thanks @archicorp46-debug for the precise report and reproduction.

## Verification

- `bun test packages/viewer/src/systems/level/level-stacking.test.ts`
- `bun run --filter @pascal-app/viewer build`
- `bun check`
- `bun check-types`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core 3D level positioning for all scenes; behavior is well-tested for multi-building and legacy orphans but wrong building resolution could mis-stack levels visually.
> 
> **Overview**
> Fixes multi-building scenes where every level was stacked on one global Y ladder, so a second building’s ground floor appeared above the first.
> 
> The PR adds **`level-stacking`** helpers: **`getLevelBuildingId`** (building parent or legacy children lookup) and **`getLevelStackPositions`** (cumulative height per `buildingId`, with orphan levels sharing one `null` stack). **`LevelSystem`** and **`snapLevelsToTruePositions`** in **`level-utils`** now build the same entries and read Y from that map instead of a single walk over all levels. Bun tests cover single-building order, independent ground planes per building, and orphan legacy stacking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e6a71a21c0b022af674bc4064b9031aa1e5cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->