### PR TITLE
editor: session multi-select groups (Ctrl+G)

### DIFF
--- a/packages/editor/src/components/editor-2d/floorplan-group-action-menu.tsx
+++ b/packages/editor/src/components/editor-2d/floorplan-group-action-menu.tsx
@@ -1,11 +1,20 @@
 'use client'
 
+import { useScene } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isActive } from '../../lib/interaction/scope'
+import {
+  canCreateSessionGroup,
+  selectionIntersectsSessionGroup,
+} from '../../lib/session-groups'
 import useEditor from '../../store/use-editor'
 import useInteractionScope, { useMovingNode } from '../../store/use-interaction-scope'
+import useSessionGroups, {
+  groupCurrentSelection,
+  ungroupCurrentSelection,
+} from '../../store/use-session-groups'
 import {
   deleteSelection,
   duplicateSelectionAndPickUp,
@@ -14,25 +23,27 @@ import {
 import { NodeActionMenu } from '../editor/node-action-menu'
 
 /**
- * Floating Move / Duplicate / Delete pill for a MULTI-selection in the 2D
- * floor plan — the group sibling of `FloorplanRegistryActionMenu` (which is
- * sole-selection only). Anchored above the dashed group selection box; every
- * action targets the whole selection: Move picks the group up (it rides the
- * cursor until a click places it), Duplicate clones the selection and picks
- * the clones up, Delete removes everything selected.
- *
- * Gated on floorplan hover so it never coexists with the 3D group menu in
- * split view (that one hides while the floor plan is hovered), and hidden
- * during any active interaction so it never competes with a live drag.
+ * Floating multi-select pill on the floor plan: Move, Group, Ungroup, Duplicate, Delete.
  */
 export function FloorplanGroupActionMenu() {
-  const isMultiSelect = useViewer((s) => s.selection.selectedIds.length > 1)
+  const selectedIds = useViewer((s) => s.selection.selectedIds)
+  const isMultiSelect = selectedIds.length > 1
   const movingNode = useMovingNode()
   const isFloorplanHovered = useEditor((s) => s.isFloorplanHovered)
   const scopeActive = useInteractionScope((s) => isActive(s.scope))
+  const sessionGroups = useSessionGroups((s) => s.groups)
+  const sceneNodes = useScene((s) => s.nodes)
+  const liveIds = useMemo(() => new Set(Object.keys(sceneNodes)), [sceneNodes])
+  const showGroup = useMemo(
+    () => canCreateSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
+  )
+  const showUngroup = useMemo(
+    () => selectionIntersectsSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
+  )
 
   const [position, setPosition] = useState<{ left: number; top: number } | null>(null)
-
   const isVisible = isMultiSelect && !movingNode && isFloorplanHovered && !scopeActive
 
   useEffect(() => {
@@ -43,9 +54,6 @@ export function FloorplanGroupActionMenu() {
     let raf = 0
     const tick = () => {
       raf = requestAnimationFrame(tick)
-      // The dashed group box exists exactly while the multi-selection has
-      // transformable participants — anchor to its top edge. Only publish
-      // actual changes so the idle poll doesn't re-render every frame.
       const box = document.querySelector('[data-group-selection-box]') as SVGGElement | null
       if (!box) {
         setPosition((prev) => (prev === null ? prev : null))
@@ -77,9 +85,11 @@ export function FloorplanGroupActionMenu() {
       <NodeActionMenu
         onDelete={() => deleteSelection()}
         onDuplicate={() => duplicateSelectionAndPickUp()}
+        onGroup={showGroup ? () => groupCurrentSelection() : undefined}
         onMove={() => startGroupPickUp()}
         onPointerDown={(event) => event.stopPropagation()}
         onPointerUp={(event) => event.stopPropagation()}
+        onUngroup={showUngroup ? () => ungroupCurrentSelection() : undefined}
       />
     </div>,
     document.body,

--- a/packages/editor/src/components/editor-2d/floorplan-group-action-menu.tsx
+++ b/packages/editor/src/components/editor-2d/floorplan-group-action-menu.tsx
@@ -5,10 +5,7 @@ import { useViewer } from '@pascal-app/viewer'
 import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { isActive } from '../../lib/interaction/scope'
-import {
-  canCreateSessionGroup,
-  selectionIntersectsSessionGroup,
-} from '../../lib/session-groups'
+import { canCreateSessionGroup, selectionIntersectsSessionGroup } from '../../lib/session-groups'
 import useEditor from '../../store/use-editor'
 import useInteractionScope, { useMovingNode } from '../../store/use-interaction-scope'
 import useSessionGroups, {

--- a/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
+++ b/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
@@ -84,7 +84,6 @@ import { clearSurfacePlanSnapFeedback } from '../../../lib/surface-plan-snap'
 import useDirectManipulationFeedback from '../../../store/use-direct-manipulation-feedback'
 import useDrawingView from '../../../store/use-drawing-view'
 import useEditor, { isAngleSnapActive } from '../../../store/use-editor'
-import { expandSessionSelectionForNode } from '../../../store/use-session-groups'
 import useFloorplanAnnotationVisibility from '../../../store/use-floorplan-annotation-visibility'
 import useFloorplanMode from '../../../store/use-floorplan-mode'
 import useInteractionScope, {
@@ -92,6 +91,7 @@ import useInteractionScope, {
   useEndpointReshape,
   useMovingNode,
 } from '../../../store/use-interaction-scope'
+import { expandSessionSelectionForNode } from '../../../store/use-session-groups'
 import { startGroupPickUp } from '../../editor/group-actions'
 import { classifyParticipant } from '../../editor/group-transform-shared'
 import { suppressBoxSelectForPointer } from '../../tools/select/box-select-state'
@@ -592,7 +592,7 @@ export const FloorplanRegistryLayer = memo(function FloorplanRegistryLayer() {
   const applyEntrySelection = useCallback(
     (id: AnyNodeId, options: { shouldToggle: boolean; isolateMember: boolean }) => {
       const currentSelectedIds = useViewer.getState().selection.selectedIds
-      let nextSelectedIds: AnyNodeId[]
+      let nextSelectedIds: string[]
       if (options.shouldToggle) {
         nextSelectedIds = currentSelectedIds.includes(id)
           ? currentSelectedIds.filter((selectedId) => selectedId !== id)
@@ -601,7 +601,7 @@ export const FloorplanRegistryLayer = memo(function FloorplanRegistryLayer() {
         nextSelectedIds = [id]
       } else {
         const expanded = expandSessionSelectionForNode(id)
-        nextSelectedIds = (expanded && expanded.length > 1 ? expanded : [id]) as AnyNodeId[]
+        nextSelectedIds = expanded && expanded.length > 1 ? expanded : [id]
       }
       setSelection({ selectedIds: nextSelectedIds })
       if (nextSelectedIds.length === 1 && nextSelectedIds[0] === id) {

--- a/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
+++ b/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
@@ -84,6 +84,7 @@ import { clearSurfacePlanSnapFeedback } from '../../../lib/surface-plan-snap'
 import useDirectManipulationFeedback from '../../../store/use-direct-manipulation-feedback'
 import useDrawingView from '../../../store/use-drawing-view'
 import useEditor, { isAngleSnapActive } from '../../../store/use-editor'
+import { expandSessionSelectionForNode } from '../../../store/use-session-groups'
 import useFloorplanAnnotationVisibility from '../../../store/use-floorplan-annotation-visibility'
 import useFloorplanMode from '../../../store/use-floorplan-mode'
 import useInteractionScope, {
@@ -589,13 +590,19 @@ export const FloorplanRegistryLayer = memo(function FloorplanRegistryLayer() {
   }, [bumpAffectedSiblingEpochs])
 
   const applyEntrySelection = useCallback(
-    (id: AnyNodeId, shouldToggle: boolean) => {
+    (id: AnyNodeId, options: { shouldToggle: boolean; isolateMember: boolean }) => {
       const currentSelectedIds = useViewer.getState().selection.selectedIds
-      const nextSelectedIds = shouldToggle
-        ? currentSelectedIds.includes(id)
+      let nextSelectedIds: AnyNodeId[]
+      if (options.shouldToggle) {
+        nextSelectedIds = currentSelectedIds.includes(id)
           ? currentSelectedIds.filter((selectedId) => selectedId !== id)
           : [...currentSelectedIds, id]
-        : [id]
+      } else if (options.isolateMember) {
+        nextSelectedIds = [id]
+      } else {
+        const expanded = expandSessionSelectionForNode(id)
+        nextSelectedIds = (expanded && expanded.length > 1 ? expanded : [id]) as AnyNodeId[]
+      }
       setSelection({ selectedIds: nextSelectedIds })
       if (nextSelectedIds.length === 1 && nextSelectedIds[0] === id) {
         const node = useScene.getState().nodes[id]
@@ -618,7 +625,10 @@ export const FloorplanRegistryLayer = memo(function FloorplanRegistryLayer() {
     (id: AnyNodeId, event: React.PointerEvent<SVGGElement>) => {
       if (event.button !== 0) return
       event.stopPropagation()
-      applyEntrySelection(id, event.metaKey || event.ctrlKey || event.shiftKey)
+      applyEntrySelection(id, {
+        shouldToggle: event.metaKey || event.ctrlKey || event.shiftKey,
+        isolateMember: event.altKey && !(event.metaKey || event.ctrlKey || event.shiftKey),
+      })
     },
     [applyEntrySelection],
   )

--- a/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
+++ b/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
@@ -701,7 +701,11 @@ export const FloorplanRegistryLayer = memo(function FloorplanRegistryLayer() {
         if (endEvent.pointerId !== pointerId) return
         cleanup()
         if (!engaged) {
-          applyEntrySelection(id, true)
+          // Cmd/Ctrl+click without drag: toggle member (options object, not bare boolean).
+          applyEntrySelection(id, {
+            shouldToggle: true,
+            isolateMember: false,
+          })
         }
       }
 

--- a/packages/editor/src/components/editor/floorplan-background-selection.test.ts
+++ b/packages/editor/src/components/editor/floorplan-background-selection.test.ts
@@ -7,7 +7,7 @@ const baseArgs = {
   currentSelectedIds: ['wall_1'],
   getFloorplanHitIdAtPoint: () => 'door_1',
   isWallBuildActive: false,
-  modifierKeys: { meta: false, ctrl: false, shift: false },
+  modifierKeys: { meta: false, ctrl: false, shift: false, alt: false },
   planPoint: [0, 0] as [number, number],
   structureLayer: 'elements',
 }
@@ -16,7 +16,7 @@ describe('resolveFloorplanBackgroundSelection', () => {
   test('shift-click on a floorplan node toggles into the current selection', () => {
     const result = resolveFloorplanBackgroundSelection({
       ...baseArgs,
-      modifierKeys: { meta: false, ctrl: false, shift: true },
+      modifierKeys: { meta: false, ctrl: false, shift: true, alt: false },
     })
 
     expect(result).toEqual({
@@ -30,7 +30,7 @@ describe('resolveFloorplanBackgroundSelection', () => {
     const result = resolveFloorplanBackgroundSelection({
       ...baseArgs,
       currentSelectedIds: ['wall_1', 'door_1'],
-      modifierKeys: { meta: false, ctrl: false, shift: true },
+      modifierKeys: { meta: false, ctrl: false, shift: true, alt: false },
     })
 
     expect(result).toEqual({
@@ -44,13 +44,40 @@ describe('resolveFloorplanBackgroundSelection', () => {
     const result = resolveFloorplanBackgroundSelection({
       ...baseArgs,
       getFloorplanHitIdAtPoint: () => null,
-      modifierKeys: { meta: false, ctrl: false, shift: true },
+      modifierKeys: { meta: false, ctrl: false, shift: true, alt: false },
     })
 
     expect(result).toEqual({
       handled: true,
       kind: 'clear-elements',
       preserveSelection: true,
+    })
+  })
+
+  test('plain click expands a session group', () => {
+    const result = resolveFloorplanBackgroundSelection({
+      ...baseArgs,
+      expandIdsForNode: (nodeId) => (nodeId === 'door_1' ? ['door_1', 'wall_2'] : null),
+    })
+
+    expect(result).toEqual({
+      handled: true,
+      kind: 'select-elements',
+      selectedIds: ['door_1', 'wall_2'],
+    })
+  })
+
+  test('alt-click selects one member without expanding', () => {
+    const result = resolveFloorplanBackgroundSelection({
+      ...baseArgs,
+      expandIdsForNode: () => ['door_1', 'wall_2'],
+      modifierKeys: { meta: false, ctrl: false, shift: false, alt: true },
+    })
+
+    expect(result).toEqual({
+      handled: true,
+      kind: 'select-elements',
+      selectedIds: ['door_1'],
     })
   })
 

--- a/packages/editor/src/components/editor/floorplan-background-selection.ts
+++ b/packages/editor/src/components/editor/floorplan-background-selection.ts
@@ -7,17 +7,41 @@ type ModifierKeys = {
   meta: boolean
   ctrl: boolean
   shift: boolean
+  /** Alt alone: select one session-group member without expanding. */
+  alt: boolean
 }
 
 type ResolveFloorplanBackgroundSelectionArgs = {
   canSelectElementFloorplanGeometry: boolean
   canSelectFloorplanZones: boolean
   currentSelectedIds: string[]
+  /** Session-group expand on plain click (not on modifier/Alt). */
+  expandIdsForNode?: (nodeId: string) => string[] | null
   getFloorplanHitIdAtPoint: (planPoint: WallPlanPoint) => string | null
   isWallBuildActive: boolean
   modifierKeys: ModifierKeys
   planPoint: WallPlanPoint
   structureLayer: string
+}
+
+function hasToggleModifier(modifierKeys: ModifierKeys): boolean {
+  return modifierKeys.meta || modifierKeys.ctrl || modifierKeys.shift
+}
+
+function resolveHitSelection(
+  hitId: string,
+  currentSelectedIds: string[],
+  modifierKeys: ModifierKeys,
+  expandIdsForNode?: (nodeId: string) => string[] | null,
+): string[] {
+  if (hasToggleModifier(modifierKeys)) {
+    return currentSelectedIds.includes(hitId)
+      ? currentSelectedIds.filter((selectedId) => selectedId !== hitId)
+      : [...currentSelectedIds, hitId]
+  }
+  if (modifierKeys.alt) return [hitId]
+  const expanded = expandIdsForNode?.(hitId)
+  return expanded && expanded.length > 1 ? expanded : [hitId]
 }
 
 export type FloorplanBackgroundSelectionResult =
@@ -48,6 +72,7 @@ export function resolveFloorplanBackgroundSelection({
   canSelectElementFloorplanGeometry,
   canSelectFloorplanZones,
   currentSelectedIds,
+  expandIdsForNode,
   getFloorplanHitIdAtPoint,
   isWallBuildActive,
   modifierKeys,
@@ -71,12 +96,7 @@ export function resolveFloorplanBackgroundSelection({
       return {
         handled: true,
         kind: 'select-elements',
-        selectedIds:
-          modifierKeys.meta || modifierKeys.ctrl || modifierKeys.shift
-            ? currentSelectedIds.includes(hitId)
-              ? currentSelectedIds.filter((selectedId) => selectedId !== hitId)
-              : [...currentSelectedIds, hitId]
-            : [hitId],
+        selectedIds: resolveHitSelection(hitId, currentSelectedIds, modifierKeys, expandIdsForNode),
       }
     }
   }
@@ -92,7 +112,7 @@ export function resolveFloorplanBackgroundSelection({
     return {
       handled: true,
       kind: 'clear-elements',
-      preserveSelection: modifierKeys.meta || modifierKeys.ctrl || modifierKeys.shift,
+      preserveSelection: hasToggleModifier(modifierKeys),
     }
   }
 

--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -115,6 +115,7 @@ import useInteractionScope, {
   useReshapingNode,
 } from '../../store/use-interaction-scope'
 import usePlacementPreview from '../../store/use-placement-preview'
+import { expandSessionSelectionForNode } from '../../store/use-session-groups'
 import { useStairBuildPreview } from '../../store/use-stair-build-preview'
 import { FloorplanAlignmentGuideLayer } from '../editor-2d/floorplan-alignment-guide-layer'
 import { FloorplanCursorIndicatorOverlay as Editor2dFloorplanCursorIndicatorOverlay } from '../editor-2d/floorplan-cursor-indicator-overlay'
@@ -843,11 +844,13 @@ function getSelectionModifierKeys(event?: {
   metaKey?: boolean
   ctrlKey?: boolean
   shiftKey?: boolean
+  altKey?: boolean
 }) {
   return {
     meta: Boolean(event?.metaKey),
     ctrl: Boolean(event?.ctrlKey),
     shift: Boolean(event?.shiftKey),
+    alt: Boolean(event?.altKey),
   }
 }
 
@@ -9978,6 +9981,7 @@ export function FloorplanPanel({
         canSelectElementFloorplanGeometry,
         canSelectFloorplanZones,
         currentSelectedIds: useViewer.getState().selection.selectedIds,
+        expandIdsForNode: expandSessionSelectionForNode,
         getFloorplanHitIdAtPoint,
         isWallBuildActive,
         modifierKeys,

--- a/packages/editor/src/components/editor/group-actions.ts
+++ b/packages/editor/src/components/editor/group-actions.ts
@@ -34,7 +34,6 @@ import useEditor, {
   isMagneticSnapActive,
 } from '../../store/use-editor'
 import useInteractionScope from '../../store/use-interaction-scope'
-import { removeDeletedIdsFromSessionGroups } from '../../store/use-session-groups'
 import { useFloorplanGroupDrag } from '../editor-2d/floorplan-group-move'
 import {
   classifyParticipant,
@@ -563,7 +562,6 @@ export function cutSelectionToEditorClipboard(): boolean {
     sfxEmitter.emit('sfx:structure-delete')
   }
   useScene.getState().deleteNodes(payload.rootIds)
-  removeDeletedIdsFromSessionGroups(payload.rootIds)
   useViewer.getState().setSelection({ selectedIds: [] })
   return true
 }
@@ -583,7 +581,6 @@ export function deleteSelection(): boolean {
       sfxEmitter.emit('sfx:structure-delete')
     }
     useScene.getState().deleteNodes(selectedIds)
-    removeDeletedIdsFromSessionGroups(selectedIds)
     useViewer.getState().setSelection({ selectedIds: [] })
   }
 

--- a/packages/editor/src/components/editor/group-actions.ts
+++ b/packages/editor/src/components/editor/group-actions.ts
@@ -34,6 +34,7 @@ import useEditor, {
   isMagneticSnapActive,
 } from '../../store/use-editor'
 import useInteractionScope from '../../store/use-interaction-scope'
+import { removeDeletedIdsFromSessionGroups } from '../../store/use-session-groups'
 import { useFloorplanGroupDrag } from '../editor-2d/floorplan-group-move'
 import {
   classifyParticipant,
@@ -581,6 +582,7 @@ export function deleteSelection(): boolean {
       sfxEmitter.emit('sfx:structure-delete')
     }
     useScene.getState().deleteNodes(selectedIds)
+    removeDeletedIdsFromSessionGroups(selectedIds)
     useViewer.getState().setSelection({ selectedIds: [] })
   }
 

--- a/packages/editor/src/components/editor/group-actions.ts
+++ b/packages/editor/src/components/editor/group-actions.ts
@@ -563,6 +563,7 @@ export function cutSelectionToEditorClipboard(): boolean {
     sfxEmitter.emit('sfx:structure-delete')
   }
   useScene.getState().deleteNodes(payload.rootIds)
+  removeDeletedIdsFromSessionGroups(payload.rootIds)
   useViewer.getState().setSelection({ selectedIds: [] })
   return true
 }

--- a/packages/editor/src/components/editor/group-floating-action-menu.tsx
+++ b/packages/editor/src/components/editor/group-floating-action-menu.tsx
@@ -7,10 +7,7 @@ import { useFrame } from '@react-three/fiber'
 import { useCallback, useMemo, useRef } from 'react'
 import * as THREE from 'three'
 import { resolveOverlayPolicy } from '../../lib/interaction/overlay-policy'
-import {
-  canCreateSessionGroup,
-  selectionIntersectsSessionGroup,
-} from '../../lib/session-groups'
+import { canCreateSessionGroup, selectionIntersectsSessionGroup } from '../../lib/session-groups'
 import useEditor from '../../store/use-editor'
 import useInteractionScope, { useMovingNode } from '../../store/use-interaction-scope'
 import useSessionGroups, {

--- a/packages/editor/src/components/editor/group-floating-action-menu.tsx
+++ b/packages/editor/src/components/editor/group-floating-action-menu.tsx
@@ -7,28 +7,30 @@ import { useFrame } from '@react-three/fiber'
 import { useCallback, useMemo, useRef } from 'react'
 import * as THREE from 'three'
 import { resolveOverlayPolicy } from '../../lib/interaction/overlay-policy'
+import {
+  canCreateSessionGroup,
+  selectionIntersectsSessionGroup,
+} from '../../lib/session-groups'
 import useEditor from '../../store/use-editor'
 import useInteractionScope, { useMovingNode } from '../../store/use-interaction-scope'
+import useSessionGroups, {
+  groupCurrentSelection,
+  ungroupCurrentSelection,
+} from '../../store/use-session-groups'
 import { deleteSelection, duplicateSelectionAndPickUp, startGroupPickUp } from './group-actions'
 import { classifyParticipant, computeGroupBox, expandToComponent } from './group-transform-shared'
 import { NodeActionMenu } from './node-action-menu'
 import { useMeshSettleEpoch } from './use-mesh-settle-epoch'
 
-// Matches the single-node FloatingActionMenu's zoom-compensation constants.
 const REF_ORTHO_ZOOM = 50
 const REF_CAMERA_DISTANCE = 12
 const MIN_MENU_SCALE = 0.6
 const MAX_MENU_SCALE = 1.4
-// Clearance above the group's bbox top so the pill doesn't sit on the meshes.
 const MENU_Y_OFFSET = 0.42
 
 /**
- * Floating Move / Duplicate / Delete pill for a MULTI-selection in the 3D
- * view — the group sibling of the single-node `FloatingActionMenu` (which is
- * sole-selection only). Anchored above the selection's bounding-box center;
- * every action targets the whole selection: Move picks the group up (it rides
- * the cursor until a click places it), Duplicate clones the selection and
- * picks the clones up, Delete removes everything selected.
+ * Floating pill for MULTI-selection in 3D: Move, Group, Ungroup, Duplicate, Delete.
+ * Group/Ungroup are session-only (Ctrl/Cmd+G / Ctrl/Cmd+Shift+G).
  */
 export function GroupFloatingActionMenu() {
   const selectedIds = useViewer((s) => s.selection.selectedIds)
@@ -37,8 +39,7 @@ export function GroupFloatingActionMenu() {
   const isFloorplanHovered = useEditor((s) => s.isFloorplanHovered)
   const movingNode = useMovingNode()
   const nodes = useScene((s) => s.nodes)
-  // Hard-hidden during any active interaction (drag, pick-up, reshape) so the
-  // pill never competes with the live action — same policy as the 1-node menu.
+  const sessionGroups = useSessionGroups((s) => s.groups)
   const scope = useInteractionScope((s) => s.scope)
   const menuStepBack = resolveOverlayPolicy(scope).conflictingControls === 'hidden'
 
@@ -55,9 +56,18 @@ export function GroupFloatingActionMenu() {
     [selectedIds, levelId, nodes],
   )
 
-  // World anchor above the group bbox. Depends on the scene (post-commit
-  // positions), not the camera, and the menu hides during drags — so a
-  // memo keyed on selection + nodes is enough, no per-frame box traversal.
+  const liveIds = useMemo(() => new Set(Object.keys(nodes)), [nodes])
+  // Always offer Group when multi-select is not already exactly a session group.
+  const showGroup = useMemo(
+    () => canCreateSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
+  )
+  // Ungroup when any selected member is in a session group.
+  const showUngroup = useMemo(
+    () => selectionIntersectsSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
+  )
+
   const meshEpoch = useMeshSettleEpoch(nodes)
   const anchor = useMemo(() => {
     void meshEpoch
@@ -73,8 +83,6 @@ export function GroupFloatingActionMenu() {
   }, [participantIds, nodes, levelId, meshEpoch])
 
   useFrame((state) => {
-    // Scale the HTML pill with camera zoom / distance so it feels anchored to
-    // the world — mirrors the single-node menu.
     if (!(menuScaleRef.current && groupRef.current)) return
     const raw =
       state.camera instanceof THREE.OrthographicCamera
@@ -91,6 +99,14 @@ export function GroupFloatingActionMenu() {
   const handleMove = useCallback((event: React.MouseEvent) => {
     event.stopPropagation()
     startGroupPickUp()
+  }, [])
+  const handleGroup = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation()
+    groupCurrentSelection()
+  }, [])
+  const handleUngroup = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation()
+    ungroupCurrentSelection()
   }, [])
   const handleDuplicate = useCallback((event: React.MouseEvent) => {
     event.stopPropagation()
@@ -119,9 +135,11 @@ export function GroupFloatingActionMenu() {
           <NodeActionMenu
             onDelete={handleDelete}
             onDuplicate={handleDuplicate}
+            onGroup={showGroup ? handleGroup : undefined}
             onMove={handleMove}
             onPointerDown={stopPointer}
             onPointerUp={stopPointer}
+            onUngroup={showUngroup ? handleUngroup : undefined}
           />
         </div>
       </Html>

--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -33,6 +33,7 @@ import {
 import { disposeSFXBus, initSFXBus } from '../../lib/sfx-bus'
 import useEditor from '../../store/use-editor'
 import useFloorplanMode from '../../store/use-floorplan-mode'
+import useSessionGroups from '../../store/use-session-groups'
 import { CeilingSelectionAffordanceSystem } from '../systems/ceiling/ceiling-selection-affordance-system'
 import { CeilingSystem } from '../systems/ceiling/ceiling-system'
 import { RoofEditSystem } from '../systems/roof/roof-edit-system'
@@ -1208,6 +1209,8 @@ export default function Editor({
       setIsSceneLoading(true)
       useScene.getState().unloadScene()
       useViewer.getState().resetSelection()
+      // Session groups are not scene-graph state — clear on every load/switch.
+      useSessionGroups.getState().clearGroups()
 
       try {
         const sceneGraph = onLoad ? await onLoad() : loadSceneFromLocalStorage()

--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -1246,6 +1246,9 @@ export default function Editor({
   // Apply preview scene when version preview mode changes
   useEffect(() => {
     if (isVersionPreviewMode && previewScene) {
+      // Drop session groups from the edit session so plain-click expand cannot
+      // pull in members that are not part of the preview graph.
+      useSessionGroups.getState().clearGroups()
       applySceneGraphToEditor(previewScene)
     }
   }, [isVersionPreviewMode, previewScene])

--- a/packages/editor/src/components/editor/node-action-menu.tsx
+++ b/packages/editor/src/components/editor/node-action-menu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Icon } from '@iconify/react'
-import { Copy, Move, Search, Spline, Trash2 } from 'lucide-react'
+import { Copy, Group, Move, Search, Spline, Trash2, Ungroup } from 'lucide-react'
 import type { MouseEventHandler, PointerEventHandler } from 'react'
 
 type NodeActionMenuProps = {
@@ -11,6 +11,10 @@ type NodeActionMenuProps = {
   onDuplicate?: MouseEventHandler<HTMLButtonElement>
   onMove?: MouseEventHandler<HTMLButtonElement>
   onCurve?: MouseEventHandler<HTMLButtonElement>
+  /** Session group (Ctrl/Cmd+G) — multi-selection floating pill. */
+  onGroup?: MouseEventHandler<HTMLButtonElement>
+  /** Dissolve session group (Ctrl/Cmd+Shift+G). */
+  onUngroup?: MouseEventHandler<HTMLButtonElement>
   onPointerDown?: PointerEventHandler<HTMLDivElement>
   onPointerUp?: PointerEventHandler<HTMLDivElement>
   onPointerEnter?: PointerEventHandler<HTMLDivElement>
@@ -24,6 +28,8 @@ export function NodeActionMenu({
   onDuplicate,
   onMove,
   onCurve,
+  onGroup,
+  onUngroup,
   onPointerDown,
   onPointerUp,
   onPointerEnter,
@@ -57,6 +63,28 @@ export function NodeActionMenu({
           type="button"
         >
           <Move className="h-4 w-4" />
+        </button>
+      )}
+      {onGroup && (
+        <button
+          aria-label="Group selection"
+          className="tooltip-trigger rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={onGroup}
+          title="Group (Ctrl/Cmd+G)"
+          type="button"
+        >
+          <Group className="h-4 w-4" />
+        </button>
+      )}
+      {onUngroup && (
+        <button
+          aria-label="Ungroup selection"
+          className="tooltip-trigger rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={onUngroup}
+          title="Ungroup (Ctrl/Cmd+Shift+G)"
+          type="button"
+        >
+          <Ungroup className="h-4 w-4" />
         </button>
       )}
       {onCurve && (

--- a/packages/editor/src/components/editor/selection-manager.tsx
+++ b/packages/editor/src/components/editor/selection-manager.tsx
@@ -68,6 +68,7 @@ import {
   selectionModifiersFromEvent,
   shouldPreserveSelectedRoofHostTarget,
 } from '../../lib/selection-routing'
+import { expandSessionSelectionForNode } from '../../store/use-session-groups'
 import { emitDeleteSFX, sfxEmitter } from '../../lib/sfx-bus'
 import useDirectManipulationFeedback from '../../store/use-direct-manipulation-feedback'
 import useEditor, { type MaterialTargetRole } from './../../store/use-editor'
@@ -590,6 +591,7 @@ const computeNextIds = (
     currentSelectedIds: selectedIds,
     modifierKeys: selectionModifiersFromEvent(event, modifierKeys),
     nodeId: node.id,
+    expandIdsForNode: expandSessionSelectionForNode,
   })
 }
 

--- a/packages/editor/src/components/editor/selection-manager.tsx
+++ b/packages/editor/src/components/editor/selection-manager.tsx
@@ -68,7 +68,6 @@ import {
   selectionModifiersFromEvent,
   shouldPreserveSelectedRoofHostTarget,
 } from '../../lib/selection-routing'
-import { expandSessionSelectionForNode } from '../../store/use-session-groups'
 import { emitDeleteSFX, sfxEmitter } from '../../lib/sfx-bus'
 import useDirectManipulationFeedback from '../../store/use-direct-manipulation-feedback'
 import useEditor, { type MaterialTargetRole } from './../../store/use-editor'
@@ -78,6 +77,7 @@ import useInteractionScope, {
   useIsCurveReshape,
   useMovingNode,
 } from '../../store/use-interaction-scope'
+import { expandSessionSelectionForNode } from '../../store/use-session-groups'
 import { boxSelectHandled, suppressBoxSelectForPointer } from '../tools/select/box-select-state'
 import { armGroupMove3d } from './group-move-3d'
 import { classifyParticipant } from './group-transform-shared'
@@ -776,6 +776,7 @@ export const SelectionManager = () => {
     meta: false,
     ctrl: false,
     shift: false,
+    alt: false,
   })
   const clickHandledRef = useRef(false)
 
@@ -1194,18 +1195,21 @@ export const SelectionManager = () => {
       if (event.key === 'Meta') modifierKeysRef.current.meta = true
       if (event.key === 'Control') modifierKeysRef.current.ctrl = true
       if (event.key === 'Shift') modifierKeysRef.current.shift = true
+      if (event.key === 'Alt') modifierKeysRef.current.alt = true
     }
 
     const onKeyUp = (event: KeyboardEvent) => {
       if (event.key === 'Meta') modifierKeysRef.current.meta = false
       if (event.key === 'Control') modifierKeysRef.current.ctrl = false
       if (event.key === 'Shift') modifierKeysRef.current.shift = false
+      if (event.key === 'Alt') modifierKeysRef.current.alt = false
     }
 
     const clearModifiers = () => {
       modifierKeysRef.current.meta = false
       modifierKeysRef.current.ctrl = false
       modifierKeysRef.current.shift = false
+      modifierKeysRef.current.alt = false
     }
 
     window.addEventListener('keydown', onKeyDown)

--- a/packages/editor/src/components/ui/panels/multi-selection-panel.tsx
+++ b/packages/editor/src/components/ui/panels/multi-selection-panel.tsx
@@ -2,30 +2,45 @@
 
 import { type AnyNodeId, useScene } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
-import { Copy, Trash2 } from 'lucide-react'
+import { Copy, Group, Trash2, Ungroup } from 'lucide-react'
+import { useMemo } from 'react'
 import { deleteSelection, duplicateSelectionAndPickUp } from '../../editor/group-actions'
+import {
+  canCreateSessionGroup,
+  selectionIntersectsSessionGroup,
+  selectionMatchesSessionGroup,
+} from '../../../lib/session-groups'
+import useSessionGroups, {
+  groupCurrentSelection,
+  ungroupCurrentSelection,
+} from '../../../store/use-session-groups'
 import { ActionButton, ActionGroup } from '../controls/action-button'
 import { PanelWrapper } from './panel-wrapper'
 import { formatSelectionBreakdown } from './selection-breakdown'
 
 /**
- * Docked right-side panel for a MULTI-selection — the compact sibling of the
- * single-node inspector, rendered by `PanelManager` when more than one node
- * is selected. Same collapsed-by-default `PanelWrapper` shell (header always
- * visible; the shared desktop collapse state carries across single ↔ multi
- * swaps). Actions mirror the floating group pill: Duplicate clones the
- * selection and picks the clones up, Delete removes the whole selection
- * (including its bulk-delete confirm). Unlike the pill, the docked panel
- * stays visible during interactions. `footer` is the host-injected slot
- * (e.g. community's "Save to my catalog").
+ * Docked multi-selection panel. Includes Group / Ungroup for session selection sets.
  */
 export function MultiSelectionPanel({ footer }: { footer?: React.ReactNode }) {
   const selectedIds = useViewer((s) => s.selection.selectedIds)
   const setSelection = useViewer((s) => s.setSelection)
-  // String selector — recomputed on scene ticks, but the === compare keeps
-  // unrelated mutations from re-rendering the panel.
+  const sessionGroups = useSessionGroups((s) => s.groups)
   const breakdown = useScene((s) =>
     formatSelectionBreakdown(selectedIds.map((id) => s.nodes[id as AnyNodeId]?.type)),
+  )
+  const sceneNodes = useScene((s) => s.nodes)
+  const liveIds = useMemo(() => new Set(Object.keys(sceneNodes)), [sceneNodes])
+  const matchedGroup = useMemo(
+    () => selectionMatchesSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
+  )
+  const showGroup = useMemo(
+    () => canCreateSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
+  )
+  const showUngroup = useMemo(
+    () => selectionIntersectsSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
   )
 
   return (
@@ -33,12 +48,38 @@ export function MultiSelectionPanel({ footer }: { footer?: React.ReactNode }) {
       footer={footer}
       icon="/icons/select.webp"
       onClose={() => setSelection({ selectedIds: [] })}
-      title={`${selectedIds.length} selected`}
+      title={
+        matchedGroup
+          ? `${matchedGroup.label} · ${selectedIds.length}`
+          : `${selectedIds.length} selected`
+      }
       width={320}
     >
       {breakdown && <div className="px-3 py-3 text-muted-foreground text-xs">{breakdown}</div>}
+      {matchedGroup && (
+        <div className="border-border/50 border-t px-3 py-2 text-muted-foreground text-xs">
+          {matchedGroup.label} (session only). Plain click reselects all members. Not saved with the
+          project.
+        </div>
+      )}
       <div className="border-border/50 border-t p-3">
         <ActionGroup>
+          {showGroup && (
+            <ActionButton
+              icon={<Group className="h-4 w-4" />}
+              label="Group"
+              onClick={() => groupCurrentSelection()}
+              title="Group (Ctrl/Cmd+G)"
+            />
+          )}
+          {showUngroup && (
+            <ActionButton
+              icon={<Ungroup className="h-4 w-4" />}
+              label="Ungroup"
+              onClick={() => ungroupCurrentSelection()}
+              title="Ungroup (Ctrl/Cmd+Shift+G)"
+            />
+          )}
           <ActionButton
             icon={<Copy className="h-4 w-4" />}
             label="Duplicate"

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/keyboard-shortcuts-dialog.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/keyboard-shortcuts-dialog.tsx
@@ -107,6 +107,17 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
         note: 'Also works mid-move while carrying the selection.',
       },
       {
+        keys: ['Cmd/Ctrl', 'G'],
+        action: 'Group the multi-selection (session only)',
+        note:
+          'Editor-only. Plain click a member later to reselect the whole group. Not saved with the project.',
+      },
+      {
+        keys: ['Cmd/Ctrl', 'Shift', 'G'],
+        action: 'Ungroup the session selection',
+        note: 'Keeps the current selection; only dissolves the session group.',
+      },
+      {
         keys: ['Esc'],
         action: 'Clear the selection',
         note: 'Clicking empty space does the same.',

--- a/packages/editor/src/components/ui/sidebar/panels/site-panel/tree-node.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/site-panel/tree-node.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from 'motion/react'
 import { forwardRef, memo, useEffect, useRef } from 'react'
 import { resolveNodeSelectionTarget } from '../../../../../lib/selection-routing'
 import useEditor from '../../../../../store/use-editor'
+import { expandSessionSelectionForNode } from '../../../../../store/use-session-groups'
 
 export function handleTreeSelection(
   e: React.MouseEvent,
@@ -48,7 +49,13 @@ export function handleTreeSelection(
     }
   }
 
-  setSelection({ selectedIds: [nodeId] })
+  if (e.altKey) {
+    setSelection({ selectedIds: [nodeId] })
+    return false
+  }
+
+  const expanded = expandSessionSelectionForNode(nodeId)
+  setSelection({ selectedIds: expanded && expanded.length > 1 ? expanded : [nodeId] })
   return false
 }
 

--- a/packages/editor/src/hooks/use-keyboard.ts
+++ b/packages/editor/src/hooks/use-keyboard.ts
@@ -36,6 +36,10 @@ import { toggleWindowOpenState } from '../lib/window-interaction'
 import useDeleteConfirmation from '../store/use-delete-confirmation'
 import useEditor, { getActiveContinuationContext, getActiveSnapContext } from '../store/use-editor'
 import useInteractionScope, { getMovingNode } from '../store/use-interaction-scope'
+import {
+  groupCurrentSelection,
+  ungroupCurrentSelection,
+} from '../store/use-session-groups'
 
 // References (guide/scan) are selected via `useEditor.selectedReferenceId`, not
 // the viewer selection, so selection-based key arms (R/T rotate) need this
@@ -210,7 +214,11 @@ export const useKeyboard = ({
       }
 
       // Don't handle shortcuts if user is typing in an input
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement ||
+        (e.target instanceof HTMLElement && e.target.isContentEditable)
+      ) {
         return
       }
 
@@ -695,9 +703,36 @@ export const useKeyboard = ({
       }
     }
 
+    // Capture-phase Ctrl/Cmd+G so browser "Find next" cannot steal the shortcut
+    // before the editor bubble listener runs. Uses e.code for layout stability.
+    const handleSessionGroupKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement ||
+        (e.target instanceof HTMLElement && e.target.isContentEditable)
+      ) {
+        return
+      }
+      if (useDeleteConfirmation.getState().request) return
+      if (isVersionPreviewMode) return
+      if (!(e.metaKey || e.ctrlKey) || e.altKey) return
+      const isGroupKey = e.code === 'KeyG' || e.key.toLowerCase() === 'g'
+      if (!isGroupKey) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.shiftKey) {
+        ungroupCurrentSelection()
+      } else {
+        groupCurrentSelection()
+      }
+    }
+
+    window.addEventListener('keydown', handleSessionGroupKeyDown, true)
     window.addEventListener('keydown', handleKeyDown)
     window.addEventListener('keyup', handleKeyUp)
     return () => {
+      window.removeEventListener('keydown', handleSessionGroupKeyDown, true)
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
     }

--- a/packages/editor/src/hooks/use-keyboard.ts
+++ b/packages/editor/src/hooks/use-keyboard.ts
@@ -36,10 +36,7 @@ import { toggleWindowOpenState } from '../lib/window-interaction'
 import useDeleteConfirmation from '../store/use-delete-confirmation'
 import useEditor, { getActiveContinuationContext, getActiveSnapContext } from '../store/use-editor'
 import useInteractionScope, { getMovingNode } from '../store/use-interaction-scope'
-import {
-  groupCurrentSelection,
-  ungroupCurrentSelection,
-} from '../store/use-session-groups'
+import { groupCurrentSelection, ungroupCurrentSelection } from '../store/use-session-groups'
 
 // References (guide/scan) are selected via `useEditor.selectedReferenceId`, not
 // the viewer selection, so selection-based key arms (R/T rotate) need this
@@ -704,7 +701,10 @@ export const useKeyboard = ({
     }
 
     // Capture-phase Ctrl/Cmd+G so browser "Find next" cannot steal the shortcut
-    // before the editor bubble listener runs. Uses e.code for layout stability.
+    // before the editor bubble listener runs. `stopPropagation` here silences the
+    // chord for every other capture listener (floorplan hotkeys, group move,
+    // registry move overlay) — safe only because none of them claim Ctrl/Cmd+G.
+    // `e.code` keeps it on the physical G key across keyboard layouts.
     const handleSessionGroupKeyDown = (e: KeyboardEvent) => {
       if (
         e.target instanceof HTMLInputElement ||
@@ -716,8 +716,7 @@ export const useKeyboard = ({
       if (useDeleteConfirmation.getState().request) return
       if (isVersionPreviewMode) return
       if (!(e.metaKey || e.ctrlKey) || e.altKey) return
-      const isGroupKey = e.code === 'KeyG' || e.key.toLowerCase() === 'g'
-      if (!isGroupKey) return
+      if (e.code !== 'KeyG') return
 
       e.preventDefault()
       e.stopPropagation()

--- a/packages/editor/src/lib/contextual-help.test.ts
+++ b/packages/editor/src/lib/contextual-help.test.ts
@@ -74,6 +74,14 @@ describe('resolveSelectModeHelpHints', () => {
       },
       { keys: ['R / T'], label: 'Rotate the selection ±45°' },
       {
+        keys: ['Cmd/Ctrl', 'G'],
+        label: 'Group selection (session only)',
+      },
+      {
+        keys: ['Cmd/Ctrl', 'Shift', 'G'],
+        label: 'Ungroup session selection',
+      },
+      {
         keys: [['Cmd/Ctrl', 'Shift'], 'Left click'],
         label: 'Add or remove objects from the selection',
         active: false,

--- a/packages/editor/src/lib/contextual-help.ts
+++ b/packages/editor/src/lib/contextual-help.ts
@@ -94,6 +94,14 @@ export function resolveSelectModeHelpHints({
     })
     hints.push({ keys: [ROTATE_KEYS], label: 'Rotate the selection ±45°' })
     hints.push({
+      keys: [COMMAND_KEY, 'G'],
+      label: 'Group selection (session only)',
+    })
+    hints.push({
+      keys: [COMMAND_KEY, SHIFT_KEY, 'G'],
+      label: 'Ungroup session selection',
+    })
+    hints.push({
       keys: [[COMMAND_KEY, SHIFT_KEY], LEFT_CLICK],
       label: 'Add or remove objects from the selection',
       active: commandPressed || shiftPressed,

--- a/packages/editor/src/lib/selection-routing.test.ts
+++ b/packages/editor/src/lib/selection-routing.test.ts
@@ -30,7 +30,7 @@ describe('resolveSelectedIdsForNodeClick', () => {
       resolveSelectedIdsForNodeClick({
         baseSelectedIds: ['wall_1'],
         currentSelectedIds: [],
-        modifierKeys: { meta: true, ctrl: false, shift: false },
+        modifierKeys: { meta: true, ctrl: false, shift: false, alt: false },
         nodeId: 'item_1',
       }),
     ).toEqual(['wall_1', 'item_1'])
@@ -41,10 +41,21 @@ describe('resolveSelectedIdsForNodeClick', () => {
       resolveSelectedIdsForNodeClick({
         baseSelectedIds: ['wall_1', 'item_1'],
         currentSelectedIds: [],
-        modifierKeys: { meta: false, ctrl: false, shift: true },
+        modifierKeys: { meta: false, ctrl: false, shift: true, alt: false },
         nodeId: 'item_1',
       }),
     ).toEqual(['wall_1'])
+  })
+
+  test('plain click expands session groups', () => {
+    expect(
+      resolveSelectedIdsForNodeClick({
+        currentSelectedIds: [],
+        modifierKeys: { meta: false, ctrl: false, shift: false, alt: false },
+        nodeId: 'item_2',
+        expandIdsForNode: () => ['item_2', 'item_1'],
+      }),
+    ).toEqual(['item_2', 'item_1'])
   })
 })
 
@@ -64,23 +75,27 @@ describe('emitCanvasNodeSelection', () => {
 
 describe('selectionModifiersFromEvent', () => {
   test('falls back to tracked modifier state when the click event omits keys', () => {
-    expect(selectionModifiersFromEvent({}, { meta: false, ctrl: true, shift: false })).toEqual({
+    expect(
+      selectionModifiersFromEvent({}, { meta: false, ctrl: true, shift: false, alt: false }),
+    ).toEqual({
       meta: false,
       ctrl: true,
       shift: false,
+      alt: false,
     })
   })
 
   test('prefers explicit event key state over stale tracked modifiers', () => {
     expect(
       selectionModifiersFromEvent(
-        { metaKey: false, ctrlKey: false, shiftKey: false },
-        { meta: true, ctrl: true, shift: true },
+        { metaKey: false, ctrlKey: false, shiftKey: false, altKey: false },
+        { meta: true, ctrl: true, shift: true, alt: true },
       ),
     ).toEqual({
       meta: false,
       ctrl: false,
       shift: false,
+      alt: false,
     })
   })
 })

--- a/packages/editor/src/lib/selection-routing.ts
+++ b/packages/editor/src/lib/selection-routing.ts
@@ -10,6 +10,8 @@ export type SelectionModifierKeys = {
   meta: boolean
   ctrl: boolean
   shift: boolean
+  /** Alt alone: select one session-group member without expanding. */
+  alt: boolean
 }
 
 export type NodeSelectionTarget = {
@@ -59,17 +61,19 @@ export function selectionModifiersFromEvent(
     metaKey?: boolean
     ctrlKey?: boolean
     shiftKey?: boolean
+    altKey?: boolean
     nativeEvent?: {
       metaKey?: boolean
       ctrlKey?: boolean
       shiftKey?: boolean
+      altKey?: boolean
     }
   } | null,
   fallback?: Partial<SelectionModifierKeys>,
 ): SelectionModifierKeys {
   const fromEvent = (
     key: keyof SelectionModifierKeys,
-    eventKey: 'metaKey' | 'ctrlKey' | 'shiftKey',
+    eventKey: 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey',
   ) => {
     if (typeof event?.[eventKey] === 'boolean') return event[eventKey]
     if (typeof event?.nativeEvent?.[eventKey] === 'boolean') return event.nativeEvent[eventKey]
@@ -80,6 +84,7 @@ export function selectionModifiersFromEvent(
     meta: fromEvent('meta', 'metaKey'),
     ctrl: fromEvent('ctrl', 'ctrlKey'),
     shift: fromEvent('shift', 'shiftKey'),
+    alt: fromEvent('alt', 'altKey'),
   }
 }
 
@@ -88,11 +93,14 @@ export function resolveSelectedIdsForNodeClick({
   currentSelectedIds,
   modifierKeys,
   nodeId,
+  expandIdsForNode,
 }: {
   baseSelectedIds?: readonly string[]
   currentSelectedIds: readonly string[]
   modifierKeys: SelectionModifierKeys
   nodeId: string
+  /** Session-group expand on plain click (not on modifier/Alt). */
+  expandIdsForNode?: (nodeId: string) => string[] | null
 }): string[] {
   if (isSelectionModifierActive(modifierKeys)) {
     const selectedIds = baseSelectedIds ?? currentSelectedIds
@@ -102,6 +110,12 @@ export function resolveSelectedIdsForNodeClick({
     return [...selectedIds, nodeId]
   }
 
+  if (modifierKeys.alt) {
+    return [nodeId]
+  }
+
+  const expanded = expandIdsForNode?.(nodeId)
+  if (expanded && expanded.length > 1) return expanded
   return [nodeId]
 }
 

--- a/packages/editor/src/lib/session-groups.test.ts
+++ b/packages/editor/src/lib/session-groups.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  canCreateSessionGroup,
+  createSessionGroup,
+  expandSessionGroupMembers,
+  nextSessionGroupId,
+  pruneSessionGroups,
+  removeMembersFromSessionGroups,
+  resetSessionGroupIdSerial,
+  selectionIntersectsSessionGroup,
+  selectionMatchesSessionGroup,
+  type SessionSelectionGroup,
+  ungroupSessionSelection,
+} from './session-groups'
+
+function group(id: string, memberIds: string[], label = id): SessionSelectionGroup {
+  return { id, memberIds, label }
+}
+
+describe('session-groups', () => {
+  test('createSessionGroup requires two live members', () => {
+    resetSessionGroupIdSerial()
+    expect(
+      createSessionGroup([], ['a'], { idFactory: () => 'g1', labelFactory: () => 'G1' }).created,
+    ).toBeNull()
+  })
+
+  test('create and expand and ungroup', () => {
+    resetSessionGroupIdSerial(0)
+    const { groups, created } = createSessionGroup([], ['a', 'b', 'c'], {
+      idFactory: () => 'g1',
+      labelFactory: () => 'Group 1',
+    })
+    expect(created?.memberIds).toEqual(['a', 'b', 'c'])
+    expect(expandSessionGroupMembers(groups, 'b')).toEqual(['b', 'a', 'c'])
+    expect(selectionMatchesSessionGroup(groups, ['a', 'b', 'c'])?.label).toBe('Group 1')
+    expect(canCreateSessionGroup(groups, ['a', 'b', 'c'])).toBe(false)
+    expect(canCreateSessionGroup(groups, ['a', 'b'])).toBe(true)
+    expect(ungroupSessionSelection(groups, ['a']).groups).toEqual([])
+  })
+
+  test('removeMembersFromSessionGroups prunes weak groups', () => {
+    const groups = [group('g1', ['a', 'b', 'c'], 'Suite')]
+    expect(removeMembersFromSessionGroups(groups, ['b', 'c'])).toEqual([])
+    expect(removeMembersFromSessionGroups(groups, ['c'])).toEqual([
+      group('g1', ['a', 'b'], 'Suite'),
+    ])
+  })
+
+  test('prune and id serial', () => {
+    resetSessionGroupIdSerial(0)
+    expect(nextSessionGroupId()).toBe('session-group-1')
+    expect(
+      pruneSessionGroups([group('g1', ['a', 'gone'])], new Set(['a'])),
+    ).toEqual([])
+    expect(selectionIntersectsSessionGroup([group('g1', ['a', 'b'])], ['b'])).toBe(true)
+  })
+})

--- a/packages/editor/src/lib/session-groups.test.ts
+++ b/packages/editor/src/lib/session-groups.test.ts
@@ -3,13 +3,12 @@ import {
   canCreateSessionGroup,
   createSessionGroup,
   expandSessionGroupMembers,
+  liveSessionGroups,
   nextSessionGroupId,
-  pruneSessionGroups,
-  removeMembersFromSessionGroups,
   resetSessionGroupIdSerial,
+  type SessionSelectionGroup,
   selectionIntersectsSessionGroup,
   selectionMatchesSessionGroup,
-  type SessionSelectionGroup,
   ungroupSessionSelection,
 } from './session-groups'
 
@@ -39,20 +38,51 @@ describe('session-groups', () => {
     expect(ungroupSessionSelection(groups, ['a']).groups).toEqual([])
   })
 
-  test('removeMembersFromSessionGroups prunes weak groups', () => {
+  test('liveSessionGroups hides groups that fall under two live members', () => {
+    resetSessionGroupIdSerial(0)
+    expect(nextSessionGroupId()).toBe('session-group-1')
+    expect(liveSessionGroups([group('g1', ['a', 'gone'])], new Set(['a']))).toEqual([])
+    expect(liveSessionGroups([group('g1', ['a', 'b', 'gone'])], new Set(['a', 'b']))).toEqual([
+      group('g1', ['a', 'b']),
+    ])
+    expect(selectionIntersectsSessionGroup([group('g1', ['a', 'b'])], ['b'])).toBe(true)
+  })
+
+  test('a deleted member is excluded from reads but kept in membership for undo', () => {
     const groups = [group('g1', ['a', 'b', 'c'], 'Suite')]
-    expect(removeMembersFromSessionGroups(groups, ['b', 'c'])).toEqual([])
-    expect(removeMembersFromSessionGroups(groups, ['c'])).toEqual([
-      group('g1', ['a', 'b'], 'Suite'),
+
+    // `a` deleted: reads narrow to the survivors...
+    expect(expandSessionGroupMembers(groups, 'b', new Set(['b', 'c']))).toEqual(['b', 'c'])
+    // ...and `a` and `b` deleted drops the group below the floor, so it goes inert.
+    expect(expandSessionGroupMembers(groups, 'c', new Set(['c']))).toBeNull()
+    expect(selectionIntersectsSessionGroup(groups, ['c'], new Set(['c']))).toBe(false)
+
+    // Undo restores the nodes, and membership was never rewritten — so the whole
+    // group comes back. A destructive prune would have lost `a` (or the group).
+    expect(expandSessionGroupMembers(groups, 'a', new Set(['a', 'b', 'c']))).toEqual([
+      'a',
+      'b',
+      'c',
     ])
   })
 
-  test('prune and id serial', () => {
+  test('ungroup leaves inert groups alone so undo can revive them', () => {
+    const groups = [group('g1', ['a', 'b'], 'Pair')]
+    // Only `a` is live, so the group is invisible to the user — Ctrl+Shift+G on
+    // `a` must not dissolve what it cannot see.
+    const result = ungroupSessionSelection(groups, ['a'], new Set(['a']))
+    expect(result.dissolved).toEqual([])
+    expect(result.groups).toEqual(groups)
+  })
+
+  test('grouping a member of an existing group dissolves that group whole', () => {
     resetSessionGroupIdSerial(0)
-    expect(nextSessionGroupId()).toBe('session-group-1')
-    expect(
-      pruneSessionGroups([group('g1', ['a', 'gone'])], new Set(['a'])),
-    ).toEqual([])
-    expect(selectionIntersectsSessionGroup([group('g1', ['a', 'b'])], ['b'])).toBe(true)
+    const groups = [group('g1', ['a', 'b', 'c'], 'Suite')]
+    const { groups: next, created } = createSessionGroup(groups, ['c', 'd'], {
+      idFactory: () => 'g2',
+      labelFactory: () => 'Group 2',
+    })
+    expect(created?.memberIds).toEqual(['c', 'd'])
+    expect(next).toEqual([group('g2', ['c', 'd'], 'Group 2')])
   })
 })

--- a/packages/editor/src/lib/session-groups.ts
+++ b/packages/editor/src/lib/session-groups.ts
@@ -2,6 +2,11 @@
  * Pure helpers for editor-only session selection groups.
  * Not scene-graph nodes; not saved with the project.
  * Ctrl/Cmd+G creates, Ctrl/Cmd+Shift+G dissolves; plain click expands.
+ *
+ * Stored membership is never rewritten to drop deleted nodes — `liveIds`
+ * filtering happens on every read instead. A destructive prune would make
+ * delete-then-undo lose the restored node's group, and would drop the group
+ * outright once it fell under the two-member floor.
  */
 
 export type SessionSelectionGroup = {
@@ -54,50 +59,26 @@ function withLabel(
   }
 }
 
-export function sessionGroupsEqual(
-  a: readonly SessionSelectionGroup[],
-  b: readonly SessionSelectionGroup[],
-): boolean {
-  if (a.length !== b.length) return false
-  for (let i = 0; i < a.length; i++) {
-    const left = a[i]!
-    const right = b[i]!
-    if (left.id !== right.id || left.label !== right.label) return false
-    if (left.memberIds.length !== right.memberIds.length) return false
-    for (let j = 0; j < left.memberIds.length; j++) {
-      if (left.memberIds[j] !== right.memberIds[j]) return false
-    }
-  }
-  return true
+function liveMembers(group: SessionSelectionGroup, liveIds?: ReadonlySet<string> | null): string[] {
+  return uniquePreserveOrder(group.memberIds.filter((id) => isLive(id, liveIds)))
 }
 
-export function pruneSessionGroups(
+/**
+ * Read-time view: groups narrowed to their live members, dropping any that fall
+ * under two. A group below the floor is inert, not gone — deleting members never
+ * touches storage, so undo brings it back.
+ */
+export function liveSessionGroups(
   groups: readonly SessionSelectionGroup[],
   liveIds?: ReadonlySet<string> | null,
 ): SessionSelectionGroup[] {
   const next: SessionSelectionGroup[] = []
   for (const group of groups) {
-    const members = uniquePreserveOrder(group.memberIds.filter((id) => isLive(id, liveIds)))
+    const members = liveMembers(group, liveIds)
     if (members.length < 2) continue
     next.push(withLabel(group, members))
   }
   return next
-}
-
-export function removeMembersFromSessionGroups(
-  groups: readonly SessionSelectionGroup[],
-  removedIds: readonly string[],
-  liveIds?: ReadonlySet<string> | null,
-): SessionSelectionGroup[] {
-  if (removedIds.length === 0) return pruneSessionGroups(groups, liveIds)
-  const removed = new Set(removedIds)
-  const stripped = groups.map((group) =>
-    withLabel(
-      group,
-      group.memberIds.filter((id) => !removed.has(id)),
-    ),
-  )
-  return pruneSessionGroups(stripped, liveIds)
 }
 
 export function createSessionGroup(
@@ -116,20 +97,21 @@ export function createSessionGroup(
   const liveIds = options?.liveIds
   const members = uniquePreserveOrder(memberIds.filter((id) => isLive(id, liveIds)))
   if (members.length < 2) {
-    return { groups: pruneSessionGroups(groups, liveIds), created: null, alreadyGrouped: false }
+    return { groups: [...groups], created: null, alreadyGrouped: false }
   }
 
-  const pruned = pruneSessionGroups(groups, liveIds)
   const memberSet = new Set(members)
-  const exact = pruned.find(
+  const exact = liveSessionGroups(groups, liveIds).find(
     (group) =>
       group.memberIds.length === members.length && group.memberIds.every((id) => memberSet.has(id)),
   )
   if (exact) {
-    return { groups: pruned, created: exact, alreadyGrouped: true }
+    return { groups: [...groups], created: exact, alreadyGrouped: true }
   }
 
-  const kept = pruned.filter((group) => !group.memberIds.some((id) => memberSet.has(id)))
+  // Grouping a selection takes its members out of whatever group they were in,
+  // dissolving that group whole rather than leaving a remnant.
+  const kept = groups.filter((group) => !group.memberIds.some((id) => memberSet.has(id)))
   const id = (options?.idFactory ?? nextSessionGroupId)()
   const label =
     options?.labelFactory?.() ??
@@ -145,15 +127,17 @@ export function ungroupSessionSelection(
 ): { groups: SessionSelectionGroup[]; dissolved: SessionSelectionGroup[] } {
   const selected = new Set(selectedIds)
   if (selected.size === 0) {
-    return { groups: pruneSessionGroups(groups, liveIds), dissolved: [] }
+    return { groups: [...groups], dissolved: [] }
   }
 
-  const pruned = pruneSessionGroups(groups, liveIds)
   const kept: SessionSelectionGroup[] = []
   const dissolved: SessionSelectionGroup[] = []
-  for (const group of pruned) {
-    if (group.memberIds.some((id) => selected.has(id))) {
-      dissolved.push(group)
+  for (const group of groups) {
+    // Only a live-viable group is visible to the user, so only that can be
+    // dissolved. An inert one (members deleted) is left alone for undo.
+    const live = liveMembers(group, liveIds)
+    if (live.length >= 2 && live.some((id) => selected.has(id))) {
+      dissolved.push(withLabel(group, live))
     } else {
       kept.push(group)
     }
@@ -169,7 +153,7 @@ export function expandSessionGroupMembers(
   if (!nodeId) return null
   for (const group of groups) {
     if (!group.memberIds.includes(nodeId)) continue
-    const members = uniquePreserveOrder(group.memberIds.filter((id) => isLive(id, liveIds)))
+    const members = liveMembers(group, liveIds)
     if (members.length < 2) return null
     if (members[0] === nodeId) return members
     return [nodeId, ...members.filter((id) => id !== nodeId)]
@@ -186,7 +170,7 @@ export function selectionMatchesSessionGroup(
   const selected = uniquePreserveOrder(selectedIds.filter((id) => isLive(id, liveIds)))
   if (selected.length < 2) return null
   const selectedSet = new Set(selected)
-  for (const group of pruneSessionGroups(groups, liveIds)) {
+  for (const group of liveSessionGroups(groups, liveIds)) {
     if (group.memberIds.length !== selected.length) continue
     if (group.memberIds.every((id) => selectedSet.has(id))) return group
   }
@@ -200,7 +184,7 @@ export function selectionIntersectsSessionGroup(
 ): boolean {
   if (selectedIds.length === 0) return false
   const selected = new Set(selectedIds)
-  for (const group of pruneSessionGroups(groups, liveIds)) {
+  for (const group of liveSessionGroups(groups, liveIds)) {
     if (group.memberIds.some((id) => selected.has(id))) return true
   }
   return false

--- a/packages/editor/src/lib/session-groups.ts
+++ b/packages/editor/src/lib/session-groups.ts
@@ -1,0 +1,217 @@
+/**
+ * Pure helpers for editor-only session selection groups.
+ * Not scene-graph nodes; not saved with the project.
+ * Ctrl/Cmd+G creates, Ctrl/Cmd+Shift+G dissolves; plain click expands.
+ */
+
+export type SessionSelectionGroup = {
+  id: string
+  memberIds: readonly string[]
+  label: string
+}
+
+export type SessionGroupIdFactory = () => string
+
+let sessionGroupSerial = 0
+
+export function nextSessionGroupId(): string {
+  sessionGroupSerial += 1
+  return `session-group-${sessionGroupSerial}`
+}
+
+export function nextSessionGroupLabel(): string {
+  return `Group ${Math.max(1, sessionGroupSerial)}`
+}
+
+export function resetSessionGroupIdSerial(value = 0): void {
+  sessionGroupSerial = value
+}
+
+function uniquePreserveOrder(ids: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const id of ids) {
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  return out
+}
+
+function isLive(id: string, liveIds?: ReadonlySet<string> | null): boolean {
+  if (!liveIds) return true
+  return liveIds.has(id)
+}
+
+function withLabel(
+  group: SessionSelectionGroup,
+  memberIds: readonly string[],
+): SessionSelectionGroup {
+  return {
+    id: group.id,
+    label: group.label || 'Group',
+    memberIds,
+  }
+}
+
+export function sessionGroupsEqual(
+  a: readonly SessionSelectionGroup[],
+  b: readonly SessionSelectionGroup[],
+): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const left = a[i]!
+    const right = b[i]!
+    if (left.id !== right.id || left.label !== right.label) return false
+    if (left.memberIds.length !== right.memberIds.length) return false
+    for (let j = 0; j < left.memberIds.length; j++) {
+      if (left.memberIds[j] !== right.memberIds[j]) return false
+    }
+  }
+  return true
+}
+
+export function pruneSessionGroups(
+  groups: readonly SessionSelectionGroup[],
+  liveIds?: ReadonlySet<string> | null,
+): SessionSelectionGroup[] {
+  const next: SessionSelectionGroup[] = []
+  for (const group of groups) {
+    const members = uniquePreserveOrder(group.memberIds.filter((id) => isLive(id, liveIds)))
+    if (members.length < 2) continue
+    next.push(withLabel(group, members))
+  }
+  return next
+}
+
+export function removeMembersFromSessionGroups(
+  groups: readonly SessionSelectionGroup[],
+  removedIds: readonly string[],
+  liveIds?: ReadonlySet<string> | null,
+): SessionSelectionGroup[] {
+  if (removedIds.length === 0) return pruneSessionGroups(groups, liveIds)
+  const removed = new Set(removedIds)
+  const stripped = groups.map((group) =>
+    withLabel(
+      group,
+      group.memberIds.filter((id) => !removed.has(id)),
+    ),
+  )
+  return pruneSessionGroups(stripped, liveIds)
+}
+
+export function createSessionGroup(
+  groups: readonly SessionSelectionGroup[],
+  memberIds: readonly string[],
+  options?: {
+    liveIds?: ReadonlySet<string> | null
+    idFactory?: SessionGroupIdFactory
+    labelFactory?: () => string
+  },
+): {
+  groups: SessionSelectionGroup[]
+  created: SessionSelectionGroup | null
+  alreadyGrouped: boolean
+} {
+  const liveIds = options?.liveIds
+  const members = uniquePreserveOrder(memberIds.filter((id) => isLive(id, liveIds)))
+  if (members.length < 2) {
+    return { groups: pruneSessionGroups(groups, liveIds), created: null, alreadyGrouped: false }
+  }
+
+  const pruned = pruneSessionGroups(groups, liveIds)
+  const memberSet = new Set(members)
+  const exact = pruned.find(
+    (group) =>
+      group.memberIds.length === members.length && group.memberIds.every((id) => memberSet.has(id)),
+  )
+  if (exact) {
+    return { groups: pruned, created: exact, alreadyGrouped: true }
+  }
+
+  const kept = pruned.filter((group) => !group.memberIds.some((id) => memberSet.has(id)))
+  const id = (options?.idFactory ?? nextSessionGroupId)()
+  const label =
+    options?.labelFactory?.() ??
+    (options?.idFactory ? `Group ${kept.length + 1}` : nextSessionGroupLabel())
+  const created: SessionSelectionGroup = { id, label, memberIds: members }
+  return { groups: [...kept, created], created, alreadyGrouped: false }
+}
+
+export function ungroupSessionSelection(
+  groups: readonly SessionSelectionGroup[],
+  selectedIds: readonly string[],
+  liveIds?: ReadonlySet<string> | null,
+): { groups: SessionSelectionGroup[]; dissolved: SessionSelectionGroup[] } {
+  const selected = new Set(selectedIds)
+  if (selected.size === 0) {
+    return { groups: pruneSessionGroups(groups, liveIds), dissolved: [] }
+  }
+
+  const pruned = pruneSessionGroups(groups, liveIds)
+  const kept: SessionSelectionGroup[] = []
+  const dissolved: SessionSelectionGroup[] = []
+  for (const group of pruned) {
+    if (group.memberIds.some((id) => selected.has(id))) {
+      dissolved.push(group)
+    } else {
+      kept.push(group)
+    }
+  }
+  return { groups: kept, dissolved }
+}
+
+export function expandSessionGroupMembers(
+  groups: readonly SessionSelectionGroup[],
+  nodeId: string,
+  liveIds?: ReadonlySet<string> | null,
+): string[] | null {
+  if (!nodeId) return null
+  for (const group of groups) {
+    if (!group.memberIds.includes(nodeId)) continue
+    const members = uniquePreserveOrder(group.memberIds.filter((id) => isLive(id, liveIds)))
+    if (members.length < 2) return null
+    if (members[0] === nodeId) return members
+    return [nodeId, ...members.filter((id) => id !== nodeId)]
+  }
+  return null
+}
+
+export function selectionMatchesSessionGroup(
+  groups: readonly SessionSelectionGroup[],
+  selectedIds: readonly string[],
+  liveIds?: ReadonlySet<string> | null,
+): SessionSelectionGroup | null {
+  if (selectedIds.length < 2) return null
+  const selected = uniquePreserveOrder(selectedIds.filter((id) => isLive(id, liveIds)))
+  if (selected.length < 2) return null
+  const selectedSet = new Set(selected)
+  for (const group of pruneSessionGroups(groups, liveIds)) {
+    if (group.memberIds.length !== selected.length) continue
+    if (group.memberIds.every((id) => selectedSet.has(id))) return group
+  }
+  return null
+}
+
+export function selectionIntersectsSessionGroup(
+  groups: readonly SessionSelectionGroup[],
+  selectedIds: readonly string[],
+  liveIds?: ReadonlySet<string> | null,
+): boolean {
+  if (selectedIds.length === 0) return false
+  const selected = new Set(selectedIds)
+  for (const group of pruneSessionGroups(groups, liveIds)) {
+    if (group.memberIds.some((id) => selected.has(id))) return true
+  }
+  return false
+}
+
+export function canCreateSessionGroup(
+  groups: readonly SessionSelectionGroup[],
+  selectedIds: readonly string[],
+  liveIds?: ReadonlySet<string> | null,
+): boolean {
+  const live = uniquePreserveOrder(selectedIds.filter((id) => isLive(id, liveIds)))
+  if (live.length < 2) return false
+  return selectionMatchesSessionGroup(groups, live, liveIds) === null
+}

--- a/packages/editor/src/store/use-session-groups.ts
+++ b/packages/editor/src/store/use-session-groups.ts
@@ -1,19 +1,16 @@
 import { type AnyNodeId, useScene } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import { create } from 'zustand'
-import { sfxEmitter } from '../lib/sfx-bus'
 import {
   canCreateSessionGroup,
   createSessionGroup,
   expandSessionGroupMembers,
-  pruneSessionGroups,
-  removeMembersFromSessionGroups,
+  type SessionSelectionGroup,
   selectionIntersectsSessionGroup,
   selectionMatchesSessionGroup,
-  type SessionSelectionGroup,
-  sessionGroupsEqual,
   ungroupSessionSelection,
 } from '../lib/session-groups'
+import { sfxEmitter } from '../lib/sfx-bus'
 
 type SessionGroupsState = {
   groups: SessionSelectionGroup[]
@@ -31,34 +28,16 @@ function liveNodeIdSet(): Set<string> {
   return new Set(Object.keys(useScene.getState().nodes))
 }
 
-function commitGroups(next: SessionSelectionGroup[]): boolean {
-  const prev = useSessionGroups.getState().groups
-  if (sessionGroupsEqual(prev, next)) return false
-  useSessionGroups.getState().setGroups(next)
-  return true
-}
-
-export function pruneSessionGroupsToScene(): boolean {
-  return commitGroups(pruneSessionGroups(useSessionGroups.getState().groups, liveNodeIdSet()))
-}
-
-export function removeDeletedIdsFromSessionGroups(removedIds: readonly string[]): boolean {
-  if (removedIds.length === 0) return false
-  return commitGroups(
-    removeMembersFromSessionGroups(
-      useSessionGroups.getState().groups,
-      removedIds,
-      liveNodeIdSet(),
-    ),
-  )
-}
-
+/**
+ * Membership is never rewritten when a member is deleted — every read filters
+ * against the live scene instead. Deleting a member and undoing must restore it
+ * to its group, and a destructive prune would have already dropped it (or the
+ * whole group, once it fell under the two-member floor).
+ */
 export function expandSessionSelectionForNode(nodeId: string): string[] | null {
-  const liveIds = liveNodeIdSet()
-  const pruned = pruneSessionGroups(useSessionGroups.getState().groups, liveIds)
-  commitGroups(pruned)
-  if (pruned.length === 0) return null
-  return expandSessionGroupMembers(pruned, nodeId, liveIds)
+  const groups = useSessionGroups.getState().groups
+  if (groups.length === 0) return null
+  return expandSessionGroupMembers(groups, nodeId, liveNodeIdSet())
 }
 
 /** Ctrl/Cmd+G — create session group from multi-selection. */

--- a/packages/editor/src/store/use-session-groups.ts
+++ b/packages/editor/src/store/use-session-groups.ts
@@ -1,0 +1,124 @@
+import { type AnyNodeId, useScene } from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
+import { create } from 'zustand'
+import { sfxEmitter } from '../lib/sfx-bus'
+import {
+  canCreateSessionGroup,
+  createSessionGroup,
+  expandSessionGroupMembers,
+  pruneSessionGroups,
+  removeMembersFromSessionGroups,
+  selectionIntersectsSessionGroup,
+  selectionMatchesSessionGroup,
+  type SessionSelectionGroup,
+  sessionGroupsEqual,
+  ungroupSessionSelection,
+} from '../lib/session-groups'
+
+type SessionGroupsState = {
+  groups: SessionSelectionGroup[]
+  setGroups: (groups: SessionSelectionGroup[]) => void
+  clearGroups: () => void
+}
+
+const useSessionGroups = create<SessionGroupsState>((set) => ({
+  groups: [],
+  setGroups: (groups) => set({ groups }),
+  clearGroups: () => set({ groups: [] }),
+}))
+
+function liveNodeIdSet(): Set<string> {
+  return new Set(Object.keys(useScene.getState().nodes))
+}
+
+function commitGroups(next: SessionSelectionGroup[]): boolean {
+  const prev = useSessionGroups.getState().groups
+  if (sessionGroupsEqual(prev, next)) return false
+  useSessionGroups.getState().setGroups(next)
+  return true
+}
+
+export function pruneSessionGroupsToScene(): boolean {
+  return commitGroups(pruneSessionGroups(useSessionGroups.getState().groups, liveNodeIdSet()))
+}
+
+export function removeDeletedIdsFromSessionGroups(removedIds: readonly string[]): boolean {
+  if (removedIds.length === 0) return false
+  return commitGroups(
+    removeMembersFromSessionGroups(
+      useSessionGroups.getState().groups,
+      removedIds,
+      liveNodeIdSet(),
+    ),
+  )
+}
+
+export function expandSessionSelectionForNode(nodeId: string): string[] | null {
+  const liveIds = liveNodeIdSet()
+  const pruned = pruneSessionGroups(useSessionGroups.getState().groups, liveIds)
+  commitGroups(pruned)
+  if (pruned.length === 0) return null
+  return expandSessionGroupMembers(pruned, nodeId, liveIds)
+}
+
+/** Ctrl/Cmd+G — create session group from multi-selection. */
+export function groupCurrentSelection(): boolean {
+  const selectedIds = useViewer.getState().selection.selectedIds as string[]
+  if (selectedIds.length < 2) return false
+
+  const liveIds = liveNodeIdSet()
+  const { groups, created } = createSessionGroup(useSessionGroups.getState().groups, selectedIds, {
+    liveIds,
+  })
+  useSessionGroups.getState().setGroups(groups)
+  if (!created) return false
+
+  useViewer.getState().setSelection({
+    selectedIds: created.memberIds as AnyNodeId[],
+  })
+  sfxEmitter.emit('sfx:menu-click')
+  return true
+}
+
+/** Ctrl/Cmd+Shift+G — dissolve session groups intersecting selection. */
+export function ungroupCurrentSelection(): boolean {
+  const selectedIds = useViewer.getState().selection.selectedIds as string[]
+  if (selectedIds.length === 0) return false
+
+  const liveIds = liveNodeIdSet()
+  const { groups, dissolved } = ungroupSessionSelection(
+    useSessionGroups.getState().groups,
+    selectedIds,
+    liveIds,
+  )
+  if (dissolved.length === 0) return false
+  useSessionGroups.getState().setGroups(groups)
+  sfxEmitter.emit('sfx:menu-click')
+  return true
+}
+
+export function currentSelectionMatchesSessionGroup(): SessionSelectionGroup | null {
+  return selectionMatchesSessionGroup(
+    useSessionGroups.getState().groups,
+    useViewer.getState().selection.selectedIds as string[],
+    liveNodeIdSet(),
+  )
+}
+
+export function currentSelectionIntersectsSessionGroup(): boolean {
+  return selectionIntersectsSessionGroup(
+    useSessionGroups.getState().groups,
+    useViewer.getState().selection.selectedIds as string[],
+    liveNodeIdSet(),
+  )
+}
+
+export function currentSelectionCanCreateSessionGroup(): boolean {
+  return canCreateSessionGroup(
+    useSessionGroups.getState().groups,
+    useViewer.getState().selection.selectedIds as string[],
+    liveNodeIdSet(),
+  )
+}
+
+export default useSessionGroups

--- a/wiki/architecture/README.md
+++ b/wiki/architecture/README.md
@@ -18,6 +18,7 @@ Canonical rules for code that touches `packages/core`, `packages/viewer`, `packa
 | [interaction-scope](interaction-scope.md) | The authoritative interaction state machine ("the spine"): `InteractionScope` union, the begin/update/end/endIf contract, the raycast hot-set, and the overlay scope matrix |
 | [viewer-isolation](viewer-isolation.md) | Keeping `@pascal-app/viewer` editor-agnostic |
 | [selection-managers](selection-managers.md) | Two-layer selection (viewer + editor), events, outliner |
+| [selection-groups](selection-groups.md) | Session multi-select groups (Ctrl/Cmd+G), expand-on-click, PR roadmap for persistent groups |
 | [scene-registry](scene-registry.md) | Global node ID → Object3D map and `useRegistry` |
 | [spatial-queries](spatial-queries.md) | Placement validation (`canPlaceOnFloor`/`Wall`/`Ceiling`) for tools |
 | [node-schemas](node-schemas.md) | Zod schema pattern for node types, `createNode`, `updateNode` |

--- a/wiki/architecture/README.md
+++ b/wiki/architecture/README.md
@@ -18,7 +18,7 @@ Canonical rules for code that touches `packages/core`, `packages/viewer`, `packa
 | [interaction-scope](interaction-scope.md) | The authoritative interaction state machine ("the spine"): `InteractionScope` union, the begin/update/end/endIf contract, the raycast hot-set, and the overlay scope matrix |
 | [viewer-isolation](viewer-isolation.md) | Keeping `@pascal-app/viewer` editor-agnostic |
 | [selection-managers](selection-managers.md) | Two-layer selection (viewer + editor), events, outliner |
-| [selection-groups](selection-groups.md) | Session multi-select groups (Ctrl/Cmd+G), expand-on-click, PR roadmap for persistent groups |
+| [selection-groups](selection-groups.md) | Session multi-select groups (Ctrl/Cmd+G), expand-on-click, how they differ from collections |
 | [scene-registry](scene-registry.md) | Global node ID → Object3D map and `useRegistry` |
 | [spatial-queries](spatial-queries.md) | Placement validation (`canPlaceOnFloor`/`Wall`/`Ceiling`) for tools |
 | [node-schemas](node-schemas.md) | Zod schema pattern for node types, `createNode`, `updateNode` |

--- a/wiki/architecture/selection-groups.md
+++ b/wiki/architecture/selection-groups.md
@@ -1,0 +1,36 @@
+# Selection Groups
+
+*Session multi-select groups (Ctrl/Cmd+G) vs future persistent groups and saved arrangements.*
+
+Applies to: `packages/editor/src/lib/session-groups.ts`, `packages/editor/src/store/use-session-groups.ts`, multi-select UI under `packages/editor/src/components/ui/panels/` and floating menus, selection expand in `packages/editor/src/lib/selection-routing.ts`.
+
+## What this is
+
+Editor-only **session selection groups**. They remember a multi-select set so a plain click on any member reselects the whole set. They are **not** scene-graph nodes and are **not** written into project JSON.
+
+| Shortcut | Behavior |
+|---|---|
+| Ctrl/Cmd+G | Create a session group from 2+ selected nodes. Auto label `Group N`. |
+| Ctrl/Cmd+Shift+G | Dissolve session groups that intersect the selection. Selection is kept. |
+| Alt+click | Select a single member without expanding. |
+
+Also available as **Group / Ungroup** icons on the multi-select floating pill (Move · Group · Copy · Delete) and the right multi-select panel.
+
+## Layer rules
+
+| Layer | Session groups |
+|---|---|
+| `packages/core` | No |
+| `packages/viewer` | No |
+| `packages/editor` | Yes (store, selection expand, menus, keyboard) |
+| `packages/mcp` | No |
+
+## Future options (not this PR)
+
+- **Persistent scene-graph groups** — real parent/`groupId` in the scene, save/load.
+- **Saved room arrangements** — reusable furniture presets / catalog placements.
+
+## Related
+
+- [selection-managers](selection-managers.md) — multi-select modifiers
+- [tools](tools.md) — 2D ↔ 3D multi-select move/rotate parity

--- a/wiki/architecture/selection-groups.md
+++ b/wiki/architecture/selection-groups.md
@@ -1,8 +1,8 @@
 # Selection Groups
 
-*Session multi-select groups (Ctrl/Cmd+G) vs future persistent groups and saved arrangements.*
+*Session multi-select groups (Ctrl/Cmd+G) vs collections and future persistent groups.*
 
-Applies to: `packages/editor/src/lib/session-groups.ts`, `packages/editor/src/store/use-session-groups.ts`, multi-select UI under `packages/editor/src/components/ui/panels/` and floating menus, selection expand in `packages/editor/src/lib/selection-routing.ts`.
+Applies to: `packages/editor/src/lib/session-groups.ts`, `packages/editor/src/store/use-session-groups.ts`, multi-select UI under `packages/editor/src/components/ui/panels/` and floating menus, selection expand in `packages/editor/src/lib/selection-routing.ts` and `packages/editor/src/components/editor/floorplan-background-selection.ts`.
 
 ## What this is
 
@@ -15,6 +15,44 @@ Editor-only **session selection groups**. They remember a multi-select set so a 
 | Alt+click | Select a single member without expanding. |
 
 Also available as **Group / Ungroup** icons on the multi-select floating pill (Move · Group · Copy · Delete) and the right multi-select panel.
+
+## Membership is never pruned
+
+Deleting a member does **not** rewrite stored membership. Every read narrows to the
+live scene instead (`liveSessionGroups`, `expandSessionGroupMembers`), and a group
+with fewer than two live members is inert rather than removed.
+
+This is what makes delete + undo work: a destructive prune would drop the deleted
+node from the group, and drop the group outright once it fell under the two-member
+floor — with no way back, since session groups aren't in the undo history. It also
+means no delete path needs a hook; `deleteNodes` has several callers and read-time
+filtering covers all of them.
+
+Storage is only cleared wholesale, by `clearGroups()` on scene load and on entering
+version preview, where the node ids change entirely.
+
+## Session groups vs collections
+
+`packages/core` also has **collections** (`schema/collections.ts`): named, colored,
+persisted sets of node ids, managed from the item inspector's *Manage collections…*
+popover. They overlap with session groups but answer a different question:
+
+| | Session group | Collection |
+|---|---|---|
+| Persisted | No | Yes (project JSON) |
+| Created by | Ctrl/Cmd+G on a selection | Named explicitly in the inspector |
+| Click a member | Reselects the whole set | No selection behavior |
+| Lifetime | Until reload | Until deleted |
+| Layer | `packages/editor` | `packages/core` |
+
+Reach for a session group for the throwaway "keep these six chairs together while I
+lay out this room" case, and a collection to label a set you'll come back to. They
+are deliberately not backed by the same store: giving Ctrl+G persistence would put
+an unnamed `Group 4` into everyone's saved project on a stray keypress.
+
+If collections ever gain click-to-expand, this split should be revisited — that
+would make them a strict superset, and session groups could become the unsaved tier
+of one concept rather than a second one.
 
 ## Layer rules
 

--- a/wiki/architecture/selection-managers.md
+++ b/wiki/architecture/selection-managers.md
@@ -98,8 +98,10 @@ the shortcut dialog in sync when changing selection gestures.
 
 `Ctrl/Cmd+G` / `Ctrl/Cmd+Shift+G` create and dissolve **session selection groups** in
 `use-session-groups` (not the scene graph). Plain click expands to live members via
-`expandIdsForNode` on `resolveSelectedIdsForNodeClick`. See
-[selection-groups](selection-groups.md).
+`expandIdsForNode`, threaded into all three click paths:
+`resolveSelectedIdsForNodeClick` (3D), the registry layer's `applyEntrySelection` (2D
+entries), and `resolveFloorplanBackgroundSelection` (2D background hit-test). Alt+click
+opts out. See [selection-groups](selection-groups.md).
 
 ---
 

--- a/wiki/architecture/selection-managers.md
+++ b/wiki/architecture/selection-managers.md
@@ -94,6 +94,13 @@ The floating helper in `packages/editor/src/components/ui/helpers/helper-manager
 mirrors these rules from current selection state and held modifiers. Keep that helper and
 the shortcut dialog in sync when changing selection gestures.
 
+### Session groups (editor-only)
+
+`Ctrl/Cmd+G` / `Ctrl/Cmd+Shift+G` create and dissolve **session selection groups** in
+`use-session-groups` (not the scene graph). Plain click expands to live members via
+`expandIdsForNode` on `resolveSelectedIdsForNodeClick`. See
+[selection-groups](selection-groups.md).
+
 ---
 
 ## Rules


### PR DESCRIPTION
## What does this PR do?

Adds **editor-only session selection groups** so multi-select furniture and structure pieces can be remembered and reselected as a set (Figma-like, without scene-graph parents).

- **Ctrl/Cmd+G** creates a session group from 2+ selected nodes (auto label `Group N`)
- **Ctrl/Cmd+Shift+G** dissolves session groups that intersect the selection
- Plain click on a member expands to all live members (3D, floor plan, scene tree)
- **Alt+click** isolates a single member
- **Group / Ungroup** icons on the multi-select floating pill (Move · Group · Copy · Delete) and the right multi-select panel
- Capture-phase keyboard handler so browser Find does not steal Ctrl+G
- Delete prunes dead members from session groups
- Docs: `wiki/architecture/selection-groups.md` (+ links from selection-managers / architecture index)

Out of scope: persistent scene-graph groups, save/load with the project, MCP tools, named-group rename UI.

Related open PRs (same fork style): #569 mcp layout clearance, #570 light WebGPU preview.

## How to test

1. From repo root:
   `bun test packages/editor/src/lib/session-groups.test.ts packages/editor/src/lib/selection-routing.test.ts packages/editor/src/lib/contextual-help.test.ts`
   Expect all green.
2. Run the standalone editor (`bun` + Next on port 3002), open a scene with furniture.
3. Select mode (V). Multi-select 2+ items with Ctrl/Cmd+click.
4. Confirm the floating pill shows **Group** next to Move / Copy / Delete (also on the right panel).
5. Click **Group** or press **Ctrl/Cmd+G**. Panel title becomes like `Group 1 · N`.
6. Click empty space, then click one member — whole group reselects.
7. **Alt+click** one member — only that object is selected.
8. **Ctrl/Cmd+Shift+G** or **Ungroup** — membership dissolves; selection is kept.
9. Hard refresh — session groups are gone (session-only; expected).

## Screenshots / screen recording

N/A attached here — interactive multi-select UX. Optional: short clip of Group icon + Ctrl+G expand-on-click if desired.

## Checklist

- [x] I've tested this locally with `bun test` on the packages above and manual editor multi-select
- [x] My code follows the existing code style
- [x] I've updated relevant documentation (`wiki/architecture/selection-groups.md`)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to selection click paths (3D, 2D, tree, keyboard) but session groups stay out of the scene graph and persistence; main risk is regressions in multi-select modifiers or stale expand after preview/load.
> 
> **Overview**
> Adds **editor-only session selection groups** so a multi-select set can be remembered and re-selected without scene-graph parents or project save.
> 
> **Create / dissolve:** **Ctrl/Cmd+G** groups 2+ selected nodes (auto `Group N`); **Ctrl/Cmd+Shift+G** dissolves groups that intersect the selection while keeping the current selection. A capture-phase **keydown** handler on **KeyG** prevents the browser from stealing **Ctrl/Cmd+G**.
> 
> **Reselect behavior:** Plain click on a member **expands** to all live group members via `expandSessionSelectionForNode`, wired through 3D `resolveSelectedIdsForNodeClick`, 2D registry `applyEntrySelection`, floorplan background hits, and the site tree. **Alt+click** selects a single member without expanding. **Alt** is tracked in selection modifier keys alongside meta/ctrl/shift.
> 
> **UI:** Optional **Group / Ungroup** on `NodeActionMenu` and the 2D/3D multi-select floating pills and docked multi-selection panel (with group label when the selection matches a session group). Help text and keyboard shortcut docs updated.
> 
> **State:** New `session-groups` helpers and `useSessionGroups` zustand store; groups are cleared on scene load/switch and version preview. Stored membership is **not** rewritten when nodes are deleted—reads filter by live scene ids so delete+undo can restore group membership.
> 
> **Docs:** `wiki/architecture/selection-groups.md` and links from selection-managers / architecture index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c804e3fc3749935e6545b66c2da1767bcc5d3293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->