### PR TITLE
Fix release package tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,4 +258,4 @@ jobs:
             git tag "$TAG"
           done
 
-          git push --follow-tags
+          git push origin HEAD:main $TAGS


### PR DESCRIPTION
## Summary
- push each generated package tag explicitly alongside the release commit
- avoid relying on `--follow-tags`, which ignores the workflow’s lightweight tags

## Verification
- repaired and verified all six `1.0.0-beta.1` package tags against release commit `d92c0e65`
- release dry run and publish workflows completed successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to the release git push command; no runtime app or auth logic affected.
> 
> **Overview**
> Fixes release tagging so **per-package version tags** (e.g. `@pascal-app/core@1.0.0-beta.1`) actually reach the remote after the version-bump commit.
> 
> The **Commit version bumps & tag** step in `.github/workflows/release.yml` now runs `git push origin HEAD:main $TAGS` instead of `git push --follow-tags`. Tags are still created in a loop before the push; the change is only how they are published. **`--follow-tags`** was not pushing these workflow-created tags reliably (including lightweight tags), so the push now names **`main`** and every tag in **`$TAGS`** explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1c29d4acf0e89ed272b3bb9c6c9187504ab260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->