### PR TITLE
editor: light WebGPU preview and /editor scene redirect

### DIFF
--- a/apps/editor/app/page.tsx
+++ b/apps/editor/app/page.tsx
@@ -91,16 +91,12 @@ export default function Home() {
     <div className="relative h-screen w-screen">
       {PROJECT_ID === 'local-editor' && (
         <div className="pointer-events-none absolute top-3 left-1/2 z-40 -translate-x-1/2">
-          <div className="pointer-events-auto flex items-center gap-3 rounded-full border border-border/60 bg-background/90 px-4 py-1.5 text-xs shadow-sm backdrop-blur">
-            <span className="text-muted-foreground">Local editor — scenes are not saved.</span>
-            <Link className="font-medium text-foreground hover:underline" href="/scenes">
-              Open recent scenes
-            </Link>
-            <span aria-hidden className="text-muted-foreground">
-              ·
+          <div className="pointer-events-auto flex max-w-[min(92vw,42rem)] flex-wrap items-center justify-center gap-x-3 gap-y-1 rounded-full border border-border/60 bg-background/90 px-4 py-1.5 text-xs shadow-sm backdrop-blur">
+            <span className="text-muted-foreground">
+              Blank canvas — saved scenes are under Scenes (not this page).
             </span>
             <Link className="font-medium text-foreground hover:underline" href="/scenes">
-              Create new
+              Open saved scenes
             </Link>
           </div>
         </div>

--- a/apps/editor/app/scenes/page.tsx
+++ b/apps/editor/app/scenes/page.tsx
@@ -83,8 +83,7 @@ export default async function ScenesPage() {
               <li key={scene.id}>
                 <Link
                   className="group block rounded-xl border border-border/60 bg-background p-4 transition-colors hover:border-border hover:bg-accent/30"
-                  href={`/scene/${scene.id}?disable=postFx,outline`}
-                  title="Opens with light preview (post-FX off) for stable local WebGPU"
+                  href={`/scene/${scene.id}`}
                 >
                   <div className="flex aspect-video items-center justify-center overflow-hidden rounded-lg bg-accent/30">
                     {scene.thumbnailUrl ? (

--- a/apps/editor/app/scenes/page.tsx
+++ b/apps/editor/app/scenes/page.tsx
@@ -83,7 +83,8 @@ export default async function ScenesPage() {
               <li key={scene.id}>
                 <Link
                   className="group block rounded-xl border border-border/60 bg-background p-4 transition-colors hover:border-border hover:bg-accent/30"
-                  href={`/scene/${scene.id}`}
+                  href={`/scene/${scene.id}?disable=postFx,outline`}
+                  title="Opens with light preview (post-FX off) for stable local WebGPU"
                 >
                   <div className="flex aspect-video items-center justify-center overflow-hidden rounded-lg bg-accent/30">
                     {scene.thumbnailUrl ? (

--- a/apps/editor/components/scene-loader.tsx
+++ b/apps/editor/components/scene-loader.tsx
@@ -106,14 +106,13 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
   const [saveError, setSaveError] = useState<string | null>(null)
 
   // Light preview: re-run when query changes (same scene, client navigation to ?disable=…).
-  // See packages/mcp/docs/layout-clearance-error-log.md pitfall L5 (editor).
+  // When flags are removed, restore default shading so the render pipeline is not left stuck.
   useEffect(() => {
     const disable = searchParams.get('disable') ?? ''
     const light =
       disable.split(',').some((p) => p.trim() === 'postFx') || searchParams.get('safe') === '1'
-    if (!light) return
     try {
-      useViewer.getState().setShading('solid')
+      useViewer.getState().setShading(light ? 'solid' : 'rendered')
     } catch {
       // Viewer store may not be ready yet on first paint.
     }

--- a/apps/editor/components/scene-loader.tsx
+++ b/apps/editor/components/scene-loader.tsx
@@ -9,17 +9,14 @@ import {
   type SceneGraph,
   type SidebarTab,
 } from '@pascal-app/editor'
-import { useViewer } from '@pascal-app/viewer'
 import { Hammer, Layers } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
 import { BuildTab } from './build-tab'
 import { CommunityViewerToolbarLeft, CommunityViewerToolbarRight } from './viewer-toolbar'
-
-/** Lighter preview path: skips post-FX and outline passes (viewer `?disable=` flags). */
-export const LIGHT_PREVIEW_QUERY = 'disable=postFx,outline'
 
 export interface SceneMeta {
   id: string
@@ -96,11 +93,14 @@ function sceneGraphSignature(graph: SceneGraphWithCollections): string {
   })
 }
 
+/**
+ * `?disable=postFx` is read at post-processing module load, so it only takes
+ * effect on a full page load. Reading it here as well lets the flag survive a
+ * client-side navigation, since `disablePostFx` is a live prop.
+ */
 function isLightPreviewQuery(searchParams: URLSearchParams): boolean {
   const disable = searchParams.get('disable') ?? ''
-  return (
-    disable.split(',').some((p) => p.trim() === 'postFx') || searchParams.get('safe') === '1'
-  )
+  return disable.split(',').some((p) => p.trim() === 'postFx')
 }
 
 export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
@@ -111,20 +111,8 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
   const suppressRemoteSaveUntilRef = useRef(0)
   const [conflict, setConflict] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
-  /** Bumps when Light preview is clicked while already active so effects re-apply. */
-  const [lightApplyTick, setLightApplyTick] = useState(0)
 
   const lightPreview = isLightPreviewQuery(searchParams)
-
-  // Light preview: host prop disablePostFx rebuilds the pipeline; solid shading pairs with it.
-  // When flags clear, restore rendered so post-FX can come back.
-  useEffect(() => {
-    try {
-      useViewer.getState().setShading(lightPreview ? 'solid' : 'rendered')
-    } catch {
-      // Viewer store may not be ready yet on first paint.
-    }
-  }, [lightPreview, lightApplyTick])
 
   const handleLoad = useCallback(async () => initialScene, [initialScene])
 
@@ -251,20 +239,16 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
       )}
       <div className="pointer-events-none absolute top-4 right-4 z-40 flex items-center gap-2">
         <button
+          aria-pressed={lightPreview}
+          className={cn(
+            'pointer-events-auto rounded-md border border-border px-3 py-1.5 font-medium text-xs shadow-sm backdrop-blur',
+            lightPreview ? 'bg-accent' : 'bg-background/90 hover:bg-accent/40',
+          )}
+          onClick={() =>
+            router.push(lightPreview ? `/scene/${meta.id}` : `/scene/${meta.id}?disable=postFx`)
+          }
+          title="Skip the post-processing pipeline — lighter on the GPU, no ambient occlusion or selection outlines"
           type="button"
-          className="pointer-events-auto rounded-md border border-border bg-background/90 px-3 py-1.5 font-medium text-xs shadow-sm backdrop-blur hover:bg-accent/40"
-          onClick={() => {
-            // Force re-apply even if URL already has light-preview flags (toolbar may have changed shading).
-            setLightApplyTick((n) => n + 1)
-            try {
-              useViewer.getState().setShading('solid')
-            } catch {
-              // ignore
-            }
-            if (!lightPreview) {
-              router.push(`/scene/${meta.id}?${LIGHT_PREVIEW_QUERY}`)
-            }
-          }}
         >
           Light preview
         </button>

--- a/apps/editor/components/scene-loader.tsx
+++ b/apps/editor/components/scene-loader.tsx
@@ -13,7 +13,7 @@ import { useViewer } from '@pascal-app/viewer'
 import { Hammer, Layers } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { BuildTab } from './build-tab'
 import { CommunityViewerToolbarLeft, CommunityViewerToolbarRight } from './viewer-toolbar'
@@ -98,26 +98,26 @@ function sceneGraphSignature(graph: SceneGraphWithCollections): string {
 
 export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const versionRef = useRef(meta.version)
   const lastRemoteGraphJsonRef = useRef<string | null>(null)
   const suppressRemoteSaveUntilRef = useRef(0)
   const [conflict, setConflict] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
 
-  // Light preview: solid shading pairs with `?disable=postFx` (viewer post-processing flags).
+  // Light preview: re-run when query changes (same scene, client navigation to ?disable=…).
+  // See packages/mcp/docs/layout-clearance-error-log.md pitfall L5 (editor).
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const params = new URLSearchParams(window.location.search)
-    const disable = params.get('disable') ?? ''
+    const disable = searchParams.get('disable') ?? ''
     const light =
-      disable.split(',').some((p) => p.trim() === 'postFx') || params.get('safe') === '1'
+      disable.split(',').some((p) => p.trim() === 'postFx') || searchParams.get('safe') === '1'
     if (!light) return
     try {
       useViewer.getState().setShading('solid')
     } catch {
       // Viewer store may not be ready yet on first paint.
     }
-  }, [])
+  }, [searchParams])
 
   const handleLoad = useCallback(async () => initialScene, [initialScene])
 

--- a/apps/editor/components/scene-loader.tsx
+++ b/apps/editor/components/scene-loader.tsx
@@ -96,6 +96,13 @@ function sceneGraphSignature(graph: SceneGraphWithCollections): string {
   })
 }
 
+function isLightPreviewQuery(searchParams: URLSearchParams): boolean {
+  const disable = searchParams.get('disable') ?? ''
+  return (
+    disable.split(',').some((p) => p.trim() === 'postFx') || searchParams.get('safe') === '1'
+  )
+}
+
 export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -104,19 +111,20 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
   const suppressRemoteSaveUntilRef = useRef(0)
   const [conflict, setConflict] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  /** Bumps when Light preview is clicked while already active so effects re-apply. */
+  const [lightApplyTick, setLightApplyTick] = useState(0)
 
-  // Light preview: re-run when query changes (same scene, client navigation to ?disable=…).
-  // When flags are removed, restore default shading so the render pipeline is not left stuck.
+  const lightPreview = isLightPreviewQuery(searchParams)
+
+  // Light preview: host prop disablePostFx rebuilds the pipeline; solid shading pairs with it.
+  // When flags clear, restore rendered so post-FX can come back.
   useEffect(() => {
-    const disable = searchParams.get('disable') ?? ''
-    const light =
-      disable.split(',').some((p) => p.trim() === 'postFx') || searchParams.get('safe') === '1'
     try {
-      useViewer.getState().setShading(light ? 'solid' : 'rendered')
+      useViewer.getState().setShading(lightPreview ? 'solid' : 'rendered')
     } catch {
       // Viewer store may not be ready yet on first paint.
     }
-  }, [searchParams])
+  }, [lightPreview, lightApplyTick])
 
   const handleLoad = useCallback(async () => initialScene, [initialScene])
 
@@ -242,12 +250,24 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
         </div>
       )}
       <div className="pointer-events-none absolute top-4 right-4 z-40 flex items-center gap-2">
