### PR TITLE
fix(nodes): reuse wall draft preview geometry

### DIFF
--- a/packages/nodes/src/fence/tool.tsx
+++ b/packages/nodes/src/fence/tool.tsx
@@ -50,15 +50,7 @@ import {
 import { getSceneTheme, useViewer } from '@pascal-app/viewer'
 import { useThree } from '@react-three/fiber'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import {
-  BoxGeometry,
-  BufferGeometry,
-  type Camera,
-  DoubleSide,
-  type Group,
-  type Mesh,
-  Vector3,
-} from 'three'
+import { BufferGeometry, type Camera, DoubleSide, type Group, type Mesh, Vector3 } from 'three'
 import {
   DraftAngleArc,
   type DraftAngleLabel,
@@ -430,16 +422,11 @@ function updateFencePreview(
   }
   mesh.visible = true
   direction.normalize()
-  const geometry = new BoxGeometry(length, previewHeight, previewThickness)
   const angle = Math.atan2(direction.z, direction.x)
 
   mesh.position.set((start.x + end.x) / 2, start.y + previewHeight / 2, (start.z + end.z) / 2)
   mesh.rotation.y = -angle
-
-  if (mesh.geometry) {
-    mesh.geometry.dispose()
-  }
-  mesh.geometry = geometry
+  mesh.scale.set(length, previewHeight, previewThickness)
 }
 
 function getCurrentLevelElements(): { walls: WallNode[]; fences: FenceNode[] } {
@@ -762,7 +749,7 @@ const StraightFenceTool: React.FC = () => {
       />
       <CursorSphere height={previewHeight} ref={cursorRef} />
       <mesh layers={EDITOR_LAYER} ref={previewRef} renderOrder={1} visible={false}>
-        <shapeGeometry />
+        <boxGeometry />
         <meshBasicMaterial
           color="#ffffff"
           depthTest={false}

--- a/packages/nodes/src/wall/tool.tsx
+++ b/packages/nodes/src/wall/tool.tsx
@@ -53,7 +53,7 @@ import {
 import { getSceneTheme, useViewer } from '@pascal-app/viewer'
 import { useThree } from '@react-three/fiber'
 import { useEffect, useRef, useState } from 'react'
-import { BoxGeometry, DoubleSide, type Group, type Mesh, Vector3 } from 'three'
+import { DoubleSide, type Group, type Mesh, Vector3 } from 'three'
 import {
   DraftAngleArc,
   type DraftAngleLabel,
@@ -395,16 +395,11 @@ function updateWallPreview(
   mesh.visible = true
   direction.normalize()
 
-  const geometry = new BoxGeometry(length, previewHeight, previewThickness)
   const angle = Math.atan2(direction.z, direction.x)
 
   mesh.position.set((start.x + end.x) / 2, start.y + previewHeight / 2, (start.z + end.z) / 2)
   mesh.rotation.y = -angle
-
-  if (mesh.geometry) {
-    mesh.geometry.dispose()
-  }
-  mesh.geometry = geometry
+  mesh.scale.set(length, previewHeight, previewThickness)
 }
 
 function getLevelWalls(levelId: string | null, nodes: Record<string, AnyNode>): WallNode[] {
@@ -772,13 +767,9 @@ export const WallTool: React.FC = () => {
           angleLabel: null,
         })
         triggerSFX('sfx:structure-build-start')
-        // Visibility is owned by `updateWallPreview` — it flips
-        // `mesh.visible` based on segment length. Setting it here
-        // (before any geometry data has been written) draws the
-        // mesh's empty `<shapeGeometry/>` placeholder, which WebGPU
-        // flags as "Vertex buffer slot 0 ... was not set" on the
-        // first frame after click. Leaving it false until the next
-        // `onGridMove` writes a real BoxGeometry skips that frame.
+        // Visibility is owned by `updateWallPreview`. Leave the
+        // unit box hidden until the first pointer move scales and
+        // positions it for the active segment.
         setDraftMeasurement(null)
       } else if (buildingState.current === 1) {
         const angleLocked = isAngleSnapActive()
@@ -862,11 +853,9 @@ export const WallTool: React.FC = () => {
           y: draftY,
           angleLabel: null,
         })
-        // Hide the preview until the next `onGridMove` writes the
-        // new segment's geometry. Without this the prior segment's
-        // BoxGeometry stays visible for a frame on top of the
-        // freshly-committed real wall, producing a brief
-        // double-paint at the new wall's position.
+        // Hide the preview until the next `onGridMove` scales and
+        // repositions it. Otherwise the prior segment stays visible
+        // for a frame on top of the freshly committed wall.
         if (wallPreviewRef.current) {
           wallPreviewRef.current.visible = false
         }
@@ -908,7 +897,7 @@ export const WallTool: React.FC = () => {
       />
       <CursorSphere height={previewHeight} ref={cursorRef} />
       <mesh layers={EDITOR_LAYER} ref={wallPreviewRef} renderOrder={1} visible={false}>
-        <shapeGeometry />
+        <boxGeometry />
         <meshBasicMaterial
           color="#818cf8"
           depthTest={false}


### PR DESCRIPTION
## What does this PR do?

This removes per-pointer-move geometry allocation from the 3D wall draft preview.

Previously, every `grid:move` event constructed a new `BoxGeometry`, disposed the previous geometry, and assigned the replacement to the preview mesh. Continuous wall drawing therefore created avoidable CPU allocations and GPU resource churn on the editor's hottest interaction path.

The preview now mounts one unit `boxGeometry` and updates the mesh position, rotation, and scale. Snapping, preview dimensions, visibility, and chained wall placement behavior remain unchanged.

In a local 30-event pointer-move sample, the previous path produced roughly 4 MB of short-lived heap growth. With geometry reuse, the sampled heap delta was effectively flat; exact values remain workload- and GC-dependent.

Validation performed:

- `bun test packages/nodes/src/wall` — 71 passed
- `bun run build` in `packages/nodes` — passed
- Biome check for `packages/nodes/src/wall/tool.tsx` — passed
- Manual continuous-wall checks in both the 3D editor and 2D floorplan

## How to test

1. Run `bun dev`, open a project in the 3D editor, and select the Wall tool.
2. Place the first wall segment, then move the pointer to preview and place a second connected segment; verify the preview follows continuously and retains the expected height and thickness.
3. Switch to the 2D floorplan and verify wall preview, chained placement, and cancellation still behave as before.

## Screenshots / screen recording

Not included: this is a resource-lifetime optimization with intentionally unchanged visual output. The interaction was verified manually in both 3D and 2D.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (not applicable: no public API or behavior change)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only preview rendering optimization with unchanged snapping, dimensions, and placement behavior; visual output should match prior behavior.
> 
> **Overview**
> **Wall and straight fence draft previews** no longer allocate a new `BoxGeometry` on every `grid:move`. Both tools mount a single unit **`boxGeometry`** and drive the bar with **`mesh.scale`** plus the existing position/rotation updates in `updateWallPreview` / `updateFencePreview`, dropping per-move dispose/assign churn on the editor’s hottest path.
> 
> The preview mesh JSX switches from **`shapeGeometry`** to **`boxGeometry`**, aligned with the scale-based path and avoiding a one-frame WebGPU “vertex buffer slot 0” warning when visibility was toggled before real geometry existed. Wall-tool comments are tightened to describe hiding the unit box until the first move scales it (including after chained segments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f9f9f68cbd09a46a64cffd700c3d434850ab52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->