### PR TITLE
respect millimetre notation in 3d labels

### DIFF
--- a/packages/editor/src/components/editor/alignment-3d-guide-layer.tsx
+++ b/packages/editor/src/components/editor/alignment-3d-guide-layer.tsx
@@ -66,6 +66,7 @@ export const Alignment3DGuideLayer = memo(function Alignment3DGuideLayer() {
   const guides = useAlignmentGuides((s) => s.guides)
   const levelId = useViewer((s) => s.selection.levelId)
   const unit = useViewer((s) => s.unit)
+  const metricNotation = useViewer((s) => s.metricNotation)
   const groupRef = useRef<Group>(null)
 
   // Guides carry only XZ in WORLD coords; their Y has to track the active
@@ -85,16 +86,24 @@ export const Alignment3DGuideLayer = memo(function Alignment3DGuideLayer() {
   return (
     <group ref={groupRef}>
       {guides.map((guide, i) => (
-        <GuideLine guide={guide} key={i} unit={unit} />
+        <GuideLine guide={guide} key={i} metricNotation={metricNotation} unit={unit} />
       ))}
     </group>
   )
 })
 
-function GuideLine({ guide, unit }: { guide: AlignmentGuide; unit: 'metric' | 'imperial' }) {
+function GuideLine({
+  guide,
+  metricNotation,
+  unit,
+}: {
+  guide: AlignmentGuide
+  metricNotation: 'meters' | 'millimeters'
+  unit: 'metric' | 'imperial'
+}) {
   const { x: fx, z: fz } = guide.from
   const { x: tx, z: tz } = guide.to
-  const distLabel = formatMeasurement(guide.distance, unit)
+  const distLabel = formatMeasurement(guide.distance, unit, metricNotation)
 
   // Lay out the dash centres along the from→to direction. The ribbon
   // stretches the dash period up if the line is long enough to exceed the

--- a/packages/editor/src/components/editor/elevation-3d-guide-layer.tsx
+++ b/packages/editor/src/components/editor/elevation-3d-guide-layer.tsx
@@ -44,6 +44,7 @@ type Vec3 = [number, number, number]
 export const Elevation3DGuideLayer = memo(function Elevation3DGuideLayer() {
   const guide = useElevationGuides((state) => state.guide)
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const groupRef = useRef<Group>(null)
 
   useFrame(() => {
@@ -76,8 +77,8 @@ export const Elevation3DGuideLayer = memo(function Elevation3DGuideLayer() {
   ]
   const elevationText =
     Math.abs(guide.elevation) < 1e-6
-      ? formatMeasurement(0, unit)
-      : `${guide.elevation < 0 ? '-' : '+'}${formatMeasurement(Math.abs(guide.elevation), unit)}`
+      ? formatMeasurement(0, unit, metricNotation)
+      : `${guide.elevation < 0 ? '-' : '+'}${formatMeasurement(Math.abs(guide.elevation), unit, metricNotation)}`
 
   return (
     <group ref={groupRef}>

--- a/packages/editor/src/components/editor/floating-action-menu.tsx
+++ b/packages/editor/src/components/editor/floating-action-menu.tsx
@@ -294,6 +294,7 @@ export function FloatingActionMenu() {
   const setMovingNode = useEditor((s) => s.setMovingNode)
   const setSelection = useViewer((s) => s.setSelection)
   const unit = useViewer((s) => s.unit)
+  const metricNotation = useViewer((s) => s.metricNotation)
   // Drives the height-drag dimension pill below the menu. `activeHandleDrag`
   // flips only at drag start / end, so subscribing here is cheap — the live
   // height value is written imperatively in the useFrame below.
@@ -417,7 +418,7 @@ export function FloatingActionMenu() {
           ? getWallEffectiveHeightForNodes(node, useScene.getState().nodes)
           : FENCE_DEFAULT_HEIGHT
       const liveHeight = override?.height ?? node.height ?? fallbackHeight
-      pillHeightRef.current.textContent = `H ${formatMeasurement(liveHeight, unit)}`
+      pillHeightRef.current.textContent = `H ${formatMeasurement(liveHeight, unit, metricNotation)}`
     }
 
     const obj = sceneRegistry.nodes.get(selectedId)
@@ -884,7 +885,7 @@ export function FloatingActionMenu() {
                 under it for duct fittings. */}
             {node && hasPorts(node.type) ? (
               <div className="-translate-x-1/2 pointer-events-none absolute bottom-full left-1/2 mb-2 flex flex-col items-center gap-1">
-                <SystemSummaryPill nodeId={node.id} unit={unit} />
+                <SystemSummaryPill metricNotation={metricNotation} nodeId={node.id} unit={unit} />
                 {hasAxisCycling(node.type) ? (
                   <div className="flex items-center gap-2 whitespace-nowrap rounded-full border border-border/60 bg-background/90 px-4 py-1.5 text-xs tabular-nums shadow-sm backdrop-blur">
                     <span className="font-medium text-foreground">
@@ -918,7 +919,15 @@ export function FloatingActionMenu() {
  * subscription it needs (connectivity changes when ANY joint moves) doesn't
  * re-render the always-mounted parent menu on every unrelated scene tick.
  */
-function SystemSummaryPill({ nodeId, unit }: { nodeId: AnyNodeId; unit: 'metric' | 'imperial' }) {
+function SystemSummaryPill({
+  metricNotation,
+  nodeId,
+  unit,
+}: {
+  metricNotation: 'meters' | 'millimeters'
+  nodeId: AnyNodeId
+  unit: 'metric' | 'imperial'
+}) {
   const allNodes = useScene((s) => s.nodes)
   const summary = useMemo(() => summarizeSystemFor(nodeId, allNodes), [nodeId, allNodes])
   if (!summary) return null
@@ -935,7 +944,7 @@ function SystemSummaryPill({ nodeId, unit }: { nodeId: AnyNodeId; unit: 'metric'
             ·
           </span>
           <span className="text-muted-foreground">
-            {formatMeasurement(summary.runLengthM, unit)} · {summary.runCount}{' '}
+            {formatMeasurement(summary.runLengthM, unit, metricNotation)} · {summary.runCount}{' '}
             {summary.runCount === 1 ? 'run' : 'runs'}
           </span>
         </>

--- a/packages/editor/src/components/editor/measurement-pill.tsx
+++ b/packages/editor/src/components/editor/measurement-pill.tsx
@@ -1,23 +1,17 @@
 'use client'
 
+import { useViewer } from '@pascal-app/viewer'
 import { type ForwardedRef, Fragment, forwardRef } from 'react'
+import { formatLinearMeasurement, type MetricNotation } from '../../lib/measurements'
 
 // Canonical in-world dimension formatter — metric metres or imperial
 // feet/inches. Shared by every measurement readout so they read the same.
 export function formatMeasurement(
   value: number,
   unit: 'metric' | 'imperial',
-  metricNotation: 'meters' | 'millimeters' = 'meters',
+  metricNotation: MetricNotation = 'meters',
 ): string {
-  if (unit === 'imperial') {
-    const feet = value * 3.280_84
-    const wholeFeet = Math.floor(feet)
-    const inches = Math.round((feet - wholeFeet) * 12)
-    if (inches === 12) return `${wholeFeet + 1}'0"`
-    return `${wholeFeet}'${inches}"`
-  }
-  if (metricNotation === 'millimeters') return `${Math.round(value * 1000)}mm`
-  return `${Number.parseFloat(value.toFixed(2))}m`
+  return formatLinearMeasurement(value, unit, metricNotation)
 }
 
 type MeasurePart = 'height' | 'length' | 'thickness'
@@ -55,12 +49,18 @@ export function DimensionPill({
   primary?: string
   primaryRef?: ForwardedRef<HTMLSpanElement>
 }) {
+  const metricNotation = useViewer((state) => state.metricNotation)
+
   return (
     <div className="flex items-center gap-2 whitespace-nowrap rounded-full border border-border/60 bg-background/90 px-4 py-1.5 text-xs tabular-nums shadow-sm backdrop-blur">
       {parts.map((part, index) => {
         const text = part.signed
-          ? `${part.value < 0 ? '-' : '+'}${formatMeasurement(Math.abs(part.value), unit)}`
-          : formatMeasurement(part.value, unit)
+          ? `${part.value < 0 ? '-' : '+'}${formatMeasurement(
+              Math.abs(part.value),
+              unit,
+              metricNotation,
+            )}`
+          : formatMeasurement(part.value, unit, metricNotation)
         return (
           <Fragment key={part.key}>
             {index > 0 ? (

--- a/packages/editor/src/components/editor/opening-guides-3d-layer.tsx
+++ b/packages/editor/src/components/editor/opening-guides-3d-layer.tsx
@@ -53,17 +53,26 @@ const mid = (a: OpeningGuideVec3, b: OpeningGuideVec3): OpeningGuideVec3 => [
 export const OpeningGuides3DLayer = memo(function OpeningGuides3DLayer() {
   const guides = useOpeningGuides((s) => s.guides)
   const unit = useViewer((s) => s.unit)
+  const metricNotation = useViewer((s) => s.metricNotation)
   if (guides.length === 0) return null
   return (
     <>
       {guides.map((guide) => (
-        <OpeningGuide guide={guide} key={guide.id} unit={unit} />
+        <OpeningGuide guide={guide} key={guide.id} metricNotation={metricNotation} unit={unit} />
       ))}
     </>
   )
 })
 
-function OpeningGuide({ guide, unit }: { guide: OpeningGuide3D; unit: 'metric' | 'imperial' }) {
+function OpeningGuide({
+  guide,
+  metricNotation,
+  unit,
+}: {
+  guide: OpeningGuide3D
+  metricNotation: 'meters' | 'millimeters'
+  unit: 'metric' | 'imperial'
+}) {
   if (guide.kind === 'badge') {
     return (
       <Html
@@ -76,7 +85,7 @@ function OpeningGuide({ guide, unit }: { guide: OpeningGuide3D; unit: 'metric' |
           className="whitespace-nowrap rounded-[3px] px-[5px] py-[2px] font-sans font-semibold text-[11px] text-white"
           style={{ backgroundColor: BADGE_PILL }}
         >
-          {`= ${formatMeasurement(guide.value, unit)}`}
+          {`= ${formatMeasurement(guide.value, unit, metricNotation)}`}
         </div>
       </Html>
     )
@@ -97,7 +106,7 @@ function OpeningGuide({ guide, unit }: { guide: OpeningGuide3D; unit: 'metric' |
             className="whitespace-nowrap rounded-[3px] px-[5px] py-[2px] font-medium font-sans text-[11px] text-white"
             style={{ backgroundColor: DIMENSION_PILL }}
           >
-            {formatMeasurement(guide.value, unit)}
+            {formatMeasurement(guide.value, unit, metricNotation)}
           </div>
         </Html>
       ) : null}

--- a/packages/editor/src/components/editor/site-edge-labels.tsx
+++ b/packages/editor/src/components/editor/site-edge-labels.tsx
@@ -50,6 +50,7 @@ export function SiteEdgeLabels() {
   })
   const activeHandleDrag = useActiveHandleDrag()
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const cameraMode = useViewer((state) => state.cameraMode)
   const isNight = useViewer((state) => getSceneTheme(state.sceneTheme).appearance === 'dark')
   const camera = useThree((state) => state.camera)
@@ -132,7 +133,7 @@ export function SiteEdgeLabels() {
               textShadow: `-1.5px -1.5px 0 ${shadowColor}, 1.5px -1.5px 0 ${shadowColor}, -1.5px 1.5px 0 ${shadowColor}, 1.5px 1.5px 0 ${shadowColor}, 0 0 4px ${shadowColor}, 0 0 4px ${shadowColor}`,
             }}
           >
-            {formatLinearMeasurement(edge.dist, unit)}
+            {formatLinearMeasurement(edge.dist, unit, metricNotation)}
           </div>
         </Html>
       ))}

--- a/packages/editor/src/components/editor/wall-measurement-label.tsx
+++ b/packages/editor/src/components/editor/wall-measurement-label.tsx
@@ -510,6 +510,7 @@ function SelectedMeasurementAnnotation({ node }: { node: WallNode | ItemNode }) 
 function WallMeasurementAnnotation({ wall }: { wall: WallNode }) {
   const nodes = useScene((state) => state.nodes)
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const isNight = useViewer((state) => getSceneTheme(state.sceneTheme).appearance === 'dark')
   const color = isNight ? '#ffffff' : '#111111'
   const shadowColor = isNight ? '#111111' : '#ffffff'
@@ -528,9 +529,9 @@ function WallMeasurementAnnotation({ wall }: { wall: WallNode }) {
     }
     return total
   }, [guide, wall])
-  const label = formatLinearMeasurement(length, unit)
+  const label = formatLinearMeasurement(length, unit, metricNotation)
   const height = useMemo(() => getWallEffectiveHeightForNodes(wall, nodes), [nodes, wall])
-  const heightLabel = `H ${formatLinearMeasurement(height, unit)}`
+  const heightLabel = `H ${formatLinearMeasurement(height, unit, metricNotation)}`
 
   if (!(guide && Number.isFinite(length) && length >= 0.01)) return null
 

--- a/packages/editor/src/components/tools/item/use-placement-coordinator.tsx
+++ b/packages/editor/src/components/tools/item/use-placement-coordinator.tsx
@@ -295,6 +295,7 @@ export function usePlacementCoordinator(config: PlacementCoordinatorConfig): Rea
   const { canPlaceOnFloor, canPlaceOnWall, canPlaceOnCeiling } = useSpatialQuery()
   const { asset, draftNode } = config
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const gridSnapStep = useEditor((s) => s.gridSnapStep)
   const updatePreviewGeometry = useCallback((bounds: PreviewBounds) => {
     const [width, height, depth] = bounds.dimensions
@@ -2558,9 +2559,21 @@ export function usePlacementCoordinator(config: PlacementCoordinatorConfig): Rea
     depth: currentDimensionBounds.dimensions[2],
     center: [currentDimensionBounds.center[0], currentDimensionBounds.center[2]],
   }
-  const widthLabel = formatLinearMeasurement(currentDimensionBounds.dimensions[0], unit)
-  const depthLabel = formatLinearMeasurement(currentDimensionBounds.dimensions[2], unit)
-  const heightLabel = formatLinearMeasurement(currentDimensionBounds.dimensions[1], unit)
+  const widthLabel = formatLinearMeasurement(
+    currentDimensionBounds.dimensions[0],
+    unit,
+    metricNotation,
+  )
+  const depthLabel = formatLinearMeasurement(
+    currentDimensionBounds.dimensions[2],
+    unit,
+    metricNotation,
+  )
+  const heightLabel = formatLinearMeasurement(
+    currentDimensionBounds.dimensions[1],
+    unit,
+    metricNotation,
+  )
   const widthLabelPosition: [number, number, number] = [
     currentDimensionBounds.center[0],
     0.04,

--- a/packages/editor/src/components/tools/shared/placement-box.tsx
+++ b/packages/editor/src/components/tools/shared/placement-box.tsx
@@ -8,7 +8,11 @@ import { PlaneGeometry } from 'three'
 import { distance, smoothstep, uv, vec2 } from 'three/tsl'
 import { LineBasicNodeMaterial, MeshBasicNodeMaterial } from 'three/webgpu'
 import { EDITOR_LAYER } from '../../../lib/constants'
-import { formatLinearMeasurement, type LinearUnit } from '../../../lib/measurements'
+import {
+  formatLinearMeasurement,
+  type LinearUnit,
+  type MetricNotation,
+} from '../../../lib/measurements'
 import { createLineGeometry, getBoxEdgePoints } from './placement-box-geometry'
 
 const VALID_COLOR = 0x22_c5_5e // green-500
@@ -17,6 +21,7 @@ const MEASUREMENT_COLOR = 0x0f_17_2a
 
 type PlacementBoxMeasurements = {
   unit: LinearUnit
+  metricNotation?: MetricNotation
 }
 
 function getMeasurementGuidePoints(width: number, height: number, depth: number) {
@@ -271,15 +276,15 @@ export function PlacementBox({
         renderOrder={998}
       />
       <MeasurementPill
-        label={formatLinearMeasurement(width, measurements.unit)}
+        label={formatLinearMeasurement(width, measurements.unit, measurements.metricNotation)}
         position={[0, 0.04, depth / 2 + 0.24]}
       />
       <MeasurementPill
-        label={formatLinearMeasurement(depth, measurements.unit)}
+        label={formatLinearMeasurement(depth, measurements.unit, measurements.metricNotation)}
         position={[width / 2 + 0.24, 0.04, 0]}
       />
       <MeasurementPill
-        label={formatLinearMeasurement(height, measurements.unit)}
+        label={formatLinearMeasurement(height, measurements.unit, measurements.metricNotation)}
         position={[-width / 2 - 0.24, height / 2, -depth / 2]}
       />
     </>

--- a/packages/editor/src/components/tools/site/terrain-brush-cursor.tsx
+++ b/packages/editor/src/components/tools/site/terrain-brush-cursor.tsx
@@ -79,6 +79,7 @@ export const TerrainBrushCursor: React.FC<{
   const sampling = useEditor((state) => state.terrainSampling)
   const color = brushRingColor(verb, sampling)
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
 
   const lineRef = useRef<Line>(null)
   const centerRef = useRef<Group>(null)
@@ -195,7 +196,7 @@ export const TerrainBrushCursor: React.FC<{
 
     const centerHeight = surfaceHeightAt(surface, hit.x, hit.z)
     center.position.set(hit.x, centerHeight + RING_LIFT, hit.z)
-    const heightLabel = `H ${formatMeasurement(centerHeight, unit)}`
+    const heightLabel = `H ${formatMeasurement(centerHeight, unit, metricNotation)}`
     if (heightRef.current) {
       heightRef.current.style.display = ''
       if (heightLabel !== lastHeightLabelRef.current) {

--- a/packages/editor/src/lib/measurements.test.ts
+++ b/packages/editor/src/lib/measurements.test.ts
@@ -75,6 +75,10 @@ describe('linear measurements', () => {
   test('formats metric measurements in whole millimeters', () => {
     expect(formatLinearMeasurement(3.456, 'metric', 'millimeters')).toBe('3456mm')
     expect(formatLinearMeasurement(-0.1524, 'metric', 'millimeters')).toBe('-152mm')
+    expect(formatLinearMeasurement(0.2, 'metric', 'millimeters')).toBe('200mm')
+    expect(formatLinearMeasurement(18.4, 'metric', 'millimeters')).toBe('18400mm')
+    expect(formatLinearMeasurement(0.0005, 'metric', 'millimeters')).toBe('1mm')
+    expect(formatLinearMeasurement(-0.0005, 'metric', 'millimeters')).toBe('-1mm')
   })
 
   test('formats imperial measurements as feet and inches', () => {

--- a/packages/nodes/src/cabinet/tool.tsx
+++ b/packages/nodes/src/cabinet/tool.tsx
@@ -256,6 +256,7 @@ function wallHitFromWallEvent(event: WallEvent): WallHit | null {
 const CabinetTool = () => {
   const activeLevelId = useViewer((s) => s.selection.levelId)
   const unit = useViewer((s) => s.unit)
+  const metricNotation = useViewer((s) => s.metricNotation)
   const [placement, setPlacement] = useState<CabinetPlacement | null>(null)
   const [draftSegments, setDraftSegments] = useState<DraftSegment[]>([])
   const [yaw, setYaw] = useState(0)
@@ -1179,7 +1180,7 @@ const CabinetTool = () => {
       {placement.guide && <WallSnapGuide blocked={!placement.valid} guide={placement.guide} />}
       <PlacementBox
         dimensions={placementBoxDimensions}
-        measurements={{ unit }}
+        measurements={{ unit, metricNotation }}
         position={placementBoxPosition}
         rotationY={placementRotationY}
         valid={placement.valid}

--- a/packages/nodes/src/ceiling/panel.tsx
+++ b/packages/nodes/src/ceiling/panel.tsx
@@ -36,6 +36,7 @@ import { useCallback, useEffect, useRef } from 'react'
 export function CeilingPanel() {
   const selectedId = useViewer((s) => s.selection.selectedIds[0])
   const unit = useViewer((s) => s.unit)
+  const metricNotation = useViewer((s) => s.metricNotation)
   const setSelection = useViewer((s) => s.setSelection)
   const editingHole = useEditingHole()
   const setMovingNode = useEditor((s) => s.setMovingNode)
@@ -254,7 +255,7 @@ export function CeilingPanel() {
         />
         {isFollows ? (
           <div className="px-1 text-[11px] text-muted-foreground">
-            Currently {formatLinearMeasurement(resolvedHeight, unit)}
+            Currently {formatLinearMeasurement(resolvedHeight, unit, metricNotation)}
           </div>
         ) : (
           <SliderControl

--- a/packages/nodes/src/dormer/placement-guides.tsx
+++ b/packages/nodes/src/dormer/placement-guides.tsx
@@ -90,6 +90,7 @@ export function DormerPlacementGuides({
   movingId?: string
 }) {
   const unit = useViewer((s) => s.unit)
+  const metricNotation = useViewer((s) => s.metricNotation)
 
   const [cx, , cz] = center
   const faceBounds = getRoofSurfaceFaceBoundsAt(segment, cx, cz)
@@ -181,22 +182,37 @@ export function DormerPlacementGuides({
   return (
     <>
       {guides.map((g) => (
-        <Guide key={g.id} guide={g} unit={unit} />
+        <Guide key={g.id} guide={g} metricNotation={metricNotation} unit={unit} />
       ))}
     </>
   )
 }
 
-function Guide({ guide, unit }: { guide: DormerGuide; unit: 'metric' | 'imperial' }) {
+function Guide({
+  guide,
+  metricNotation,
+  unit,
+}: {
+  guide: DormerGuide
+  metricNotation: 'meters' | 'millimeters'
+  unit: 'metric' | 'imperial'
+}) {
   if (guide.kind === 'badge') {
-    return <GuideBadge at={guide.at} pill={`= ${formatMeasurement(guide.value, unit)}`} />
+    return (
+      <GuideBadge
+        at={guide.at}
+        pill={`= ${formatMeasurement(guide.value, unit, metricNotation)}`}
+      />
+    )
   }
 
   return (
     <GuideLine
       from={guide.from}
       kind={guide.kind}
-      pill={guide.value === undefined ? undefined : formatMeasurement(guide.value, unit)}
+      pill={
+        guide.value === undefined ? undefined : formatMeasurement(guide.value, unit, metricNotation)
+      }
       to={guide.to}
     />
   )

--- a/packages/nodes/src/fence/tool.tsx
+++ b/packages/nodes/src/fence/tool.tsx
@@ -377,6 +377,7 @@ function getDraftMeasurementState(
   end: FencePlanPoint,
   segments: SegmentLike[],
   unit: 'metric' | 'imperial',
+  metricNotation: 'meters' | 'millimeters',
   baseY: number,
   previewHeight: number,
   previewThickness: number,
@@ -386,7 +387,7 @@ function getDraftMeasurementState(
   const length = Math.hypot(dx, dz)
   if (length < 0.01) return null
   return {
-    lengthLabel: formatLinearMeasurement(length, unit),
+    lengthLabel: formatLinearMeasurement(length, unit, metricNotation),
     lengthPosition: [
       (start[0] + end[0]) / 2,
       baseY + previewHeight + DRAFT_LABEL_Y_OFFSET,
@@ -465,6 +466,7 @@ export const FenceTool: React.FC = () => {
 
 const StraightFenceTool: React.FC = () => {
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const isDark = useViewer((state) => getSceneTheme(state.sceneTheme).appearance === 'dark')
   // A placed preset seeds `toolDefaults.fence` before the tool mounts, so
   // the draft preview is drawn at the preset's height / thickness rather
@@ -615,6 +617,7 @@ const StraightFenceTool: React.FC = () => {
             snappedLocal,
             getReferenceSegments(walls, fences),
             unit,
+            metricNotation,
             startingPoint.current.y,
             previewHeightRef.current,
             previewThicknessRef.current,
@@ -751,7 +754,7 @@ const StraightFenceTool: React.FC = () => {
       draftPreview.setFenceDraftStart(null)
       draftPreview.setFenceDraftEnd(null)
     }
-  }, [unit])
+  }, [unit, metricNotation])
 
   return (
     <group>

--- a/packages/nodes/src/measurement/renderer.tsx
+++ b/packages/nodes/src/measurement/renderer.tsx
@@ -291,9 +291,10 @@ function buildRenderData(measurement: ResolvedMeasurementPayload): MeasurementRe
 function formatMeasurement(
   measurement: ResolvedMeasurementPayload,
   unit: 'metric' | 'imperial',
+  metricNotation: 'meters' | 'millimeters',
 ): string {
   if (measurement.kind === 'distance') {
-    return formatLinearMeasurement(measurementDistance(...measurement.points), unit)
+    return formatLinearMeasurement(measurementDistance(...measurement.points), unit, metricNotation)
   }
   if (measurement.kind === 'angle') {
     return formatAngleRadians(measurementAngle(...measurement.points))
@@ -302,7 +303,11 @@ function formatMeasurement(
     return `A ${formatAreaLabel(measurementArea(measurement.base), unit)}`
   }
   if (measurement.kind === 'perimeter') {
-    return `P ${formatLinearMeasurement(measurementPerimeter(measurement.base), unit)}`
+    return `P ${formatLinearMeasurement(
+      measurementPerimeter(measurement.base),
+      unit,
+      metricNotation,
+    )}`
   }
   return `V ${formatVolumeLabel(measurementPrismVolume(measurement.base, measurement.extrusion), unit)}`
 }
@@ -325,6 +330,7 @@ export const MeasurementRenderer = ({ node }: { node: MeasurementNode }) => {
   const handlers = useNodeEvents(node, 'measurement')
   const showMeasurements = useViewer((state) => state.showMeasurements)
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const active = useViewer(
     (state) =>
       state.hoveredId === node.id || state.selection.selectedIds.some((id) => id === node.id),
@@ -350,9 +356,9 @@ export const MeasurementRenderer = ({ node }: { node: MeasurementNode }) => {
   })
   const data = buildRenderData(resolved.payload)
   const label = useMemo(() => {
-    const value = formatMeasurement(resolved.payload, unit)
+    const value = formatMeasurement(resolved.payload, unit, metricNotation)
     return resolved.dangling.length > 0 ? `Unlinked · ${value}` : value
-  }, [resolved, unit])
+  }, [metricNotation, resolved, unit])
   const color = measurementPresentationColor(resolved.dangling.length > 0, active)
   const lineMaterial = useMemo(
     () =>

--- a/packages/nodes/src/measurement/tool.tsx
+++ b/packages/nodes/src/measurement/tool.tsx
@@ -1353,6 +1353,7 @@ const MeasurementDraftPreview: FC<{
   const extrusionHeight = useMeasurementDraft((state) => state.extrusionHeight)
   const error = useMeasurementDraft((state) => state.error)
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const axisIntersectionCache = useRef<{
     intersections: QueriedAxisSurfaceIntersection[]
     key: string
@@ -1525,7 +1526,7 @@ const MeasurementDraftPreview: FC<{
       const end = livePoints[livePoints.length - 1]!
       label = {
         position: localToPreviewFrame(levelObject, buildingObject, midpoint(start, end)),
-        text: formatLinearMeasurement(measurementDistance(start, end), unit),
+        text: formatLinearMeasurement(measurementDistance(start, end), unit, metricNotation),
       }
     } else if (kind === 'angle' && livePoints.length >= 3) {
       const anglePoints = livePoints.slice(0, 3) as [
@@ -1547,7 +1548,11 @@ const MeasurementDraftPreview: FC<{
           text:
             kind === 'area'
               ? `A ${formatAreaLabel(measurementArea(livePoints), unit)}`
-              : `P ${formatLinearMeasurement(measurementPerimeter(livePoints), unit)}`,
+              : `P ${formatLinearMeasurement(
+                  measurementPerimeter(livePoints),
+                  unit,
+                  metricNotation,
+                )}`,
         }
       }
     } else if (kind === 'volume' && points.length >= 3 && baseNormal) {
@@ -1603,6 +1608,7 @@ const MeasurementDraftPreview: FC<{
     hoverOwner,
     kind,
     levelId,
+    metricNotation,
     points,
     stage,
     surfaceQuery,

--- a/packages/nodes/src/wall/tool.tsx
+++ b/packages/nodes/src/wall/tool.tsx
@@ -361,6 +361,7 @@ function getDraftMeasurementState(
   end: WallPlanPoint,
   walls: WallNode[],
   unit: 'metric' | 'imperial',
+  metricNotation: 'meters' | 'millimeters',
   baseY: number,
   previewHeight: number,
 ): DraftMeasurementState {
@@ -369,7 +370,7 @@ function getDraftMeasurementState(
   const length = Math.hypot(dx, dz)
   if (length < 0.01) return null
   return {
-    lengthLabel: formatLinearMeasurement(length, unit),
+    lengthLabel: formatLinearMeasurement(length, unit, metricNotation),
     lengthPosition: [
       (start[0] + end[0]) / 2,
       baseY + previewHeight + DRAFT_LABEL_Y_OFFSET,
@@ -448,6 +449,7 @@ function getBelowLevelWalls(): WallNode[] {
 
 export const WallTool: React.FC = () => {
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const isDark = useViewer((state) => getSceneTheme(state.sceneTheme).appearance === 'dark')
   const activeLevelId = useViewer((state) => state.selection.levelId)
   const activeLevelHeight = useScene((state) => {
@@ -711,6 +713,7 @@ export const WallTool: React.FC = () => {
             snappedLocal,
             walls,
             unit,
+            metricNotation,
             startingPoint.current.y,
             previewHeightRef.current,
           ),
@@ -897,7 +900,7 @@ export const WallTool: React.FC = () => {
       draftPreview.setWallDraftStart(null)
       draftPreview.setWallDraftEnd(null)
     }
-  }, [unit])
+  }, [unit, metricNotation])
 
   return (
     <group>

--- a/packages/nodes/src/zone/quantities-panel.tsx
+++ b/packages/nodes/src/zone/quantities-panel.tsx
@@ -24,10 +24,12 @@ type Point2D = readonly [number, number]
 
 function ZonePlanSketch({
   edgeLengths,
+  metricNotation,
   polygon,
   unit,
 }: {
   edgeLengths: readonly number[]
+  metricNotation: 'meters' | 'millimeters'
   polygon: readonly Point2D[]
   unit: 'metric' | 'imperial'
 }) {
@@ -92,7 +94,7 @@ function ZonePlanSketch({
           midpoint[0] + (fromCenter[0] / directionLength) * 15,
           midpoint[1] + (fromCenter[1] / directionLength) * 15,
         ]
-        const label = formatLinearMeasurement(edgeLengths[index] ?? 0, unit)
+        const label = formatLinearMeasurement(edgeLengths[index] ?? 0, unit, metricNotation)
         const labelWidth = Math.max(24, label.length * 5.5 + 8)
 
         return (
@@ -317,6 +319,7 @@ function RoomDocumentationPanel({ zone }: { zone: ZoneNode }) {
 export default function ZoneQuantitiesPanel() {
   const selectedZoneId = useViewer((state) => state.selection.zoneId)
   const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
   const nodes = useScene((state) => state.nodes)
   const zone = selectedZoneId ? (nodes[selectedZoneId] as ZoneNode | undefined) : undefined
   const livePolygon = useLiveNodeOverrides((state) =>
@@ -372,12 +375,13 @@ export default function ZoneQuantitiesPanel() {
             <span className="text-cyan-800">A</span>
             <span>{formatAreaLabel(report.footprintArea, unit, 2)}</span>
             <span className="ml-auto text-slate-600">P</span>
-            <span>{formatLinearMeasurement(report.perimeter, unit)}</span>
+            <span>{formatLinearMeasurement(report.perimeter, unit, metricNotation)}</span>
           </div>
         </div>
 
         <ZonePlanSketch
           edgeLengths={report.edgeLengths}
+          metricNotation={metricNotation}
           polygon={effectiveZone.polygon}
           unit={unit}
         />


### PR DESCRIPTION
## what does this pr do?

fixes #509 by completing the label only millimetre preference across 3d measurement surfaces that still defaulted to metres.

- passes the persisted metric notation through saved and draft 3d measurements
- updates alignment, opening, dormer, drag, and system summary pills
- reuses the canonical linear formatter so negative values and half millimetre rounding stay consistent
- keeps numeric editor inputs and area and volume labels unchanged

## how to test

1. choose metric millimetres in the viewer settings.
2. create distance and perimeter measurements in both floor plan and 3d views.
3. move an opening or dormer and confirm its guide labels use millimetres.
4. drag a wall or fence height handle and confirm every value in the pill uses millimetres.
5. switch back to metres and imperial and confirm those labels update immediately.

local validation completed with a 1,329 file biome check and 25 passing measurement tests. i could not run bun dev or package type checks because the filtered dependency install exceeded the available disk space on the five remaining runtime packages.

## screenshots / screen recording

not included. this change only wires the existing display preference into the remaining label paths.

## checklist

- [ ] i have tested this locally with bun dev
- [x] my code follows the existing code style
- [x] i have updated relevant documentation, not applicable here
- [x] this pr targets the main branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only wiring to an existing preference and shared formatter; no auth, persistence, or calculation logic changes beyond label strings.
> 
> **Overview**
> Completes **metric millimetres** across 3D measurement readouts that still formatted linear distances in metres regardless of viewer settings.
> 
> The persisted **`metricNotation`** from `useViewer` is threaded into alignment, elevation, opening, wall, site-edge, placement, terrain-brush, floating-menu (height pill + HVAC system summary), and node-owned surfaces (wall/fence draft tools, measurements, cabinets, dormers, zone sketch). **`formatMeasurement`** in `measurement-pill` now delegates to **`formatLinearMeasurement`** so signed deltas and mm rounding stay consistent; **`DimensionPill`** reads notation from the store directly. **`PlacementBox`** accepts optional **`metricNotation`** on its measurements config.
> 
> Tests add mm cases for sub-millimetre rounding and larger values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e003630c78eeba947ccb5fc6905502633fad4a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->