-        <Link
+        <button
+          type="button"
           className="pointer-events-auto rounded-md border border-border bg-background/90 px-3 py-1.5 font-medium text-xs shadow-sm backdrop-blur hover:bg-accent/40"
-          href={`/scene/${meta.id}?${LIGHT_PREVIEW_QUERY}`}
+          onClick={() => {
+            // Force re-apply even if URL already has light-preview flags (toolbar may have changed shading).
+            setLightApplyTick((n) => n + 1)
+            try {
+              useViewer.getState().setShading('solid')
+            } catch {
+              // ignore
+            }
+            if (!lightPreview) {
+              router.push(`/scene/${meta.id}?${LIGHT_PREVIEW_QUERY}`)
+            }
+          }}
         >
           Light preview
-        </Link>
+        </button>
         <Link
           className="pointer-events-auto rounded-md border border-border bg-background/90 px-3 py-1.5 font-medium text-xs shadow-sm backdrop-blur hover:bg-accent/40"
           href="/scenes"
@@ -256,6 +276,7 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
         </Link>
       </div>
       <Editor
+        disablePostFx={lightPreview}
         layoutVersion="v2"
         onLoad={handleLoad}
         onSave={handleSave}

--- a/apps/editor/components/scene-loader.tsx
+++ b/apps/editor/components/scene-loader.tsx
@@ -9,6 +9,7 @@ import {
   type SceneGraph,
   type SidebarTab,
 } from '@pascal-app/editor'
