### PR TITLE
Hide crop switcher when host preselects a capture crop

### DIFF
--- a/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
+++ b/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
@@ -109,6 +109,9 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
   const isPreset = captureMode.mode === 'preset'
   const requestedCrop = captureMode.mode === 'standard' ? captureMode.crop : undefined
   const requestedAspect = captureMode.mode === 'standard' ? captureMode.standardAspect : undefined
+  // A host-preselected crop means the host needs that exact output shape
+  // (e.g. the publish-cover capture) — hide the crop/aspect switcher.
+  const isCropLocked = isPreset || requestedCrop !== undefined
 
   const [mode, setMode] = useState<CropMode>('standard')
   const [standardAspect, setStandardAspect] = useState<StandardAspect>('16:9')
@@ -538,7 +541,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
 
       {/* Bottom-center: crop switcher, caption + shutter */}
       <div className="pointer-events-none absolute right-0 bottom-5 left-0 flex flex-col items-center gap-2.5">
-        {!isPreset && (
+        {!isCropLocked && (
           <div className="pointer-events-auto relative flex items-center gap-1 rounded-full border border-white/10 bg-neutral-950/85 px-1.5 py-1.5 shadow-xl backdrop-blur-md">
             {/* Clicking Standard while it's active opens the aspect picker */}
             <ModeButton


### PR DESCRIPTION
The snapshot capture overlay hides its crop/aspect switcher whenever the host preselects a crop mode — hosts that need an exact output shape (the community publish dialog's 16:9 cover capture) get a locked, guided capture instead of user-changeable options. Preset mode behavior unchanged.

Consumed by pascalorg/private-editor community-3005 (community publish flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small capture-overlay UI change with no auth, data, or capture pipeline logic changes beyond control visibility.
> 
> **Overview**
> **Locks the snapshot capture UI when the host requires a fixed output shape.** The bottom crop/aspect switcher (Standard / Viewport / Area and aspect picker) now hides whenever `captureMode.crop` is set on a standard capture—not only in preset mode.
> 
> Hosts such as the community publish **16:9 cover** flow can steer users through framing and shutter without letting them change crop mode or aspect. Existing preset capture behavior for the switcher is unchanged; this extends the same “locked crop” treatment to host-preselected standard crops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed80617f02b4d0d88d22da48a045ed667f4d6c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->