### PR TITLE
Use Node for standalone editor Vercel functions

### DIFF
--- a/apps/editor/vercel.json
+++ b/apps/editor/vercel.json
@@ -4,6 +4,5 @@
   "installCommand": "cd ../.. && npx -y bun@1.3.13 install --frozen-lockfile",
   "outputDirectory": ".next",
   "cleanUrls": true,
-  "trailingSlash": false,
-  "bunVersion": "1.x"
+  "trailingSlash": false
 }


### PR DESCRIPTION
## Why

The Next.js 16.3 upgrade exposed a pre-handler runtime failure when Vercel packaged Community functions with its Bun beta. The standalone OSS editor has dynamic server routes and generates the same Turbopack external loader path, so retaining `bunVersion` leaves its committed deployment configuration vulnerable to the same failure.

## What changed

- remove only `bunVersion` from `apps/editor/vercel.json`
- keep Bun 1.3.13 for dependency installation and builds
- allow Vercel Functions to use the project/default Node runtime

## Validation

- parsed `apps/editor/vercel.json` as JSON
- `git diff --check`
- `bun run build --filter=editor --force` — 5/5 tasks, Next.js 16.3.0, all editor routes emitted
- `bun run check-types --filter=editor --force` — 6/6 tasks
- `bun run test --filter=editor --force` — 19 passed, 0 failed

This is the runtime-config closure identified by the adversarial review of #579.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single deployment-config change with no application code or auth/data impact; aligns runtime with a known fix for a packaging failure.
> 
> **Overview**
> Removes **`bunVersion`** from `apps/editor/vercel.json` so Vercel packages Community/server functions on the **Node** runtime instead of the Bun beta.
> 
> **Install and build** still use Bun 1.3.13 via `installCommand` and `buildCommand`; only the **function execution** runtime changes. This avoids the Next.js 16.3 / Turbopack external-loader failure seen when dynamic server routes run under Vercel’s Bun packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf64e68ed8239431844c766be6a5c0475d0b604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->