+import { useViewer } from '@pascal-app/viewer'
 import { Hammer, Layers } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -16,6 +17,9 @@ import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { BuildTab } from './build-tab'
 import { CommunityViewerToolbarLeft, CommunityViewerToolbarRight } from './viewer-toolbar'
+
+/** Lighter preview path: skips post-FX and outline passes (viewer `?disable=` flags). */
+export const LIGHT_PREVIEW_QUERY = 'disable=postFx,outline'
 
 export interface SceneMeta {
   id: string
@@ -99,6 +103,21 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
   const suppressRemoteSaveUntilRef = useRef(0)
   const [conflict, setConflict] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Light preview: solid shading pairs with `?disable=postFx` (viewer post-processing flags).
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    const disable = params.get('disable') ?? ''
+    const light =
+      disable.split(',').some((p) => p.trim() === 'postFx') || params.get('safe') === '1'
+    if (!light) return
+    try {
+      useViewer.getState().setShading('solid')
+    } catch {
+      // Viewer store may not be ready yet on first paint.
+    }
+  }, [])
 
   const handleLoad = useCallback(async () => initialScene, [initialScene])
 
@@ -224,6 +243,12 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
         </div>
       )}
       <div className="pointer-events-none absolute top-4 right-4 z-40 flex items-center gap-2">
