### PR TITLE
fix(editor): clicks dead in 3D after camera rests — stuck cameraDragging flag

### DIFF
--- a/packages/editor/src/components/editor/custom-camera-controls.tsx
+++ b/packages/editor/src/components/editor/custom-camera-controls.tsx
@@ -457,11 +457,14 @@ export const CustomCameraControls = () => {
     }
   }, [freezeActivePoseInterpolation])
 
-  const beginLocalCameraInteraction = useCallback(() => {
-    cancelPoseApplication()
-    cameraDraggingLifecycle.begin()
-    emitter.emit('camera-controls:interaction-start', undefined)
-  }, [cameraDraggingLifecycle, cancelPoseApplication])
+  const beginLocalCameraInteraction = useCallback(
+    ({ dragging = true }: { dragging?: boolean } = {}) => {
+      cancelPoseApplication()
+      if (dragging) cameraDraggingLifecycle.begin()
+      emitter.emit('camera-controls:interaction-start', undefined)
+    },
+    [cameraDraggingLifecycle, cancelPoseApplication],
+  )
 
   const applyPendingPose = useCallback(() => {
     if (isFirstPersonMode) {
@@ -1123,10 +1126,18 @@ export const CustomCameraControls = () => {
   // Cancel any in-progress 2D-origin navigation pose when the user starts
   // dragging (right-click orbit, middle-click pan, touch). `controlstart`
   // fires only for user pointer interactions — not for programmatic
-  // moveTo/rotateTo which emit `transitionstart` instead.
+  // moveTo/rotateTo which emit `transitionstart` instead. It also fires for
+  // pointerdowns whose button is mapped to ACTION.NONE (plain left click in
+  // edit mode); those must not flag the camera as dragging — no rest/sleep
+  // ever follows to clear the flag, which would leave canvas clicks
+  // (selection, placement) suppressed until the next real camera move.
   const handleControlStart = useCallback(() => {
     clearPendingFloorplanNavigationPose()
-    beginLocalCameraInteraction()
+    beginLocalCameraInteraction({
+      dragging: controls.current
+        ? controls.current.currentAction !== CameraControlsImpl.ACTION.NONE
+        : false,
+    })
   }, [beginLocalCameraInteraction, clearPendingFloorplanNavigationPose])
 
   // Preview mode: auto-navigate camera to selected node (viewer behavior)
@@ -1435,6 +1446,16 @@ export const CustomCameraControls = () => {
     cameraDraggingLifecycle.end()
   }, [cameraDraggingLifecycle])
 
+  const onControlEnd = useCallback(() => {
+    // A mapped-button tap with zero camera movement never wakes the
+    // controls, so no rest/sleep follows — clear the dragging flag on
+    // release. While damping is still settling (`active`), rest/sleep
+    // clears it instead.
+    if (!controls.current?.active) {
+      cameraDraggingLifecycle.end()
+    }
+  }, [cameraDraggingLifecycle])
+
   // Preset capture mode frames a single subtree (often a 0.3–2m preset),
   // so the default 2m minDistance prevents the user from getting close
   // enough to compose a good thumbnail. Relax the clamp to 0.5m while
@@ -1455,6 +1476,7 @@ export const CustomCameraControls = () => {
       minDistance={minDistance}
       minPolarAngle={0}
       mouseButtons={mouseButtons}
+      onControlEnd={onControlEnd}
       onControlStart={handleControlStart}
       onUpdate={handleCameraUpdate}
       onRest={onRest}


### PR DESCRIPTION
## Problem

Since #535, clicking in the 3D editor stopped working once the camera was at rest: wall placement clicks didn't start the build, and clicking items didn't select. Clicks only sneaked through while camera damping was still settling.

## Root cause

#535 made `beginLocalCameraInteraction` set `cameraDragging = true`, and it runs on camera-controls' `controlstart`. But camera-controls dispatches `controlstart` for **every pointerdown, even for buttons mapped to `ACTION.NONE`** (plain left click in edit mode — verified in camera-controls 3.1.2 `onPointerDown` → `startDragging`, which dispatches unconditionally). A stationary click never wakes the camera, so no `rest`/`sleep` ever fires to clear the flag — and `controlend` wasn't wired. Every pointer gate that checks `cameraDragging` (`use-grid-events`, `selection-manager`, door/window/measurement tools) then swallowed all clicks.

## Fix

- `handleControlStart` only flags dragging when `controls.currentAction !== ACTION.NONE` (the state is set before `controlstart` dispatches, so it's reliable there).
- Wire `onControlEnd`: a mapped-button tap with zero movement (e.g. stationary right click) never wakes the controls either, so clear the flag on release when the controls aren't `active`; while damping is settling, `rest`/`sleep` still clears it precisely, keeping the #535 outline-suspension win.

## Verification

- Headless Playwright against Wawa House: first idle left click starts wall placement (start point + snap guides), clicks complete the wall, click after orbit+rest selects it.
- Confirmed working interactively by @wass08.
- `tsgo --noEmit` clean on `packages/editor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to camera interaction lifecycle in custom-camera-controls; low blast radius beyond editor pointer gating.
> 
> **Overview**
> Fixes **3D canvas clicks dying after the camera rests** (selection, wall placement) caused by `cameraDragging` staying true when `controlstart` fired for left-clicks mapped to `ACTION.NONE` without a following `rest`/`sleep`.
> 
> **`beginLocalCameraInteraction`** now takes an optional `dragging` flag so pose cancellation and `interaction-start` still run, but **`cameraDragging` is only set when the pointer maps to a real camera action** (`currentAction !== ACTION.NONE` in `handleControlStart`).
> 
> **`onControlEnd`** clears the dragging flag on pointer release when the controls never became `active` (e.g. a stationary right-click), while **`onRest`/`onSleep`** still clear it during damping so outline suspension during real camera moves is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9371ca563db2648b0cd3a0a112a22aa59f8ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->