### PR TITLE
editor: stop wall endpoint drag snapping back to the stale junction corner

### DIFF
--- a/packages/editor/src/components/tools/wall/wall-drafting.test.ts
+++ b/packages/editor/src/components/tools/wall/wall-drafting.test.ts
@@ -327,4 +327,35 @@ describe('snapWallDraftPointDetailed', () => {
     expect(result.point).toEqual([3.99, 0.03])
     expect(result.snap).toBeNull()
   })
+
+  // Endpoint-move regression: walls attached to the moving corner keep their
+  // pre-drag coordinates in the scene during the drag, so their stale corner
+  // recreates the old junction inside the connect radius. The move tools must
+  // pass those walls in `ignoreWallIds` (attached mode) or a sub-5cm corner
+  // correction — e.g. squaring a scan-imported 91° junction — can never land.
+  test('a stale linked-wall corner swallows a sub-connect-radius correction unless ignored', () => {
+    // `wall_d` shares the dragged corner of `wall_c` at [2, 0.03]; the user
+    // drops 3cm away at [2, 0] to square the junction.
+    const linked = makeWall([2, 0.03], [2, 2], 'wall_d')
+
+    const captured = snapWallDraftPointDetailed({
+      point: [2, 0],
+      walls: [linked],
+      ignoreWallIds: ['wall_c'],
+      magnetic: false,
+      step: 0,
+    })
+    expect(captured.point).toEqual([2, 0.03])
+    expect(captured.snap).toBe('endpoint')
+
+    const freed = snapWallDraftPointDetailed({
+      point: [2, 0],
+      walls: [linked],
+      ignoreWallIds: ['wall_c', 'wall_d'],
+      magnetic: false,
+      step: 0,
+    })
+    expect(freed.point).toEqual([2, 0])
+    expect(freed.snap).toBeNull()
+  })
 })

