### PR TITLE
editor: let the clipboard validate plugin-contributed node kinds

### DIFF
--- a/packages/editor/src/lib/scene-clipboard.test.ts
+++ b/packages/editor/src/lib/scene-clipboard.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import {
   type AnyNode,
+  type AnyNodeDefinition,
   type AnyNodeId,
   CabinetModuleNode,
   type CabinetModuleNode as CabinetModuleNodeType,
@@ -8,6 +9,8 @@ import {
   type CabinetNode as CabinetNodeType,
   type LevelNode,
   MeasurementNode,
+  nodeRegistry,
+  registerNode,
   SceneMaterial,
   type SceneMaterialId,
   useScene,
@@ -15,6 +18,7 @@ import {
   WindowNode,
 } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
+import { z } from 'zod'
 import {
   copySelectedNodesToEditorClipboard,
   getEditorClipboardSnapshot,
@@ -102,6 +106,12 @@ describe('scene clipboard', () => {
   beforeEach(() => {
     seedCabinetRun()
     useScene.temporal.getState().clear()
+  })
+
+  // The plugin-kind test registers a definition; drop it so it can't leak into
+  // any other test's registry lookups.
+  afterEach(() => {
+    nodeRegistry._reset()
   })
 
   test('copies a selected cabinet run as one subtree instead of independent modules', () => {
@@ -292,6 +302,64 @@ describe('scene clipboard', () => {
     if (pastedWall?.type === 'wall') {
       expect(pastedWall.slots?.exterior).toBe(`scene:${materialId}`)
     }
+  })
+
+  test('duplicates a plugin-contributed kind that AnyNode cannot describe', () => {
+    // `AnyNode` is a hand-maintained union of built-in kinds, so a plugin kind
+    // can never be a member of it — the registry validates those against
+    // `def.schema` instead. Registering one here reproduces exactly what a
+    // plugin does at load time; before the registry fallback this copy threw
+    // `invalid_union / no matching discriminator` and duplicate silently failed
+    // for every plugin, including the first-party trees pack.
+    const PluginNode = z.object({
+      object: z.literal('node').default('node'),
+      id: z.string(),
+      type: z.literal('warehouse:pallet').default('warehouse:pallet'),
+      name: z.string().optional(),
+      parentId: z.string().nullable().default(null),
+      visible: z.boolean().optional().default(true),
+      metadata: z.json().optional().default({}),
+      position: z.tuple([z.number(), z.number(), z.number()]).default([0, 0, 0]),
+      rotation: z.tuple([z.number(), z.number(), z.number()]).default([0, 0, 0]),
+      preset: z.string().default('epal-1'),
+    })
+    registerNode({
+      kind: 'warehouse:pallet',
+      schemaVersion: 1,
+      schema: PluginNode,
+      category: 'furnish',
+      defaults: () => ({}),
+      capabilities: { duplicable: true, deletable: true },
+    } as unknown as AnyNodeDefinition)
+
+    const pluginNodeId = 'warehouse-pallet_clipboard' as AnyNodeId
+    const pluginNode = PluginNode.parse({
+      id: pluginNodeId,
+      parentId: sourceLevelId,
+      position: [2, 0, 1],
+      preset: 'epal-2',
+    }) as unknown as AnyNode
+    useScene.setState((state) => ({
+      nodes: {
+        ...state.nodes,
+        [sourceLevelId]: makeLevel(sourceLevelId, [pluginNodeId]),
+        [pluginNodeId]: pluginNode,
+      },
+    }))
+
+    expect(copySelectedNodesToEditorClipboard([pluginNodeId])).toBe(true)
+
+    const result = pasteEditorClipboardToLevel(targetLevelId)
+    expect(result?.pastedIds).toHaveLength(1)
+
+    const pastedId = result?.pastedIds[0]
+    const pasted = pastedId ? useScene.getState().nodes[pastedId] : undefined
+    expect(pasted?.type).toBe('warehouse:pallet')
+    expect(pasted?.id).not.toBe(pluginNodeId)
+    expect(pasted?.parentId).toBe(targetLevelId)
+    // The registry schema — not `AnyNode` — is what validated it, so kind-owned
+    // fields have to survive the round trip.
+    expect((pasted as unknown as { preset?: string } | undefined)?.preset).toBe('epal-2')
   })
 
   test('waits for an in-flight copy before reading the browser clipboard', async () => {

--- a/packages/editor/src/lib/scene-clipboard.ts
+++ b/packages/editor/src/lib/scene-clipboard.ts
@@ -13,6 +13,27 @@ import {
 } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 
+/**
+ * Validate a node on its way through the clipboard.
+ *
+ * `AnyNode` is the hand-maintained union of built-in kinds, so a
+ * plugin-contributed kind can never be a member of it — the registry validates
+ * those against `def.schema` at runtime instead. Parsing with `AnyNode` alone
+ * therefore rejects every plugin node, which makes `capabilities.duplicable`
+ * unhonourable for plugins including the first-party `pascal:trees` pack.
+ *
+ * Built-in behaviour is unchanged: `AnyNode` is still tried first, and a type
+ * that is neither built-in nor registered still raises the original error.
+ */
+function parseClipboardNode(candidate: unknown): AnyNode {
+  const builtin = AnyNode.safeParse(candidate)
+  if (builtin.success) return builtin.data
+  const type = (candidate as { type?: unknown } | null)?.type
+  const definition = typeof type === 'string' ? nodeRegistry.get(type) : undefined
+  if (definition) return definition.schema.parse(candidate) as AnyNode
+  throw builtin.error
+}
+
 type ClipboardPayload = {
   copiedAt: number
   materials: SceneMaterial[]
@@ -250,7 +271,7 @@ function remapNodeReferences(
   delete metadata.isTransient
   ;(clone as Record<string, unknown>).metadata = metadata
 
-  return AnyNode.parse(clone)
+  return parseClipboardNode(clone)
 }
 
 function remapSceneMaterialReferences(
@@ -374,7 +395,13 @@ function parseClipboardPayload(text: string): ClipboardPayload | null {
       return null
     }
 
-    const nodes = candidate.nodes.map((node) => AnyNode.safeParse(node))
+    const nodes = candidate.nodes.map((node) => {
+      try {
+        return { success: true as const, data: parseClipboardNode(node) }
+      } catch {
+        return { success: false as const, data: undefined }
+      }
+    })
     if (nodes.some((result) => !result.success)) return null
     const materials = Array.isArray(candidate.materials)
       ? candidate.materials.map((material) => SceneMaterial.safeParse(material))


### PR DESCRIPTION
## What does this PR do?

`scene-clipboard.ts` validates every node it copies or pastes with `AnyNode.parse`. `AnyNode` is the hand-maintained discriminated union of built-in kinds, so a kind contributed through `registerNode` can never be a member of it — the registry validates those against `def.schema` at runtime instead.

The effect is that **`capabilities.duplicable` cannot be honoured by any plugin**. Copying a plugin node throws `invalid_union / no matching discriminator`; pasting drops it silently, because `parseClipboardPayload` treats a failed parse as an invalid payload and returns `null`. This includes the first-party `pascal:trees` pack, which declares `duplicable: true` and fails identically.

Nothing in the plugin API works around it from the outside: `DuplicableConfig` exposes only `subtree` and `prepareSubtreeClone`, and both run *after* the parse that throws.

This adds `parseClipboardNode`, which tries `AnyNode` first and falls back to the registry's schema for the node's `type`. It is applied at both call sites — the `remapNodeReferences` return, and the system-clipboard parse in `parseClipboardPayload`.

Built-in behaviour is unchanged: `AnyNode` is still attempted first, and a type that is neither built-in nor registered still raises the original `AnyNode` error rather than a vaguer one.

Found while building a third-party node pack against plugin API v1; the same failure reproduces with `pascal:trees` alone.

## How to test

1. `cd packages/editor && bun test src/lib/scene-clipboard.test.ts` — 7 pass.
2. Revert just `scene-clipboard.ts` (`git checkout main -- packages/editor/src/lib/scene-clipboard.ts`) and re-run: the new test fails with `Invalid discriminator value. Expected 'site' | 'building' | ...`, which is the error the editor surfaces today.
3. In the app, with any plugin that declares `capabilities.duplicable` installed (e.g. `pascal:trees`): place a plugin node, select it, Ctrl/Cmd+C then Ctrl/Cmd+V. Before this change nothing is pasted and the console shows the union error; after it, the node duplicates like a built-in.
4. Regression check on built-ins: copy/paste a cabinet run, a wall + measurement pair, and a standalone window — all still behave as before (covered by the pre-existing tests in the same file).

## Screenshots / screen recording

N/A — non-visual change. The observable difference is a paste that previously did nothing now producing a node.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

---

Note for the reviewer: `packages/editor` currently has one **pre-existing** unrelated failure on `main` — `floorplan-export.test.ts > resolveSheetComposition > reports duplicate reusable and sheet-local general notes`. It fails identically without this branch checked out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to clipboard parsing with built-in-first behavior preserved; risk is mainly accepting malformed plugin payloads only when a registry schema exists.
> 
> **Overview**
> **Clipboard copy/paste no longer rejects plugin node kinds** because validation went through `AnyNode` only, which cannot include kinds registered via `registerNode`.
> 
> The editor adds **`parseClipboardNode`**, which still parses built-ins with `AnyNode` and otherwise validates against **`nodeRegistry.get(type).schema`**. That helper replaces direct `AnyNode.parse` when remapping nodes on paste and when parsing nodes from the system clipboard payload, so **`capabilities.duplicable`** can work for plugin packs (e.g. trees). Unknown or unregistered types still fail with the original `AnyNode` error.
> 
> Tests register a fake plugin kind, assert copy/paste preserves kind-specific fields, and **`nodeRegistry._reset()`** in `afterEach` so registry state does not leak between tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e2e58e0669a5f6e564494a17b69d380755a05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->