### PR TITLE
fix(mcp): subtract surface holes from measured area

### DIFF
--- a/packages/mcp/src/tools/measure.test.ts
+++ b/packages/mcp/src/tools/measure.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test } from 'bun:test'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { WallNode, ZoneNode } from '@pascal-app/core/schema'
+import { SlabNode, WallNode, ZoneNode } from '@pascal-app/core/schema'
 import { SceneBridge } from '../bridge/scene-bridge'
 import { registerMeasure } from './measure'
 
@@ -58,6 +58,84 @@ describe('measure', () => {
     })
     const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text)
     expect(parsed.distanceMeters).toBe(0)
+    expect(parsed.areaSqMeters).toBeCloseTo(16, 5)
+  })
+
+  test('subtracts slab holes without changing an un-holed slab area', async () => {
+    const level = Object.values(bridge.getNodes()).find((n) => n.type === 'level')!
+    const polygon: Array<[number, number]> = [
+      [-2, -2],
+      [2, -2],
+      [2, 2],
+      [-2, 2],
+    ]
+    const solid = SlabNode.parse({ polygon })
+    const holed = SlabNode.parse({
+      polygon,
+      holes: [
+        [
+          [-1, -1],
+          [1, -1],
+          [1, 1],
+          [-1, 1],
+        ],
+      ],
+    })
+    bridge.createNode(solid, level.id)
+    bridge.createNode(holed, level.id)
+
+    const solidResult = await client.callTool({
+      name: 'measure',
+      arguments: { fromId: solid.id, toId: solid.id },
+    })
+    const solidArea = JSON.parse(
+      (solidResult.content as Array<{ type: string; text: string }>)[0]!.text,
+    ).areaSqMeters
+    const holedResult = await client.callTool({
+      name: 'measure',
+      arguments: { fromId: holed.id, toId: holed.id },
+    })
+    const holedArea = JSON.parse(
+      (holedResult.content as Array<{ type: string; text: string }>)[0]!.text,
+    ).areaSqMeters
+
+    expect(solidArea).toBeCloseTo(16, 5)
+    expect(holedArea).toBeCloseTo(12, 5)
+  })
+
+  // `loadJSON` casts its `nodes` into `setScene` without a schema parse, so a document
+  // authored before `holes` existed reaches `measure` with the field genuinely absent —
+  // the schema default never runs. Loading such a document is the real path to that
+  // state; don't fabricate it by mutating the store dict `getNodes()` hands back.
+  test('falls back to the outer polygon when a loaded document carries no holes field', async () => {
+    const slabId = 'slab_no_holes'
+    bridge.loadJSON({
+      nodes: {
+        [slabId]: {
+          object: 'node',
+          id: slabId,
+          type: 'slab',
+          name: 'Legacy slab',
+          parentId: null,
+          visible: true,
+          metadata: {},
+          children: [],
+          polygon: [
+            [-2, -2],
+            [2, -2],
+            [2, 2],
+            [-2, 2],
+          ],
+        },
+      },
+      rootNodeIds: [slabId],
+    } as unknown as Parameters<typeof bridge.loadJSON>[0])
+
+    const result = await client.callTool({
+      name: 'measure',
+      arguments: { fromId: slabId, toId: slabId },
+    })
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text)
     expect(parsed.areaSqMeters).toBeCloseTo(16, 5)
   })
 

--- a/packages/mcp/src/tools/measure.ts
+++ b/packages/mcp/src/tools/measure.ts
@@ -90,7 +90,7 @@ export function registerMeasure(server: McpServer, bridge: SceneOperations): voi
     {
       title: 'Measure',
       description:
-        'Measure distance (in meters) between two nodes, or the area of a polygon node when fromId === toId.',
+        'Measure distance (in meters) between two nodes, or the net area of a polygon node when fromId === toId.',
       inputSchema: measureInput,
       outputSchema: measureOutput,
     },