--- a/packages/nodes/src/wall/floorplan-affordances.ts
+++ b/packages/nodes/src/wall/floorplan-affordances.ts
@@ -169,6 +169,18 @@ export const wallMoveEndpointAffordance: FloorplanAffordance<WallNode> = {
     const originalEnd: WallPlanPoint = [...node.end] as WallPlanPoint
     const linkedWalls = collectLinkedWalls(nodes, node.id, originalStart, originalEnd)
     const affectedIds: AnyNodeId[] = [node.id, ...linkedWalls.map((w) => w.id)]
+    const movingOriginal: WallPlanPoint = endpoint === 'start' ? originalStart : originalEnd
+    // Walls attached to the MOVING corner cascade with the drag, but the snap
+    // pipeline reads the scene store, which keeps their pre-drag coordinates
+    // until commit. Their stale corners would recreate the old junction as a
+    // snap/alignment target: inside the connect radius the endpoint could
+    // never land closer than ~5cm to where it started, making sub-5cm
+    // corrections (e.g. squaring a scan-imported 91° corner) impossible.
+    // Excluded while attached; under Alt-detach they stay put and remain
+    // legitimate targets. Mirrors the 3D move-endpoint tool.
+    const movingLinkedWallIds = linkedWalls
+      .filter((w) => pointsEqual(w.start, movingOriginal) || pointsEqual(w.end, movingOriginal))
+      .map((w) => w.id)
 
     // Remember the latest preview so `commit()` can write it tracked.
     let lastPrimaryStart: WallPlanPoint = originalStart
@@ -181,11 +193,12 @@ export const wallMoveEndpointAffordance: FloorplanAffordance<WallNode> = {
         // Re-collect walls every tick so the snap pipeline sees fresh
         // positions (matters when the user releases + re-grabs without
         // unmounting the layer). Snap reads from scene — which holds
-        // the pre-drag positions throughout — so the linked-wall snap
-        // targets stay anchored to where corners *were*, exactly like
-        // the legacy flow.
+        // the pre-drag positions throughout — so walls that cascade with
+        // the moving corner are excluded (stale coordinates); under
+        // Alt-detach they stay put, so they rejoin the candidate pool.
         const sceneNodes = useScene.getState().nodes
         const walls = collectLevelWalls(sceneNodes, node.id)
+        const staleWallIds = modifiers.altKey ? [node.id] : [node.id, ...movingLinkedWallIds]
         // The grid step follows the active snapping mode (`getSegmentGridStep()`
         // is 0 outside grid mode), so `'lines' / 'angles' / 'off'` no longer
         // force a grid snap the mode chip says is inactive. In `'angles'` mode
@@ -195,7 +208,7 @@ export const wallMoveEndpointAffordance: FloorplanAffordance<WallNode> = {
         const snapped = snapWallDraftPoint({
           point: planPoint as WallPlanPoint,
           walls,
-          ignoreWallIds: [node.id],
+          ignoreWallIds: staleWallIds,
           start: angleLocked ? fixedPoint : undefined,
           angleSnap: angleLocked,
           magnetic: isMagneticSnapActive(),
@@ -205,13 +218,15 @@ export const wallMoveEndpointAffordance: FloorplanAffordance<WallNode> = {
         // object's edge / wall face and publishes a guide. The guide is
         // DISPLAYED in every mode except Off (isAlignmentGuideActive); the
         // magnetic pull onto it is applied only in 'lines' mode
-        // (isMagneticSnapActive), like the draft tool does. The dragged wall and
-        // its linked siblings (which cascade with the corner) are excluded from
-        // the candidate pool. Alt is detach, NOT bypass.
+        // (isMagneticSnapActive), like the draft tool does. Only the dragged
+        // wall and the siblings cascading with the moving corner are excluded
+        // from the candidate pool — walls linked at the FIXED corner don't
+        // move, and their anchors are what let the dragged corner align back
+        // onto a true axis. Alt is detach, NOT bypass.
         const aligned = alignFloorplanDraftPoint(snapped, {
           applySnap: isMagneticSnapActive(),
           bypass: !isAlignmentGuideActive(),
-          excludeIds: [node.id, ...linkedWalls.map((w) => w.id)],
+          excludeIds: staleWallIds,
         }) as WallPlanPoint
 
         const primaryStart: WallPlanPoint = endpoint === 'start' ? aligned : fixedPoint

--- a/packages/nodes/src/wall/move-endpoint-tool.tsx
+++ b/packages/nodes/src/wall/move-endpoint-tool.tsx
@@ -264,10 +264,13 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
 
     pauseSceneHistory(useScene)
     let wasCommitted = false
-    // Last point handed to `applyPreview` — lets the Alt keydown/keyup
-    // handlers re-run the preview immediately on a modifier change instead of
-    // waiting for the next mousemove.
-    let lastMovedPoint: WallPlanPoint | null = null
+    // Last RAW cursor point from `grid:move` — lets the Alt keydown/keyup
+    // handlers re-run the FULL snap pipeline immediately on a modifier change
+    // instead of waiting for the next mousemove. The raw point (not the
+    // snapped one) matters: the snap/alignment candidate set depends on Alt
+    // (stale-junction exclusion above), so a point snapped under the previous
+    // modifier state must not be reused as-is.
+    let lastRawPoint: WallPlanPoint | null = null
     // The first pointer-up is the *grab* of a click-to-move; later ones are
     // drops. See the `!hasChanged` branch in `onPointerUp`.
     let hasReleasedOnce = false
@@ -311,7 +314,6 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
     }
 
     const applyPreview = (movingPoint: WallPlanPoint, detachLinkedWalls = false) => {
-      lastMovedPoint = movingPoint
       const nextStart = target.endpoint === 'start' ? movingPoint : fixedPoint
       const nextEnd = target.endpoint === 'end' ? movingPoint : fixedPoint
       const linkedUpdates = detachLinkedWalls
@@ -375,20 +377,14 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
       setTimeout(() => window.removeEventListener('click', swallow, { capture: true }), 300)
     }
 
-    const onGridMove = (event: GridEvent) => {
-      const planPoint: WallPlanPoint = [event.localPosition[0], event.localPosition[2]]
-      // The keydown listener can't observe an Alt press that predates the
-      // tool mounting; the pointer event can. Sync the shared ref (single Alt
-      // source for snap targets, preview, HUD badge, and commit) before the
-      // snap pipeline reads it.
-      if (event.nativeEvent.altKey !== altPressedRef.current) {
-        altPressedRef.current = event.nativeEvent.altKey
-        setAltPressed(event.nativeEvent.altKey)
-      }
-      // Endpoint move honours the active snapping mode (the HUD chip): grid →
-      // lattice; lines → magnetic corner/alignment snap; angles → lock the
-      // segment to 15° rays from the FIXED corner; off → raw. No Shift bypass —
-      // Shift cycles the mode now, and Off is the bypass.
+    // Full snap pipeline from a RAW cursor point to the applied endpoint —
+    // shared by `grid:move` and the Alt keydown/keyup handlers, since the
+    // candidate set (stale-junction exclusion) flips with the modifier.
+    // Endpoint move honours the active snapping mode (the HUD chip): grid →
+    // lattice; lines → magnetic corner/alignment snap; angles → lock the
+    // segment to 15° rays from the FIXED corner; off → raw. No Shift bypass —
+    // Shift cycles the mode now, and Off is the bypass.
+    const resolveDragPoint = (planPoint: WallPlanPoint): WallPlanPoint => {
       const snapResult = snapWallDraftPointDetailed({
         point: planPoint,
         walls: levelWalls,
@@ -461,7 +457,21 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
             : null,
         )
 
-      applyPreview(alignedPoint, altPressedRef.current)
+      return alignedPoint
+    }
+
+    const onGridMove = (event: GridEvent) => {
+      const planPoint: WallPlanPoint = [event.localPosition[0], event.localPosition[2]]
+      lastRawPoint = planPoint
+      // The keydown listener can't observe an Alt press that predates the
+      // tool mounting; the pointer event can. Sync the shared ref (single Alt
+      // source for snap targets, preview, HUD badge, and commit) before the
+      // snap pipeline reads it.
+      if (event.nativeEvent.altKey !== altPressedRef.current) {
+        altPressedRef.current = event.nativeEvent.altKey
+        setAltPressed(event.nativeEvent.altKey)
+      }
+      applyPreview(resolveDragPoint(planPoint), altPressedRef.current)
     }
 
     const onPointerUp = () => {
@@ -583,16 +593,17 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
       exitMoveMode()
     }
 
-    // Single Alt writer for keyboard transitions. Re-running the preview on
-    // the flip keeps geometry and the HUD badge in lockstep — detach reverts
-    // the linked walls instantly, re-attach snaps them onto the dragged point
-    // — without waiting for the next mousemove.
+    // Single Alt writer for keyboard transitions. Re-running the FULL snap
+    // pipeline from the raw cursor on the flip keeps geometry and the HUD
+    // badge in lockstep — detach reverts the linked walls instantly and
+    // re-snaps against their (now live) corners, re-attach drops them from
+    // the candidate set again — without waiting for the next mousemove.
     const setAltState = (pressed: boolean) => {
       if (altPressedRef.current === pressed) return
       altPressedRef.current = pressed
       setAltPressed(pressed)
-      if (lastMovedPoint) {
-        applyPreview(lastMovedPoint, pressed)
+      if (lastRawPoint) {
+        applyPreview(resolveDragPoint(lastRawPoint), pressed)
       }
     }
 

--- a/packages/nodes/src/wall/move-endpoint-tool.tsx
+++ b/packages/nodes/src/wall/move-endpoint-tool.tsx
@@ -229,6 +229,21 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
     const originalStart = originalStartRef.current
     const originalEnd = originalEndRef.current
     const fixedPoint = fixedPointRef.current
+    const movingOriginalPoint = target.endpoint === 'start' ? originalStart : originalEnd
+    // Walls attached to the MOVING corner cascade with the drag, but the snap
+    // pipeline reads the scene store, which keeps their pre-drag coordinates
+    // until commit. Their stale corners would recreate the old junction as a
+    // snap/alignment target: inside the connect radius the endpoint could
+    // never land closer than ~5cm to where it started, making sub-5cm
+    // corrections (e.g. squaring a scan-imported 91° corner) impossible.
+    // Excluded while attached; under Alt-detach they stay put and remain
+    // legitimate targets.
+    const movingLinkedWallIds = linkedOriginalsRef.current
+      .filter(
+        (wall) =>
+          samePoint(wall.start, movingOriginalPoint) || samePoint(wall.end, movingOriginalPoint),
+      )
+      .map((wall) => wall.id)
     const levelWalls = Object.values(useScene.getState().nodes).filter(
       (node): node is WallNode =>
         node?.type === 'wall' && (node.parentId ?? null) === (target.wall.parentId ?? null),
@@ -238,7 +253,14 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
     // fences, items, slabs, ceilings, columns), gathered once (the set is
     // stable during the drag). Coords are building-local, the same frame as
     // the cursor and the 3D guide layer, so the published guide lines up.
+    // The attached variant additionally drops anchors owned by walls that
+    // follow the moving corner (see `movingLinkedWallIds` above) — their
+    // scene coordinates are stale during the drag.
     const wallAlignmentCandidates = collectAlignmentAnchors(useScene.getState().nodes, nodeId)
+    const movingLinkedIdSet = new Set<string>(movingLinkedWallIds)
+    const attachedAlignmentCandidates = wallAlignmentCandidates.filter(
+      (anchor) => !movingLinkedIdSet.has(anchor.nodeId),
+    )
 
     pauseSceneHistory(useScene)
     let wasCommitted = false
@@ -355,6 +377,14 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
 
     const onGridMove = (event: GridEvent) => {
       const planPoint: WallPlanPoint = [event.localPosition[0], event.localPosition[2]]
+      // The keydown listener can't observe an Alt press that predates the
+      // tool mounting; the pointer event can. Sync the shared ref (single Alt
+      // source for snap targets, preview, HUD badge, and commit) before the
+      // snap pipeline reads it.
+      if (event.nativeEvent.altKey !== altPressedRef.current) {
+        altPressedRef.current = event.nativeEvent.altKey
+        setAltPressed(event.nativeEvent.altKey)
+      }
       // Endpoint move honours the active snapping mode (the HUD chip): grid →
       // lattice; lines → magnetic corner/alignment snap; angles → lock the
       // segment to 15° rays from the FIXED corner; off → raw. No Shift bypass —
@@ -362,7 +392,7 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
       const snapResult = snapWallDraftPointDetailed({
         point: planPoint,
         walls: levelWalls,
-        ignoreWallIds: [nodeId],
+        ignoreWallIds: altPressedRef.current ? [nodeId] : [nodeId, ...movingLinkedWallIds],
         start: fixedPoint,
         angleSnap: isAngleSnapActive(),
         magnetic: isMagneticSnapActive(),
@@ -379,10 +409,13 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
       // (isAlignmentGuideActive); the magnetic pull onto them is applied only in
       // 'lines' mode (isMagneticSnapActive).
       let alignedPoint = snappedPoint
-      if (isAlignmentGuideActive() && wallAlignmentCandidates.length > 0) {
+      const alignmentCandidates = altPressedRef.current
+        ? wallAlignmentCandidates
+        : attachedAlignmentCandidates
+      if (isAlignmentGuideActive() && alignmentCandidates.length > 0) {
         const ar = resolveAlignment({
           moving: [{ nodeId, kind: 'corner', x: snappedPoint[0], z: snappedPoint[1] }],
-          candidates: wallAlignmentCandidates,
+          candidates: alignmentCandidates,
           threshold: ALIGNMENT_THRESHOLD_M,
         })
         const magnetic = isMagneticSnapActive()
@@ -428,13 +461,6 @@ export const MoveWallEndpointTool: React.FC<{ target: MovingWallEndpoint }> = ({
             : null,
         )
 
-      // The keydown listener can't observe an Alt press that predates the
-      // tool mounting; the pointer event can. Sync the shared ref (single Alt
-      // source for preview, HUD badge, and commit) before applying.
-      if (event.nativeEvent.altKey !== altPressedRef.current) {
-        altPressedRef.current = event.nativeEvent.altKey
-        setAltPressed(event.nativeEvent.altKey)
-      }
       applyPreview(alignedPoint, altPressedRef.current)
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes an endpoint-drag trap that made small corner corrections impossible: walls attached to the moving corner cascade with the drag, but the snap pipeline reads the scene store, which keeps their pre-drag coordinates until commit. Their stale corners recreated the old junction as a snap/alignment target, so inside the connect radius (5cm in grid/angles/off, up to 70cm magnetic) the endpoint always got sucked back to exactly where it started. Any sub-5cm fix — e.g. squaring a scan-imported 91° junction — was unreachable in every snapping mode (the angle badge oscillates 89° ↔ 91°, 90° is a dead zone).

Both endpoint-move paths (3D `move-endpoint-tool.tsx` + 2D `wallMoveEndpointAffordance`) now exclude the walls linked at the **moving** corner from wall-snap candidates and alignment anchors while attached. Under Alt-detach they remain candidates — they stay put in that mode, so they're live geometry.

The 2D path also over-excluded in the other direction: it dropped *all* linked walls from the alignment pool, including walls linked at the **fixed** corner. Those don't move, and their anchors are exactly the axes that let the dragged corner self-heal onto a true 90°. They're back in the pool now, restoring 2D/3D parity.

Includes a regression test pinning the mechanism (a 3cm correction next to a stale linked corner is swallowed when the linked wall is a snap candidate, lands when ignored).

## How to test

1. Draw three walls meeting at one corner: two axis-aligned (one horizontal, one vertical) and a third that arrives ~1° off-axis (e.g. its far end 3cm off the horizontal's z line). The angle badge at the junction reads 91°.
2. In 3D, drag the tilted wall's far endpoint with snapping in `lines` mode: the alignment guide from the axis-aligned wall should grab the corner ~3cm away and the badge should land on exactly 90° (previously it jumped 89° ↔ 91° and could never settle).
3. Repeat in `grid`, `angles`, and `off` modes — the endpoint no longer sticks back to its original position within 5cm; `angles` mode locks onto the 15° ray and stays there.
4. Repeat the drag in the 2D floor plan — same behaviour.
5. Hold Alt while dragging the shared corner: the detached endpoint still snaps onto the stationary corner it left (unchanged behaviour).
6. `cd packages/editor && bun test src/components/tools/wall/` and `cd packages/nodes && bun test src/wall/`.

## Screenshots / screen recording

N/A — interaction change; verified live on a RoomPlan-imported scene where a 91° junction could not be squared before this fix and self-heals to 90° with it.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core wall snapping and alignment during endpoint drags in both 3D and 2D affordances; behavior change is localized to move-endpoint flows with a targeted regression test.
> 
> **Overview**
> Fixes **endpoint drag snapping back to the old junction** when linked walls move with the corner but the snap pipeline still reads **pre-drag scene coordinates**, so sub–connect-radius corrections (e.g. squaring a ~91° scan corner) could never land.
> 
> **3D** (`move-endpoint-tool.tsx`) and **2D floor plan** (`wallMoveEndpointAffordance`) now pass walls attached only at the **moving** corner into `ignoreWallIds` / alignment `excludeIds` while attached; **Alt-detach** drops that exclusion so stationary corners stay valid snap targets. The 2D path no longer excludes **all** linked walls from alignment—walls tied at the **fixed** corner are candidates again so the dragged corner can align to true axes (2D/3D parity).
> 
> The 3D tool extracts **`resolveDragPoint`** and re-runs the full snap pipeline from **`lastRawPoint`** on Alt changes (not the last snapped point), since the candidate set flips with the modifier.
> 
> Adds a **`snapWallDraftPointDetailed`** regression test for the stale-corner swallow vs ignore behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36fc9318eea6e2b920971e2ec97f181e5fcdbf23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->