### PR TITLE
core: repair null parent links so stored scenes pass authority validation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,9 +17,9 @@
       "default": "./dist/utils/clone-scene-graph.js"
     },
     "./scene-migrations": {
-      "types": "./dist/utils/retired-scene-nodes.d.ts",
-      "import": "./dist/utils/retired-scene-nodes.js",
-      "default": "./dist/utils/retired-scene-nodes.js"
+      "types": "./dist/utils/scene-migrations.d.ts",
+      "import": "./dist/utils/scene-migrations.js",
+      "default": "./dist/utils/scene-migrations.js"
     },
     "./registry": {
       "types": "./dist/registry/index.d.ts",

--- a/packages/core/src/store/use-scene-load-scene.test.ts
+++ b/packages/core/src/store/use-scene-load-scene.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import useScene from './use-scene'
+
+describe('loadScene default scene', () => {
+  beforeEach(() => {
+    useScene.setState({
+      nodes: {},
+      rootNodeIds: [],
+      dirtyNodes: new Set(),
+      collections: {},
+    } as never)
+    useScene.temporal.getState().clear()
+  })
+
+  test('links every default node to its parent', () => {
+    useScene.getState().loadScene()
+
+    const { nodes, rootNodeIds } = useScene.getState()
+    const site = Object.values(nodes).find((node) => node.type === 'site')
+    const building = Object.values(nodes).find((node) => node.type === 'building')
+    const level = Object.values(nodes).find((node) => node.type === 'level')
+
+    expect(site).toBeDefined()
+    expect(building).toBeDefined()
+    expect(level).toBeDefined()
+    expect(rootNodeIds).toEqual([site?.id])
+
+    // The hosted scene authority validates parent/child symmetry; a default
+    // scene saved as-is must already satisfy it.
+    expect(site?.parentId).toBeNull()
+    expect(building?.parentId).toBe(site?.id as never)
+    expect(level?.parentId).toBe(building?.id as never)
+    expect(site && 'children' in site ? site.children : []).toEqual([building?.id])
+    expect(building && 'children' in building ? building.children : []).toEqual([level?.id])
+  })
+})

--- a/packages/core/src/store/use-scene.ts
+++ b/packages/core/src/store/use-scene.ts
@@ -1387,25 +1387,25 @@ const useScene: UseSceneStore = create<SceneState>()(
           return // Scene already loaded
         }
 
-        // Create hierarchy: Site → Building → Level
+        // Create hierarchy: Site → Building → Level. Parent links must be
+        // written explicitly — the schema defaults `parentId` to null, and the
+        // scene authority rejects parent/child asymmetry that the renderer
+        // happily traverses through `children`.
+        const site = SiteNode.parse({})
+        const building = BuildingNode.parse({
+          parentId: site.id,
+        })
         const level0 = LevelNode.parse({
+          parentId: building.id,
           level: 0,
           children: [],
           height: 2.5,
         })
 
-        const building = BuildingNode.parse({
-          children: [level0.id],
-        })
-
-        const site = SiteNode.parse({
-          children: [building.id],
-        })
-
         // Define all nodes flat
         const nodes: Record<AnyNodeId, AnyNode> = {
-          [site.id]: site,
-          [building.id]: building,
+          [site.id]: { ...site, children: [building.id] },
+          [building.id]: { ...building, children: [level0.id] },
           [level0.id]: level0,
         }
 

--- a/packages/core/src/utils/heal-scene-graph.test.ts
+++ b/packages/core/src/utils/heal-scene-graph.test.ts
@@ -114,4 +114,66 @@ describe('healSceneNodes', () => {
     expect(strippedStaleChildRefs).toBe(0)
     expect(nodes.wall_a).toBe(input.wall_a)
   })
+
+  test('repairs null parent links down a site → building → level chain', () => {
+    // The exact stored-production corruption behind "Live collaboration is
+    // unavailable": children arrays link the chain but building/level carry
+    // parentId null, so the authority's symmetry validation rejected the scene.
+    const { nodes, repairedParentLinkNodeIds } = healSceneNodes({
+      site_a: { id: 'site_a', type: 'site', parentId: null, children: ['building_a'] },
+      building_a: { id: 'building_a', type: 'building', parentId: null, children: ['level_a'] },
+      level_a: { id: 'level_a', type: 'level', parentId: null, children: ['wall_a'] },
+      wall_a: { id: 'wall_a', type: 'wall', parentId: 'level_a', start: [0, 0], end: [2, 0] },
+    })
+    expect(repairedParentLinkNodeIds.sort()).toEqual(['building_a', 'level_a'])
+    expect((nodes.building_a as { parentId: string }).parentId).toBe('site_a')
+    expect((nodes.level_a as { parentId: string }).parentId).toBe('building_a')
+    expect((nodes.site_a as { parentId: null }).parentId).toBeNull()
+  })
+
+  test('repairs a null parent link claimed through an embedded legacy site child', () => {
+    const embeddedBuilding = {
+      id: 'building_legacy',
+      type: 'building',
+      parentId: null,
+      children: [],
+    }
+    const { nodes, repairedParentLinkNodeIds } = healSceneNodes({
+      site_legacy: {
+        id: 'site_legacy',
+        type: 'site',
+        parentId: null,
+        children: [embeddedBuilding],
+      },
+      building_legacy: embeddedBuilding,
+    })
+    expect(repairedParentLinkNodeIds).toEqual(['building_legacy'])
+    expect((nodes.building_legacy as { parentId: string }).parentId).toBe('site_legacy')
+  })
+
+  test('leaves a null parent link alone when multiple parents claim the node', () => {
+    const { nodes, repairedParentLinkNodeIds } = healSceneNodes({
+      level_a: { id: 'level_a', type: 'level', parentId: null, children: ['item_x'] },
+      level_b: { id: 'level_b', type: 'level', parentId: null, children: ['item_x'] },
+      item_x: { id: 'item_x', type: 'item', parentId: null },
+    })
+    expect(repairedParentLinkNodeIds).toEqual([])
+    expect((nodes.item_x as { parentId: null }).parentId).toBeNull()
+  })
+
+  test('leaves an unclaimed root and an existing string parentId alone', () => {
+    const { nodes, repairedParentLinkNodeIds } = healSceneNodes({
+      site_root: { id: 'site_root', type: 'site', parentId: null, children: ['building_a'] },
+      building_a: {
+        id: 'building_a',
+        type: 'building',
+        parentId: 'site_root',
+        children: ['level_gone'],
+      },
+      level_gone: { id: 'level_gone', type: 'level', parentId: 'building_missing', children: [] },
+    })
+    expect(repairedParentLinkNodeIds).toEqual([])
+    expect((nodes.site_root as { parentId: null }).parentId).toBeNull()
+    expect((nodes.level_gone as { parentId: string }).parentId).toBe('building_missing')
+  })
 })

