### PR TITLE
chore: add a verified Bun devcontainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.8",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2",
+      "integrity": "sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "Pascal Editor",
+  "image": "oven/bun:1.3.0",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "postCreateCommand": "bun install",
+  "forwardPorts": [3002]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,6 @@
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  "postCreateCommand": "bun install",
+  "postCreateCommand": "bun install --frozen-lockfile",
   "forwardPorts": [3002]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ bun install
 bun dev
 ```
 
-The editor will be running at **http://localhost:3000**. That's it!
+The editor will be running at **http://localhost:3002**. That's it!
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ bun dev
 # 1. Build @pascal-app/core and @pascal-app/viewer
 # 2. Start watching both packages for changes
 # 3. Start the Next.js editor dev server
-# Open http://localhost:3000
+# Open http://localhost:3002
 ```
 
 **Important:** Always run `bun dev` from the root directory to ensure the package watchers are running. This enables hot reload when you edit files in `packages/core/src/` or `packages/viewer/src/`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -11,7 +11,7 @@ bun install
 bun dev
 ```
 
-The editor will be running at **http://localhost:3000**.
+The editor will be running at **http://localhost:3002**.
 
 ## Environment Variables (optional)
 
@@ -24,7 +24,7 @@ cp .env.example .env
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` | No | Enables address search in the editor |
-| `PORT` | No | Dev server port (default: 3000) |
+| `PORT` | No | Dev server port (default: 3002) |
 
 The editor works fully without any environment variables.
 

--- a/apps/editor/README.md
+++ b/apps/editor/README.md
@@ -345,7 +345,7 @@ pnpm install
 # Run development server
 pnpm dev
 
-# Open http://localhost:3000
+# Open http://localhost:3002
 ```
 
 ---


### PR DESCRIPTION
Ports the contributor work from #273 onto current main while preserving the original commit authorship.

## What changed
- add a Bun 1.3 devcontainer with Git and GitHub CLI features
- pin resolved feature versions in the generated devcontainer lockfile
- install with the frozen workspace lockfile
- forward the editor port, 3002
- correct stale 3000 references in contributor and setup docs

## Verification
- bun check
- bunx @devcontainers/cli up --workspace-folder .
- frozen bun install completed inside the new container
- bun dev reached the editor and IFC converter Ready states inside the container
- bun --filter editor dev reached Ready on 3002
- curl from inside the container returned HTTP 200 from http://127.0.0.1:3002 and loaded the built-in node registry

The disposable verification container was removed after the check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Devcontainer and documentation-only changes; no runtime application or security logic is modified.
> 
> **Overview**
> Adds a **Pascal Editor** dev container on `oven/bun:1.3.0` with Git and GitHub CLI features, `bun install --frozen-lockfile` on create, and port **3002** forwarded for the editor.
> 
> Introduces `devcontainer-lock.json` to pin resolved versions for those container features.
> 
> Updates contributor/setup READMEs so local dev URLs and the documented default `PORT` use **3002** instead of **3000** (no application code changes in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5024c50f092ab51a119fe9255ed984d4cc39d118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->