### PR TITLE
fix(editor): polyfill structuredClone for legacy browsers (Sentry MONOREPO-EDITOR-FB)

### DIFF
--- a/apps/editor/instrumentation-client.ts
+++ b/apps/editor/instrumentation-client.ts
@@ -1,0 +1,1 @@
+import './lib/polyfills/structured-clone'

--- a/apps/editor/lib/polyfills/structured-clone.ts
+++ b/apps/editor/lib/polyfills/structured-clone.ts
@@ -1,0 +1,5 @@
+import structuredClonePolyfill from '@ungap/structured-clone'
+
+if (typeof globalThis.structuredClone !== 'function') {
+  globalThis.structuredClone = structuredClonePolyfill
+}

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -23,6 +23,7 @@
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@tailwindcss/postcss": "^4.2.1",
+    "@ungap/structured-clone": "^1.3.3",
     "clsx": "^2.1.1",
     "geist": "^1.7.0",
     "lucide-react": "^1.7.0",

--- a/apps/editor/types/ungap-structured-clone.d.ts
+++ b/apps/editor/types/ungap-structured-clone.d.ts
@@ -1,0 +1,8 @@
+declare module '@ungap/structured-clone' {
+  type StructuredCloneOptions = StructuredSerializeOptions & {
+    json?: boolean
+    lossy?: boolean
+  }
+
+  export default function structuredClone<T>(value: T, options?: StructuredCloneOptions): T
+}

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@tailwindcss/postcss": "^4.2.1",
+        "@ungap/structured-clone": "^1.3.3",
         "clsx": "^2.1.1",
         "geist": "^1.7.0",
         "lucide-react": "^1.7.0",
@@ -923,6 +924,8 @@
     "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260624.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-BgkqbCmSHDb5UxqWaFlFFJ/DHNT3lEUO4W8627ap6+QthJZuXk2imiHAX3PgYXC6en9fLLyR6jjcseAa4CCshg=="],
 
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260624.1", "", { "os": "win32", "cpu": "x64" }, "sha512-WaZ+ue63NgB2j/lqjirfevh/TqcsCxSqnKhGGiRnlxHyYIBcoq+x7KngyEnyGIaywJE1PcFeXA+2EMSIPlSEiQ=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
     "@use-gesture/core": ["@use-gesture/core@10.3.1", "", {}, "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="],
 


### PR DESCRIPTION
## Summary
- add a guarded `structuredClone` polyfill for browsers that do not provide the native API
- load it from Next.js `instrumentation-client.ts` before the editor's client modules are evaluated
- add a local TypeScript declaration for `@ungap/structured-clone`

## Sentry issue
Sentry issue **MONOREPO-EDITOR-FB** shows the public viewer failing entirely on legacy Android browsers (including Honor Browser 9.8.0 / Chromium <98) with `ReferenceError: structuredClone is not defined`.

`@pascal-app/lingo@0.2.0` calls `structuredClone` during module initialization through `registerKind`. The package is imported by `packages/editor/src/lib/measurement-parser.ts`, so app-level component guards run too late. Installing the global fallback from the client instrumentation entry ensures it exists before the editor/lingo module graph is evaluated.

## Validation
- `bun install --frozen-lockfile` ✅
- Biome lint on the new instrumentation/polyfill/type declaration files ✅
- editor app typecheck: touched files pass, but the command remains red due to existing unrelated workspace type/export mismatches

Generated from the nightly Sentry triage cron.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, guarded client bootstrap change with a well-known polyfill; native browsers are untouched and scope is limited to the editor app.
> 
> **Overview**
> Fixes **hard crashes on legacy browsers** (e.g. older Android / Chromium &lt;98) where `structuredClone` is missing and the editor fails during module load (Sentry **MONOREPO-EDITOR-FB**).
> 
> The editor app now depends on **`@ungap/structured-clone`** and installs a **guarded** global fallback in `lib/polyfills/structured-clone.ts` (only when `globalThis.structuredClone` is not a function). That polyfill is pulled in from **`instrumentation-client.ts`** so it runs **before** the rest of the client bundle—important because dependencies such as **`@pascal-app/lingo`** can call `structuredClone` at import time.
> 
> A local **`ungap-structured-clone.d.ts`** types the polyfill package for TypeScript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e380b05bb2d2cf454f634df8e3b919c108b23b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->