--- a/packages/core/src/utils/heal-scene-graph.ts
+++ b/packages/core/src/utils/heal-scene-graph.ts
@@ -13,6 +13,11 @@
 //     duplicate reference renders the child twice (duplicate React keys in the
 //     2D plan, doubled hosted geometry in 3D). Same-array duplicates are
 //     collapsed too.
+//  4. A node with a null `parentId` that exactly one parent still claims via
+//     `children` (the legacy site-child flatten and the old default-scene
+//     assembler both linked children without writing `parentId`). The editor
+//     renders the chain through `children`, but the hosted scene authority
+//     validates parent/child symmetry and rejects the whole scene.
 //
 // All are also prevented at the source now; this is the load-time safety net
 // for already-saved scenes.
@@ -30,6 +35,11 @@ export interface HealSceneResult {
    * a different node (stale reparent leftovers), plus same-array duplicates.
    */
   strippedStaleChildRefs: number
+  /**
+   * Ids of nodes whose null `parentId` was repaired to the one parent that
+   * still claims them via `children`.
+   */
+  repairedParentLinkNodeIds: string[]
 }
 
 function isWallLike(node: unknown): node is { start: [number, number]; end: [number, number] } {
@@ -124,5 +134,43 @@ export function healSceneNodes(input: Record<string, unknown>): HealSceneResult 
     nodes[id] = node
   }
 