+        <Link
+          className="pointer-events-auto rounded-md border border-border bg-background/90 px-3 py-1.5 font-medium text-xs shadow-sm backdrop-blur hover:bg-accent/40"
+          href={`/scene/${meta.id}?${LIGHT_PREVIEW_QUERY}`}
+        >
+          Light preview
+        </Link>
         <Link
           className="pointer-events-auto rounded-md border border-border bg-background/90 px-3 py-1.5 font-medium text-xs shadow-sm backdrop-blur hover:bg-accent/40"
           href="/scenes"

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -7,6 +7,17 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  // MCP / package metadata returns `/editor/<id>` (hosted route). This open-source
+  // app serves saved scenes at `/scene/<id>` — redirect so links and bookmarks work.
+  async redirects() {
+    return [
+      {
+        source: '/editor/:id',
+        destination: '/scene/:id',
+        permanent: false,
+      },
+    ]
+  },
   transpilePackages: [
     'three',
     '@pascal-app/viewer',

--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -190,6 +190,13 @@ export interface EditorProps {
   // Thumbnail
   onThumbnailCapture?: (blob: Blob, cameraData: SnapshotCameraData) => void
 
+  /**
+   * When true, skip the viewer post-FX pipeline (same as `?disable=postFx`).
+   * Hosts use this for a stable local "light preview" without relying only on
+   * module-load URL flags or shading toggles.
+   */
+  disablePostFx?: boolean
+
   // Version preview overlays (rendered by host app)
   sidebarOverlay?: ReactNode
   viewerBanner?: ReactNode
@@ -961,6 +968,7 @@ const ViewerCanvas = memo(function ViewerCanvas({
   onThumbnailCapture,
   viewerSceneSlot,
   floorplanSceneSlot,
+  disablePostFx = false,
 }: {
   isVersionPreviewMode: boolean
   isLoading: boolean
@@ -973,6 +981,7 @@ const ViewerCanvas = memo(function ViewerCanvas({
   onThumbnailCapture?: (blob: Blob, cameraData: SnapshotCameraData) => void
   viewerSceneSlot?: ReactNode
   floorplanSceneSlot?: ReactNode
+  disablePostFx?: boolean
 }) {
   const viewMode = useEditor((s) => s.viewMode)
   const floorplanPaneRatio = useEditor((s) => s.floorplanPaneRatio)
@@ -1086,6 +1095,7 @@ const ViewerCanvas = memo(function ViewerCanvas({
           <SelectionPersistenceManager enabled={hasLoadedInitialScene && !showLoader} />
           <Viewer
             defaultRender={EDITOR_DEFAULT_RENDER}
+            disablePostFx={disablePostFx}
             hoverStyles={EDITOR_HOVER_STYLES}
             onSceneReadyChange={onSceneReadyChange}
             renderContext="editor"
@@ -1131,6 +1141,7 @@ export default function Editor({
   isLoading = false,
   onLoaderChange,
   onThumbnailCapture,
+  disablePostFx = false,
   sidebarOverlay,
   viewerBanner,
   settingsPanelProps,
@@ -1331,6 +1342,7 @@ export default function Editor({
 
   const viewerCanvas = (
     <ViewerCanvas
+      disablePostFx={disablePostFx}
       hasLoadedInitialScene={hasLoadedInitialScene}
       isFirstPersonMode={isFirstPersonMode}
       isLoading={isLoading}

--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -1324,6 +1324,7 @@ export default function Editor({
   const previewViewerContent = (
     <Viewer
       defaultRender={EDITOR_DEFAULT_RENDER}
+      disablePostFx={disablePostFx}
       hoverStyles={EDITOR_HOVER_STYLES}
       renderContext="editor"
       selectionManager="default"


### PR DESCRIPTION
## What does this PR do?

Improves the standalone `apps/editor` local/MCP preview experience:

1. **Route compatibility** — redirect `/editor/:id` to `/scene/:id` so MCP `editorUrl` links open saved scenes instead of 404.
2. **Light preview** — scene list opens with `?disable=postFx,outline` (existing viewer flags) and forces solid shading when that path is active; scene page exposes a **Light preview** control.
3. **Clearer home banner** — home is a blank canvas; saved scenes live under Scenes (wording fix only).

No viewer package API changes; uses existing post-processing `disable` query flags.

## How to test

1. `bun run --cwd apps/editor dev` (or project equivalent) on port 3002 with a local scene store.
2. Open `/editor/<existing-scene-id>` — expect redirect to `/scene/<id>` and the scene loads.
3. Open `/scenes` — each card links with light-preview query; canvas should stay responsive (post-FX off).
4. On a scene page, click **Light preview** — URL gains disable flags; shading goes solid.
5. Home `/` still shows blank editor with link to saved scenes.

## Screenshots / screen recording

N/A for core logic (routing + existing viewer flags). Optional: short clip of `/editor/id` redirect if desired.

## Checklist

- [x] I've tested this locally with the editor dev server
- [x] My code follows the existing code style
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to routing, copy, and an optional rendering flag wired through existing viewer `disablePostFx` support; no auth or persistence logic is touched.
> 
> **Overview**
> Adds a **non-permanent redirect** from `/editor/:id` to `/scene/:id` so MCP/host `editorUrl` links open saved scenes in the OSS app instead of 404ing.
> 
> On saved-scene pages, **Light preview** reads `?disable=postFx` (including after client-side navigation) and passes **`disablePostFx`** into `@pascal-app/editor`, which forwards it to the viewer so the post-processing pipeline is skipped for a lighter GPU path. A header control toggles that query param on/off.
> 
> The **home** local-editor banner copy is updated to clarify that `/` is a blank canvas and saved work lives under Scenes, with minor layout tweaks for wrapping on small screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7931a3393a2faa111f8700345e324be9611ade1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->