### PR TITLE
feat(viewer): export getWallHideState

### DIFF
--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -155,6 +155,7 @@ export {
   applyCountryUnitDefault,
   default as useViewer,
   type MetricNotation,
+  type WallMode,
 } from './store/use-viewer'
 export { CeilingSystem } from './systems/ceiling/ceiling-system'
 export {
@@ -224,7 +225,7 @@ export {
   getOpeningCutoutBottomPadding,
   hasFlatOpeningCutoutBottom,
 } from './systems/wall/opening-cutout-geometry'
-export { WallCutout } from './systems/wall/wall-cutout'
+export { getWallHideState, WallCutout } from './systems/wall/wall-cutout'
 export { getVisibleWallMaterials } from './systems/wall/wall-materials'
 // Wall internals re-exported so `@pascal-app/nodes`' registry-driven wall
 // definition can compose them into `def.system` without duplicating the

--- a/packages/viewer/src/store/use-viewer.ts
+++ b/packages/viewer/src/store/use-viewer.ts
@@ -11,6 +11,7 @@ import { SCENE_THEME_IDS } from '../lib/scene-themes'
 
 export type RenderContext = 'editor' | 'viewer'
 export type MetricNotation = 'meters' | 'millimeters'
+export type WallMode = 'up' | 'cutaway' | 'down' | 'translucent'
 
 type SelectionPath = {
   buildingId: BuildingNode['id'] | null
@@ -94,8 +95,8 @@ type ViewerState = {
   levelMode: 'stacked' | 'exploded' | 'solo' | 'manual'
   setLevelMode: (mode: 'stacked' | 'exploded' | 'solo' | 'manual') => void
 
-  wallMode: 'up' | 'cutaway' | 'down' | 'translucent'
-  setWallMode: (mode: 'up' | 'cutaway' | 'down' | 'translucent') => void
+  wallMode: WallMode
+  setWallMode: (mode: WallMode) => void
 
   showScans: boolean
   setShowScans: (show: boolean) => void

--- a/packages/viewer/src/systems/wall/wall-cutout.tsx
+++ b/packages/viewer/src/systems/wall/wall-cutout.tsx
@@ -14,7 +14,7 @@ import { useFrame } from '@react-three/fiber'
 import { useEffect, useRef } from 'react'
 import type { Material } from 'three'
 import { type Mesh, Vector3 } from 'three/webgpu'
-import useViewer from '../../store/use-viewer'
+import useViewer, { type WallMode } from '../../store/use-viewer'
 import {
   getMaterialsForWall,
   getSelectionHighlightMaterials,
@@ -25,10 +25,18 @@ const tmpVec = new Vector3()
 const u = new Vector3()
 const v = new Vector3()
 
-function getWallHideState(
+/**
+ * Whether a wall should be hidden or see-through for the current camera and
+ * wall mode. Pure: reads only its arguments and the mesh's world direction.
+ *
+ * Exported so hosts rendering their own layers inside `<Viewer>` can match
+ * these semantics instead of re-deriving the facing test or inferring state
+ * from the assigned material variant.
+ */
+export function getWallHideState(
   wallNode: WallNode,
   wallMesh: Mesh,
-  wallMode: string,
+  wallMode: WallMode,
   cameraDir: Vector3,
 ): boolean {
   let hideWall = wallNode.frontSide === 'interior' && wallNode.backSide === 'interior'

--- a/packages/viewer/src/systems/wall/wall-hide-state.test.ts
+++ b/packages/viewer/src/systems/wall/wall-hide-state.test.ts
@@ -1,0 +1,56 @@
+// @ts-expect-error — bun:test is provided by the Bun runtime; viewer does not
+// depend on @types/bun so the import type is unresolved at compile time.
+import { describe, expect, test } from 'bun:test'
+import { WallNode } from '@pascal-app/core'
+import { Mesh, Vector3 } from 'three/webgpu'
+import { getWallHideState } from './wall-cutout'
+
+const wall = (frontSide: string, backSide: string) =>
+  WallNode.parse({ start: [0, 0], end: [4, 0], frontSide, backSide })
+
+/** Faces +Z, so `getWorldDirection` returns (0, 0, 1). */
+const facingPositiveZ = () => new Mesh()
+
+const towardsPositiveZ = new Vector3(0, 0, 1)
+const towardsNegativeZ = new Vector3(0, 0, -1)
+
+describe('getWallHideState', () => {
+  test("'up' always shows the wall, even when both sides are interior", () => {
+    expect(
+      getWallHideState(wall('interior', 'interior'), facingPositiveZ(), 'up', towardsPositiveZ),
+    ).toBe(false)
+  })
+
+  test("'down' always hides the wall, even when both sides are exterior", () => {
+    expect(
+      getWallHideState(wall('exterior', 'exterior'), facingPositiveZ(), 'down', towardsPositiveZ),
+    ).toBe(true)
+  })
+
+  test("'cutaway' hides the near exterior face and keeps the far one", () => {
+    const exteriorFront = wall('exterior', 'interior')
+    expect(getWallHideState(exteriorFront, facingPositiveZ(), 'cutaway', towardsNegativeZ)).toBe(
+      true,
+    )
+    expect(getWallHideState(exteriorFront, facingPositiveZ(), 'cutaway', towardsPositiveZ)).toBe(
+      false,
+    )
+  })
+
+  test("'cutaway' keeps walls that are exterior on both sides visible from either direction", () => {
+    const both = wall('exterior', 'exterior')
+    expect(getWallHideState(both, facingPositiveZ(), 'cutaway', towardsNegativeZ)).toBe(false)
+    expect(getWallHideState(both, facingPositiveZ(), 'cutaway', towardsPositiveZ)).toBe(false)
+  })
+
+  test("'cutaway' hides walls that are interior on both sides", () => {
+    expect(
+      getWallHideState(
+        wall('interior', 'interior'),
+        facingPositiveZ(),
+        'cutaway',
+        towardsPositiveZ,
+      ),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #572.

## What

`getWallHideState(wallNode, wallMesh, wallMode, cameraDir)` is now exported from `@pascal-app/viewer`, along with the `WallMode` type it takes.

## Why

@esteban685 [asked for this in #572](https://github.com/pascalorg/editor/issues/572): a host rendering its own layers inside `<Viewer>`'s children seam has no way to match wall-cutout visibility today. The two available workarounds are both bad:

- re-derive the `getWorldDirection(v).dot(cameraDir) < 0` facing test in host code — it silently drifts the moment the viewer's rule changes
- read the assigned material variant's `transparent` flag — fragile, and it conflates `translucent` mode with a hidden wall

The predicate was already pure: it takes every input explicitly and touches no module state beyond a scratch `Vector3`. So this is an export, not a refactor — `WallCutout` calls the same function on the same line it did before.

## Changes

- `packages/viewer/src/systems/wall/wall-cutout.tsx` — `export function getWallHideState`, plus a JSDoc block recording *why* it is public
- `packages/viewer/src/store/use-viewer.ts` — extract `export type WallMode = 'up' | 'cutaway' | 'down' | 'translucent'` so the signature names its mode instead of accepting any `string`. `WALL_MODES` already existed as the runtime counterpart; the store fields now reference the named type.
- `packages/viewer/src/index.ts` — re-export `getWallHideState` and `type WallMode`
- `packages/viewer/src/systems/wall/wall-hide-state.test.ts` — 5 cases pinning the semantics that are now public API: `up` always shows, `down` always hides, `cutaway` hides the near exterior face and both-sides-interior walls, and keeps both-sides-exterior walls visible from either direction

## Verification

- `bun test packages/viewer/src/systems/wall/` → 24 pass, 0 fail
- `bun run check` → 1582 files clean
- `bun run check-types` → 9/9 tasks pass

No behavior change: same predicate, same call site, wider visibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only surface area with typed signatures and new unit tests; wall rendering behavior is unchanged.
> 
> **Overview**
> **Public API for wall cutaway visibility** so hosts that render custom layers inside `<Viewer>` can hide or show geometry the same way `WallCutout` does, without copying the camera-facing test or inferring hide state from material transparency.
> 
> `getWallHideState` is exported from `wall-cutout` (unchanged logic; JSDoc explains the intent). The `wallMode` argument is typed as a new exported **`WallMode`** union (`'up' | 'cutaway' | 'down' | 'translucent'`) on the viewer store and the helper. Both symbols are re-exported from `@pascal-app/viewer`.
> 
> **Tests** in `wall-hide-state.test.ts` lock in `up`/`down` overrides and `cutaway` behavior for interior/exterior combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c1f8ab4f468b5674831aee6113963f8437311ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->