### PR TITLE
ci: run the test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Type check
         run: bun run check-types
+
+      - name: Test
+        run: bun run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,27 @@ bun check        # Check for issues
 bun check:fix    # Auto-fix issues
 ```
 
+### Tests
+
+Run the whole suite from the repo root:
+
+```bash
+bun run test     # every package, via Turborepo
+```
+
+Run one package while you work on it:
+
+```bash
+bun --cwd packages/core run test
+```
+
+Use `bun run test`, not bare `bun test`. `test` is one of Bun's own
+subcommands, so `bun test` never reaches the package script — it runs Bun's
+collector over every file it can find, including compiled copies under `dist/`,
+and reports inflated counts. `bun run test` goes through Turborepo, which
+builds workspace dependencies first (several packages import theirs from
+`dist/`) and runs each package's own scoped test script.
+
 ### Project structure
 
 | Package | What it does |
@@ -52,7 +73,7 @@ New node kinds and sidebar panels can ship as a plugin instead of editing the bu
 
 1. **Fork the repo** and create a branch from `main`
 2. **Make your changes** and test locally with `bun dev`
-3. **Run `bun check`** to make sure linting passes
+3. **Run `bun check` and `bun run test`** to make sure linting and tests pass
 4. **Open a PR** with a clear description of what changed and why
 5. **Link related issues** if applicable (e.g., "Fixes #42")
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -49,6 +49,7 @@ The editor works fully without any environment variables.
 | `bun check` | Lint and format check (Biome) |
 | `bun check:fix` | Auto-fix lint and format issues |
 | `bun check-types` | TypeScript type checking |
+| `bun run test` | Run every package's test suite |
 
 ## Contributing
 

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -8,7 +8,8 @@
     "build": "dotenv -e ../../.env.local -- next build",
     "start": "next start",
     "lint": "biome lint",
-    "check-types": "next typegen && tsgo --noEmit"
+    "check-types": "next typegen && tsgo --noEmit",
+    "test": "bun test lib"
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,6 +292,7 @@
         "zustand": "^5",
       },
       "devDependencies": {
+        "@pascal-app/core": "^1.0.0-beta.4",
         "@pascal/typescript-config": "*",
         "@types/node": "^22",
         "@types/react": "^19.2.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "check": "biome check",
     "check:fix": "biome check --write",
     "check-types": "turbo run check-types",
+    "test": "turbo run test",
     "kill": "lsof -ti:3002 | xargs kill -9 2>/dev/null || echo 'No processes found on port 3002'",
     "clean:cache": "rm -rf apps/*/.next apps/*/.swc apps/*/.turbo packages/*/.turbo tooling/*/.turbo .turbo node_modules/.cache",
     "restart": "bun kill && bun clean:cache && bun dev",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -8,7 +8,8 @@
     "./catalog": "./src/components/ui/item-catalog/catalog-items.tsx"
   },
   "scripts": {
-    "check-types": "tsgo --noEmit"
+    "check-types": "tsgo --noEmit",
+    "test": "bun test src"
   },
   "peerDependencies": {
     "@pascal-app/core": "^1.0.0-beta.4",

--- a/packages/ifc-converter/package.json
+++ b/packages/ifc-converter/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "tsc --build",
     "dev": "tsgo --build --watch",
+    "test": "bun test tests",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "tsc --build",
     "dev": "tsgo --build --watch",
+    "test": "bun test src",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
@@ -34,6 +35,7 @@
     "zustand": "^5"
   },
   "devDependencies": {
+    "@pascal-app/core": "^1.0.0-beta.4",
     "@pascal/typescript-config": "*",
     "@types/node": "^22",
     "@types/react": "^19.2.2",

--- a/packages/viewer/tsconfig.json
+++ b/packages/viewer/tsconfig.json
@@ -9,6 +9,6 @@
     "types": ["node"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"],
   "references": [{ "path": "../core" }]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,10 @@
     "check-types": {
       "dependsOn": ["^build", "^check-types"]
     },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "dev": {
       "dependsOn": ["^build"],
       "cache": false,


### PR DESCRIPTION
## Why

The repo has **313 test files (~60k lines)** and they're good tests — schema migrations, wall mitering, CSG cutouts, placement collision, `NaN`/`Infinity` sanitization. But almost none of them run on a pull request.

- `ci.yml` runs only `bun run check` and `bun run check-types`.
- `mcp-ci.yml` runs `packages/mcp` plus two `apps/editor/lib` files, and only on path matches.
- `turbo.json` has no `test` task at all.
- `packages/viewer`, `packages/editor`, `packages/ifc-converter` and `apps/editor` contain **95 test files between them and had no `test` script**, so there was no way to run them even locally.

Net effect: roughly 2,200 of 2,491 tests were not acting as a gate on any change.

## What this does

- Adds a `test` task to `turbo.json` (`dependsOn: ["^build"]`, no outputs) and a root `test` script, then one `Test` step to `ci.yml`.
- Adds the missing `test` scripts to the four packages above.
- **Fixes a dependency-graph bug:** `packages/viewer` declared `@pascal-app/core` *only* as a `peerDependency`. Turbo doesn't traverse peer deps, so `^build` resolved to nothing and viewer's tests couldn't resolve core's `dist/`. `editor`, `nodes` and `mcp` all declare it in `devDependencies` **and** `peerDependencies`; this makes `viewer` consistent with them. (One line in `bun.lock`.)
- Scopes each glob to `src`/`tests`/`lib`. Bare `bun test` at a package root also collects the **compiled** tests under `dist/`, which is why viewer appeared to have 132 tests when it has 66.
- Documents `bun test` in `SETUP.md` and `CONTRIBUTING.md` (neither mentioned tests).

## Verification

From a clean tree — `rm -rf packages/*/dist packages/*/.turbo .turbo` — on Bun 1.3.14:

```
Tasks:    12 successful, 12 total
Time:     1m3.611s
```

| Package | Tests |
|---|---|
| `@pascal-app/core` | 760 pass, 0 fail (72 files) |
| `@pascal-app/nodes` | 876 pass, 0 fail (112 files) |
| `@pascal-app/editor` | 481 pass, 0 fail (66 files) |
| `@pascal-app/mcp` | 297 pass, 0 fail (46 files) |
| `@pascal-app/viewer` | 66 pass, 0 fail (14 files) |
| `editor` (app) | 8 pass, 0 fail (2 files) |
| `@pascal-app/ifc-converter` | 3 pass, 0 fail (1 file) |

**2,491 passing, 0 failing.** Warm re-run is `FULL TURBO` (289ms), so the added CI step costs ~1 min cold and nothing when cached. `bun run check` (1,527 files) and `bun run check-types` (9/9) still pass.

## Notes

- No test files or product code were changed — this is wiring only.
- `mcp-ci.yml` is left alone. It's now partly redundant with the root task, but it also builds `packages/mcp` and lints a specific file set, so I didn't want to fold it in without your call. Happy to do that in a follow-up.
- Worth considering `bun test --coverage` or `--bail` later; deliberately kept out of scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure and documentation only; no runtime or test logic changes, with low blast radius beyond longer CI when the cache is cold.
> 
> **Overview**
> **Wires the monorepo test suite into CI and local workflows** so thousands of existing tests actually gate PRs, without changing product or test code.
> 
> Adds a root `test` script and a Turborepo `test` task (`dependsOn: ["^build"]`), plus a **Test** step in `ci.yml` after typecheck. Packages that had tests but no script now expose scoped `bun test` commands (`src` / `tests` / `lib`) so runs don’t pick up compiled copies under `dist/`.
> 
> **Fixes viewer test/build ordering:** `@pascal-app/core` is added to `packages/viewer` `devDependencies` (alongside the existing peer) so Turbo can build core before viewer tests resolve `dist/`. Viewer `tsconfig` also excludes `**/*.test.*` from the library build.
> 
> **Docs:** `SETUP.md`, `CONTRIBUTING.md`, and the PR checklist now tell contributors to use `bun run test` (not bare `bun test`) and explain why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5bc81d0e6f5f6b7f325238dd30171ce8525486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->