-  return { nodes, droppedWallIds, strippedChildRefs, strippedStaleChildRefs }
+  // Pass 3: repair null parent links. A node claimed as a child by exactly one
+  // parent must point back at it; legacy writers linked `children` without
+  // writing `parentId`. Embedded legacy site children claim by their `id` so
+  // the flattened flat-map node is repaired too.
+  const claimantsByChildId = new Map<string, string[]>()
+  for (const [id, node] of Object.entries(nodes)) {
+    const children = (node as { children?: unknown })?.children
+    if (!Array.isArray(children)) continue
+    for (const child of children) {
+      const childId =
+        typeof child === 'string'
+          ? child
+          : child && typeof child === 'object' && typeof (child as { id?: unknown }).id === 'string'
+            ? (child as { id: string }).id
+            : null
+      if (!childId || !(childId in nodes)) continue
+      const claimants = claimantsByChildId.get(childId) ?? []
+      claimants.push(id)
+      claimantsByChildId.set(childId, claimants)
+    }
+  }
+
+  const repairedParentLinkNodeIds: string[] = []
+  for (const [id, node] of Object.entries(nodes)) {
+    if (!node || typeof node !== 'object') continue
+    if ((node as { parentId?: unknown }).parentId != null) continue
+    const claimants = claimantsByChildId.get(id)
+    if (claimants?.length !== 1 || claimants[0] === id) continue
+    nodes[id] = { ...(node as Record<string, unknown>), parentId: claimants[0] }
+    repairedParentLinkNodeIds.push(id)
+  }
+
+  return {
+    nodes,
+    droppedWallIds,
+    strippedChildRefs,
+    strippedStaleChildRefs,
+    repairedParentLinkNodeIds,
+  }
 }

--- a/packages/core/src/utils/scene-migrations.ts
+++ b/packages/core/src/utils/scene-migrations.ts
@@ -1,0 +1,9 @@
+// Server-safe scene migrations shared by the client loader and the hosted
+// scene authority. Everything exported here must stay pure data logic with no
+// store, React, or Three.js imports so it can run in Server Components and
+// API routes.
+export { type HealSceneResult, healSceneNodes } from './heal-scene-graph'
+export {
+  type RetiredSceneNodeMigration,
+  removeRetiredDrawingSheetNodes,
+} from './retired-scene-nodes'


### PR DESCRIPTION
## What does this PR do?

Repairs the stored-scene corruption behind the hosted "Live collaboration is unavailable for this project. Editing is paused to protect the scene." incident (Sentry MONOREPO-EDITOR-JR/JQ/GF): scenes whose `children` arrays link site → building → level while `building`/`level` carry `parentId: null`. The editor renders these scenes by traversing `children`, but the hosted scene authority validates parent/child symmetry and rejected every snapshot, locking sessions read-only and silently discarding tool placements (ghost + SFX with no commit).

- `healSceneNodes` gains a repair pass: a node with a null `parentId` that exactly one parent claims via `children` points back at that parent. Embedded legacy site children claim by `id`, so the flattened flat-map node is repaired too. Ambiguous multi-claim nodes are left alone.
- `loadScene` writes explicit parent links for the default Site → Building → Level hierarchy (it previously relied on the schema's `parentId: null` default — one of the two writers of the corrupt shape; the other was the legacy embedded-site-child flatten, which pass 3 now covers on load).
- New `@pascal-app/core/scene-migrations` barrel exports `healSceneNodes` alongside `removeRetiredDrawingSheetNodes`, keeping the entry server-safe so the hosted authority can apply the identical normalization before validating.

## How to test

1. `bun test packages/core/src/utils/heal-scene-graph.test.ts` — new cases cover the null-parent chain repair, embedded legacy site-child claims, ambiguous multi-claim nodes, and untouched dangling parents.
2. `bun test packages/core/src/store/use-scene-load-scene.test.ts` — the default scene now carries symmetric parent links.
3. `bun test packages/core/src` — full core suite (930 tests).
4. In the hosted app, feed a stored graph with `building`/`level` at `parentId: null` through `normalizeAuthoritySceneGraph` (companion private-editor change) and confirm `apiGraphSchema` accepts it.

## Screenshots / screen recording

N/A — non-visual data-repair change.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scene graph normalization used on load and by the hosted authority; incorrect repair logic could alter hierarchy, though guards limit repairs to unambiguous single-claim cases.
> 
> **Overview**
> Fixes stored scenes where **`children`** links site → building → level but **`parentId`** stays null on building/level, which blocked hosted scene authority validation and paused live collaboration.
> 
> **`healSceneNodes`** adds a third pass: if a node has **`parentId: null`** and exactly one parent lists it in **`children`** (including embedded legacy site children), it sets **`parentId`** to that parent; ambiguous multi-parent claims are unchanged.
> 
> **`loadScene`** now sets explicit **`parentId`** on the default Site → Building → Level graph instead of relying on schema defaults, so new default scenes save with symmetric parent/child links.
> 
> The **`@pascal-app/core/scene-migrations`** export is pointed at a new server-safe barrel that re-exports **`healSceneNodes`** and **`removeRetiredDrawingSheetNodes`** for shared client/authority normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c4d1700b1ddc86297ec96fa6c618ee5933d7f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->