### PR TITLE
fix(editor): keep the autosave wipe guard armed after the scene loads

### DIFF
--- a/packages/editor/src/hooks/use-auto-save.test.ts
+++ b/packages/editor/src/hooks/use-auto-save.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { isSuspiciousNodeDrop } from './use-auto-save'
+import { createStoredNodeCountTracker, isSuspiciousNodeDrop } from './use-auto-save'
 
 describe('isSuspiciousNodeDrop', () => {
   test('blocks populated scenes from being flushed as empty skeletons', () => {
@@ -10,5 +10,54 @@ describe('isSuspiciousNodeDrop', () => {
   test('allows ordinary edits and intentionally empty starting scenes', () => {
     expect(isSuspiciousNodeDrop(12, 11)).toBe(false)
     expect(isSuspiciousNodeDrop(4, 0)).toBe(false)
+  })
+})
+
+describe('createStoredNodeCountTracker', () => {
+  test('adopts a loaded graph as the baseline the guard measures against', () => {
+    // The hook mounts before the scene loads, so the tracker starts at the bare
+    // scaffold and only learns the real size when the load lands. Without this,
+    // every session's first save compares a populated graph against ~0 and the
+    // guard is dead for exactly the write that can destroy the most work.
+    const tracker = createStoredNodeCountTracker(0)
+    tracker.trackLoadedGraph(42)
+
+    expect(tracker.allowWrite(0)).toBe(false)
+    expect(tracker.count).toBe(42)
+  })
+
+  test('keeps blocking after a blocked write instead of adopting the empty graph', () => {
+    const tracker = createStoredNodeCountTracker(0)
+    tracker.trackLoadedGraph(42)
+
+    expect(tracker.allowWrite(0)).toBe(false)
+    // A debounced retry must not be the thing that finally lets the wipe land.
+    expect(tracker.allowWrite(0)).toBe(false)
+  })
+
+  test('lets ordinary edits through and advances the baseline', () => {
+    const tracker = createStoredNodeCountTracker(0)
+    tracker.trackLoadedGraph(12)
+
+    expect(tracker.allowWrite(13)).toBe(true)
+    expect(tracker.count).toBe(13)
+    expect(tracker.allowWrite(5)).toBe(true)
+    expect(tracker.count).toBe(5)
+  })
+
+  test('does not treat a deliberately empty new scene as suspicious', () => {
+    const tracker = createStoredNodeCountTracker(0)
+    tracker.trackLoadedGraph(4)
+
+    expect(tracker.allowWrite(0)).toBe(true)
+  })
+
+  test('adopts a smaller loaded graph, so restoring an older version still saves', () => {
+    // Loading a 3-node version over a 40-node one is not a deletion.
+    const tracker = createStoredNodeCountTracker(0)
+    tracker.trackLoadedGraph(40)
+    tracker.trackLoadedGraph(3)
+
+    expect(tracker.allowWrite(3)).toBe(true)
   })
 })

--- a/packages/editor/src/hooks/use-auto-save.ts
+++ b/packages/editor/src/hooks/use-auto-save.ts
@@ -11,6 +11,40 @@ export function isSuspiciousNodeDrop(previousNodeCount: number, currentNodeCount
   return previousNodeCount > STRUCTURAL_NODE_COUNT && currentNodeCount <= STRUCTURAL_NODE_COUNT
 }
 
+/**
+ * Tracks the node count of the graph we believe is stored, which is what the
+ * accidental-wipe guard measures every write against.
+ *
+ * The distinction that matters: a graph that came from storage is authoritative
+ * and has to become the new baseline, while an edited or previewed graph must
+ * not. Seeding the baseline once at mount is not enough — the hook mounts
+ * before the scene has loaded, so it would sit at ~0 for the whole session and
+ * `isSuspiciousNodeDrop` could never fire.
+ */
+export function createStoredNodeCountTracker(initialNodeCount: number) {
+  let count = initialNodeCount
+
+  return {
+    get count() {
+      return count
+    },
+    /** A graph read from storage — it defines what "populated" means from here. */
+    trackLoadedGraph(nodeCount: number) {
+      count = nodeCount
+    },
+    /**
+     * `false` when the write would drop a populated scene to a bare scaffold,
+     * which is an accidental full deletion far more often than an intent. The
+     * caller reports the block; on `true` the write becomes the new baseline.
+     */
+    allowWrite(nodeCount: number) {
+      if (isSuspiciousNodeDrop(count, nodeCount)) return false
+      count = nodeCount
+      return true
+    },
+  }
+}
+
 export type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'paused' | 'error'
 
 interface UseAutoSaveOptions {
@@ -65,7 +99,9 @@ export function useAutoSave({
   // Stable subscription to scene changes
   useEffect(() => {
     let lastNodesSnapshot = JSON.stringify(useScene.getState().nodes)
-    let lastNodeCount = Object.keys(useScene.getState().nodes).length
+    const storedNodeCount = createStoredNodeCountTracker(
+      Object.keys(useScene.getState().nodes).length,
+    )
     // Collections + scene materials are document-level state that persists with
     // the graph but lives outside `nodes`. Track them by reference (zustand
     // hands out a new object on every mutation) so a material edit or a
@@ -90,17 +126,15 @@ export function useAutoSave({
         installedPlugins,
       } as SceneGraph
 
-      // Guard: refuse to autosave if the scene went from populated to nearly empty.
-      // This catches accidental full deletions before they're persisted.
       const currentNodeCount = Object.keys(nodes).length
-      if (isSuspiciousNodeDrop(lastNodeCount, currentNodeCount)) {
+      const previousNodeCount = storedNodeCount.count
+      if (!storedNodeCount.allowWrite(currentNodeCount)) {
         console.warn(
-          `[autosave] Blocked: scene dropped from ${lastNodeCount} to ${currentNodeCount} nodes. Likely accidental deletion.`,
+          `[autosave] Blocked: scene dropped from ${previousNodeCount} to ${currentNodeCount} nodes. Likely accidental deletion.`,
         )
         setSaveStatus('error')
         return
       }
-      lastNodeCount = currentNodeCount
 
       isSavingRef.current = true
       pendingSaveRef.current = false
@@ -135,6 +169,7 @@ export function useAutoSave({
     const unsubscribe = useScene.subscribe((state) => {
       if (isLoadingSceneRef.current) {
         lastNodesSnapshot = JSON.stringify(state.nodes)
+        storedNodeCount.trackLoadedGraph(Object.keys(state.nodes).length)
         lastCollectionsRef = state.collections
         lastMaterialsRef = state.materials
         lastInstalledPluginsRef = state.installedPlugins
@@ -188,16 +223,16 @@ export function useAutoSave({
       if (!hasDirtyChangesRef.current) return
       const { nodes, rootNodeIds, collections, materials, installedPlugins } = useScene.getState()
       const currentNodeCount = Object.keys(nodes).length
-      if (isSuspiciousNodeDrop(lastNodeCount, currentNodeCount)) {
+      const previousNodeCount = storedNodeCount.count
+      if (!storedNodeCount.allowWrite(currentNodeCount)) {
         console.warn(
-          `[autosave] Blocked unload flush: scene dropped from ${lastNodeCount} to ${currentNodeCount} nodes. Likely accidental deletion.`,
+          `[autosave] Blocked unload flush: scene dropped from ${previousNodeCount} to ${currentNodeCount} nodes. Likely accidental deletion.`,
         )
         setSaveStatus('error')
         return
       }
 
       hasDirtyChangesRef.current = false
-      lastNodeCount = currentNodeCount
       const sceneGraph = {
         nodes,
         rootNodeIds,


### PR DESCRIPTION
## The bug

`useAutoSave` has a guard that refuses to persist a scene which drops from populated to a bare scaffold (≤ 4 structural nodes), on the assumption that it's an accidental full deletion rather than an intent.

The baseline it measures against was seeded once, at hook mount:

```ts
let lastNodeCount = Object.keys(useScene.getState().nodes).length
```

The hook mounts *before* the scene loads. So the baseline sat at the scaffold count for the entire session, `isSuspiciousNodeDrop(4, 0)` is `false` by design, and the guard could never fire. The one write it exists to stop is precisely the one it let through: an autosave racing the initial load persists the scaffold over a populated stored scene.

The loading branch of the store subscription was already refreshing the snapshot, collections, materials and installed-plugins refs on every load — it just never refreshed the count.

## The fix

The baseline moves into `createStoredNodeCountTracker`, which separates the two cases the single mutable `let` was conflating:

- `trackLoadedGraph(n)` — a graph read from storage is authoritative and becomes the new baseline.
- `allowWrite(n)` — an edit is measured against that baseline, and only advances it if allowed.

This also removes the guard duplication between `executeSave` and `flushOnExit` (which had drifted to two different warning strings), and makes the invariant testable without pulling `react-dom` into a repo that has no DOM test setup — the same approach [`floorplan-camera-sync.ts`](https://github.com/pascalorg/editor/blob/main/packages/editor/src/components/editor/floorplan-camera-sync.ts) already uses for its closure state.

Behavior for edits is unchanged: shrinking a populated scene to ≤ 4 nodes is still blocked, an intentionally small scene can still be emptied, and a blocked write no longer risks being adopted as the baseline by a debounced retry.

## Credit

Surfaced by @evolv3ai in #551, which caught the data loss and fixed the symptom with a `nodeCount === 0` check in the standalone app's `PUT /api/scenes/[id]` route.

Two reasons to fix it here instead:

1. `apps/editor` is one of three consumers of this hook. The hosted editor and npm consumers share `useAutoSave` but not that route, so a route-level check leaves them exposed.
2. In `apps/editor`, a rejected save returns 409, and [`scene-loader.tsx:131`](https://github.com/pascalorg/editor/blob/main/apps/editor/components/scene-loader.tsx) treats 409 as a conflict-to-reload rather than a failure — it returns without throwing, so autosave marks the run saved. The client-side guard is the one that actually prevents the write.

## Verification

- `bun run check` — 1587 files, clean
- `bun run check-types` — 9/9 tasks
- `bun run test` — 12/12 tasks; 7 tests in `use-auto-save.test.ts`, 5 of them new and covering the load-then-wipe sequence that regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence guard logic shared by all editor consumers; behavior for legitimate edits is intended to stay the same but incorrect baseline updates could still block or allow bad saves.
> 
> **Overview**
> **Fixes a data-loss hole in the editor autosave “suspicious node drop” guard** by keeping the baseline node count aligned with what was actually loaded from storage, instead of freezing it at hook mount when the scene is still an empty scaffold.
> 
> Introduces **`createStoredNodeCountTracker`**: **`trackLoadedGraph`** updates the baseline when the store subscription runs during `isLoadingSceneRef`, and **`allowWrite`** blocks writes that would shrink a populated scene to ≤4 structural nodes without advancing the baseline (so debounced retries cannot persist a wipe). **`useAutoSave`** uses this for both debounced saves and **`flushOnExit`**, replacing a single **`lastNodeCount`** that never updated on load.
> 
> Adds unit tests for load-then-wipe, repeated blocks, normal edits, small empty scenes, and version restore with a smaller graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7973824dc7606f0c5643967253951fae7204255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->