@@ -108,7 +108,11 @@ export function registerMeasure(server: McpServer, bridge: SceneOperations): voi
       if (fromId === toId) {
         const n = from as AnyNode
         if (n.type === 'zone' || n.type === 'slab' || n.type === 'ceiling') {
-          const area = shoelaceArea(n.polygon as Array<[number, number]>)
+          const holes = n.type === 'zone' ? [] : n.holes
+          const holeArea = Array.isArray(holes)
+            ? holes.reduce((sum, hole) => sum + shoelaceArea(hole), 0)
+            : 0
+          const area = Math.max(0, shoelaceArea(n.polygon) - holeArea)
           const payload = {
             distanceMeters: 0,
             areaSqMeters: area,


### PR DESCRIPTION
## What does this PR do?

`measure` with `fromId === toId` on a slab or ceiling reports the **gross** polygon area, ignoring
the node's `holes`. A 4 m × 4 m slab with a 2 m × 2 m opening measures as 16 m², not 12 m².

**Repro (at `42ac4be`):** create a slab with `polygon` 4×4 and one 2×2 hole, then call
`measure { fromId: <slabId>, toId: <slabId> }` → `areaSqMeters: 16`.

**Cause:** the self-measurement branch calls `shoelaceArea(n.polygon)` and never reads `n.holes`
(`packages/mcp/src/tools/measure.ts:108-116`). Both schemas carry holes — `SlabNode.holes`
("cutouts in the slab", `packages/core/src/schema/nodes/slab.ts:22-33`) and `CeilingNode.holes`
(`packages/core/src/schema/nodes/ceiling.ts:19`).

**Elsewhere the codebase treats surface area as hole-subtracted:**
- `wiki/architecture/measurements.md`: "Slab reports expose hole-subtracted surface";
- core's build validation computes slab floor area as the outer polygon minus every declared hole,
  clamped at zero (`packages/core/src/validation/validate-build-json.ts:257-268`);
- `deriveZoneQuantityReport` subtracts holes from proven floor surface
  (`packages/core/src/lib/zone-quantities.ts:441-460`).

The MCP tool is the outlier — and it's the surface agents use for takeoff-style checks, so a
penetration or void silently inflates the reported area.

**Fix (6 lines):** in the self-measurement branch, subtract the summed shoelace area of the node's
declared holes from the outer polygon, clamped at zero — mirroring the build-validation convention
at `validate-build-json.ts:257-268`. Zones are unchanged (`ZoneNode` has no `holes` field), and the
distance path (`fromId !== toId`) is untouched. The tool description now says "net area" so the
contract states what the number is. One nuance flagged rather than hidden: `deriveZoneQuantityReport`
additionally classifies non-contained holes as unavailable before subtracting; `measure` here mirrors
the simpler build-validation form (subtract all declared holes, clamp at zero). If you'd rather
`measure` apply the containment filter too, happy to adjust.

## How to test

1. `bun test --cwd packages/mcp` — new case in `packages/mcp/src/tools/measure.test.ts`:
   a solid 4×4 slab still measures 16; the same polygon with a 2×2 hole measures 12.
2. Manual repro: run the MCP server, create the holed slab, `measure` it self-to-self → 12.
3. The exact CI commands pass locally: `bun test --cwd packages/mcp` (298 pass / 0 fail) and the
   workflow's Biome check (141 files, no issues).

## Screenshots / screen recording

N/A — non-visual change (headless MCP tool output).

## Checklist

- [x] I've tested this locally (exact MCP CI gates: `bun test --cwd packages/mcp` + the workflow's
      Biome command; plus a live headless MCP repro — `bun dev` UI not exercised, this change has no
      UI surface)
- [x] My code follows the existing code style (`bun check` on the touched package is clean)
- [x] I've updated relevant documentation (the tool's own description string; the wiki already
      documents the convention this aligns to)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in the MCP measure tool with tests; no auth, persistence, or UI surface.
> 
> **Overview**
> The MCP **`measure`** tool now reports **net** polygon area for slabs and ceilings when `fromId === toId`, subtracting each declared hole’s shoelace area from the outer polygon and clamping at zero. **Zones** are unchanged (no `holes` field). The tool description now says “net area” instead of gross polygon area.
> 
> **Tests** cover a holed vs solid 4×4 slab (16 vs 12 m²) and legacy JSON loaded without a `holes` property (still uses the outer polygon only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6030a1eeff1468d8e9d00e760eaf40020f3981c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->