### PR TITLE
fix(editor): install a structuredClone fallback where lingo is imported (Sentry MONOREPO-EDITOR-FB)

### DIFF
--- a/packages/editor/src/lib/measurement-parser.ts
+++ b/packages/editor/src/lib/measurement-parser.ts
@@ -1,3 +1,6 @@
+// Must precede the lingo import: lingo clones its kind table with
+// structuredClone while its module body evaluates. See the file's own comment.
+import './structured-clone-fallback'
 import { type Kind, parseQuantity, quantity } from '@pascal-app/lingo'
 
 /**

--- a/packages/editor/src/lib/structured-clone-fallback.test.ts
+++ b/packages/editor/src/lib/structured-clone-fallback.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+const native = globalThis.structuredClone
+
+afterEach(() => {
+  globalThis.structuredClone = native
+})
+
+async function installFallback() {
+  // Fresh module instance each time — the shim is a module side effect.
+  await import(`./structured-clone-fallback?${Math.random()}`)
+}
+
+describe('structuredClone fallback', () => {
+  test('leaves a native implementation alone', async () => {
+    await installFallback()
+    expect(globalThis.structuredClone).toBe(native)
+  })
+
+  test('installs a JSON-based clone when the global is missing', async () => {
+    // @ts-expect-error — simulating a browser without the global.
+    globalThis.structuredClone = undefined
+    await installFallback()
+
+    const source = { units: [{ factor: 1, id: 'm' }], kind: 'length' }
+    const copy = structuredClone(source)
+
+    expect(copy).toEqual(source)
+    expect(copy).not.toBe(source)
+    expect(copy.units).not.toBe(source.units)
+  })
+
+  test('lets lingo build its registry without the global', async () => {
+    // @ts-expect-error — simulating a browser without the global.
+    globalThis.structuredClone = undefined
+    await installFallback()
+
+    // The actual regression: lingo clones its kind table at module-eval time,
+    // so this import throws on a browser lacking structuredClone.
+    const { parseQuantity } = await import('@pascal-app/lingo')
+    const result = parseQuantity('180cm', { kind: 'length', unit: 'm' })
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.quantity.to('m').value).toBeCloseTo(1.8, 6)
+  })
+})

--- a/packages/editor/src/lib/structured-clone-fallback.ts
+++ b/packages/editor/src/lib/structured-clone-fallback.ts
@@ -1,0 +1,24 @@
+/**
+ * `@pascal-app/lingo` builds its unit registry at module-eval time, and
+ * `registerKind` deep-copies each kind definition with `structuredClone`. On a
+ * browser without that global (Chromium <98 — reported from Honor Browser 9.8
+ * as `ReferenceError: structuredClone is not defined`) the throw happens while
+ * the module graph is still evaluating, so a component-level guard can never
+ * run in time and the whole editor bundle fails to load.
+ *
+ * This has to be imported for its side effect from the module that pulls lingo
+ * in, so it is installed wherever `@pascal-app/editor` is loaded — the OSS app,
+ * the hosted app, and any npm consumer. An app-level polyfill would only cover
+ * the app that declares it.
+ *
+ * Scoped deliberately narrowly: the kind definitions lingo clones are plain
+ * JSON (strings, numbers, arrays of those), so a JSON round-trip is sufficient
+ * and avoids a dependency. This is NOT a spec-compliant `structuredClone` — it
+ * has no support for Map/Set/Date/ArrayBuffer/cycles and throws a `TypeError`
+ * rather than a `DataCloneError`. Anything needing real structured-clone
+ * semantics must not rely on this shim.
+ */
+if (typeof globalThis.structuredClone !== 'function') {
+  globalThis.structuredClone = (<T>(value: T): T =>
+    JSON.parse(JSON.stringify(value)) as T) as typeof structuredClone
+}


### PR DESCRIPTION
Supersedes #524, which correctly diagnosed the root cause but installed the polyfill in the wrong place.

## Root cause (verified)

`@pascal-app/lingo@0.2.0` builds `defaultRegistry = createRegistry(allKinds)` at module scope. `Registry`'s constructor calls `registerKind` for each kind, and `registerKind` does `const copy = structuredClone(def)`. So on a browser without the global, the throw happens while lingo's module body is still evaluating — no component-level guard can run in time.

`packages/editor/src/lib/measurement-parser.ts:1` imports lingo, which is what makes it load-reachable from the editor bundle. Confirmed by test: importing `@pascal-app/lingo` with `globalThis.structuredClone = undefined` throws; with the shim installed it resolves and parses correctly.

Sentry **MONOREPO-EDITOR-FB** (`ReferenceError: structuredClone is not defined`, Honor Browser 9.8 / Chromium <98).

## Why here and not in an app entry

#524 put the polyfill in `apps/editor/instrumentation-client.ts`. `apps/editor` has no Sentry SDK and no `instrumentation-client.ts` on main — the app that *reports* MONOREPO-EDITOR-FB is the hosted app, which has its own instrumentation entry and would never load that file. So the crash would have stayed unfixed for the reporting app, for every npm consumer of `@pascal-app/editor`, and the Sentry issue would have looked addressed.

`packages/editor` is the layer all three load. Importing the shim for its side effect immediately above the lingo import puts it exactly where the ordering constraint is, and keeps it visible to anyone who later moves that import.

## Scope

Deliberately a JSON round-trip rather than `@ungap/structured-clone`: lingo's kind definitions are plain JSON (strings, numbers, arrays of those), so no dependency is warranted. The file documents that it is **not** spec-compliant — no Map/Set/Date/ArrayBuffer/cycles, and it throws `TypeError` rather than `DataCloneError` — so nothing else starts leaning on it. `packages/core/src/utils/clone-scene-graph.ts` already avoids `structuredClone` for live runtime nodes for related reasons.

Not claimed: that this makes Chromium <98 able to *run* the editor. Next 16 compiles for a `chrome 111` baseline, `globals.css` uses `oklch()` 62 times, and the viewer needs WebGL2/WebGPU. This removes one hard `ReferenceError` at module load; it is not a browser-support expansion.

## Verification

- `bun run check` clean (1589 files)
- `bun run check-types` 9/9 tasks
- `bun run test` 12/12 tasks green, including 3 new tests covering native-passthrough, the JSON clone, and lingo importing successfully without the global

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, guarded polyfill with tests; only affects environments without native `structuredClone` and is scoped to JSON-serializable data lingo needs.
> 
> **Overview**
> Fixes **MONOREPO-EDITOR-FB** by ensuring `globalThis.structuredClone` exists before `@pascal-app/lingo` evaluates. Lingo deep-copies its kind registry at import time; without the global, the editor bundle throws during module load.
> 
> Adds `structured-clone-fallback.ts`, a **JSON round-trip shim** only when the native API is missing, and imports it for side effect **immediately above** the lingo import in `measurement-parser.ts` so every `@pascal-app/editor` consumer gets the fix—not an app-only entry. The shim is documented as non–spec-compliant and intentionally narrow.
> 
> Three tests cover native passthrough, JSON cloning behavior, and successful lingo import/parse when `structuredClone` is undefined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35fc449f5d65a65907afb34cafd14a7ea67a9e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->