### PR TITLE
fix(nodes): guard missing roof-segment trim in ridge-vent geometry key (Sentry MONOREPO-EDITOR-ED)

### DIFF
--- a/packages/core/src/schema/nodes/roof-segment-trim.test.ts
+++ b/packages/core/src/schema/nodes/roof-segment-trim.test.ts
@@ -32,6 +32,15 @@ describe('roof segment trim', () => {
     })
   })
 
+  // Scene loading casts migrated roof-segments instead of zod-parsing them, so a
+  // segment saved before `trim` existed reaches renderers with the field absent.
+  test('tolerates a segment carrying no trim at all', () => {
+    const trim = normalizeRoofSegmentTrim({ width: 8, depth: 6 })
+
+    expect(trim.left).toBe(0)
+    expect(trim.backRightZ).toBe(0)
+  })
+
   test('normalizes impossible side totals without inverting the footprint', () => {
     const trim = normalizeRoofSegmentTrim({
       width: 4,

--- a/packages/nodes/src/ridge-vent/renderer.tsx
+++ b/packages/nodes/src/ridge-vent/renderer.tsx
@@ -4,6 +4,7 @@ import {
   type AnyNodeId,
   getEffectiveRoofSurfaceMaterial,
   getEffectiveSegmentSurfaceMaterial,
+  normalizeRoofSegmentTrim,
   type RidgeVentNode,
   type RoofNode,
   type RoofSegmentNode,
@@ -29,7 +30,7 @@ import { buildRidgeVentGeometry } from './geometry'
 
 function ridgeVentSegmentGeometryKey(segment: RoofSegmentNode | undefined): string {
   if (!segment) return 'none'
-  const trim = segment.trim
+  const trim = normalizeRoofSegmentTrim(segment)
   return [
     segment.roofType,
     segment.width,


### PR DESCRIPTION
## Summary
- tolerate roof segments whose stored data predates the `trim` schema field
- keep the ridge-vent geometry dependency key stable by reading trim fields from an empty partial object when `segment.trim` is missing

## Root cause
The public viewer hydrates raw stored nodes without re-running the Zod parser. For legacy roof segments, that means the `RoofSegmentTrim` schema default never applies and `segment.trim` can be `undefined` at runtime. `ridgeVentSegmentGeometryKey` then dereferenced `trim.left`, crashing the viewer.

`buildRidgeVentGeometry` already routes trim handling through `normalizeRoofSegmentTrim`, so no additional guard was needed there.

## Sentry
- [MONOREPO-EDITOR-ED](https://pascalorg.sentry.io/issues/7593979332/)
- Issue `7593979332`
- Observed July 22, 2026 on `/viewer/project_myTyG1YFgGBVpS6O`

## Validation
- `bun test packages/nodes/src/ridge-vent/__tests__/geometry.test.ts` — 18 pass, 0 fail
- `bunx biome check packages/nodes/src/ridge-vent/renderer.tsx` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in ridge-vent rendering; aligns geometry key with existing normalization used elsewhere.
> 
> **Overview**
> Fixes a **viewer crash** when ridge vents render on **legacy roof segments** that were saved before the `trim` field existed. The public viewer hydrates nodes without re-running Zod, so `segment.trim` can be `undefined` even though parsed segments get defaults.
> 
> **`ridgeVentSegmentGeometryKey`** now builds its cache key from **`normalizeRoofSegmentTrim(segment)`** instead of reading `segment.trim` directly, matching how **`buildRidgeVentGeometry`** already handles trim. A core test documents that segments with no `trim` at all normalize to zero trim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdf09a3c419b95ea7119783703875db19f3d7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->