### PR TITLE
docs(mcp): state the north convention in the garden-house template

### DIFF
--- a/packages/mcp/src/templates/garden-house.ts
+++ b/packages/mcp/src/templates/garden-house.ts
@@ -15,11 +15,14 @@ import type { AnyNode, AnyNodeId } from '@pascal-app/core/schema'
  *   - 2 windows on the south wall, 1 window on each of east and west
  *   - 1 indoor "living" zone, 1 outdoor "garden" zone
  *   - 3 fence segments bounding the north/east/west of the garden
+ *
+ * Coordinate system: `[x, z]` on the XZ plane, with `x` running east/west
+ * and `z` running north/south (positive z points south).
  */
 
 const HOUSE_W = 6 // half-width of the house (12 m total)
 const HOUSE_D = 4 // half-depth of the house (8 m total)
-const GARDEN_DEPTH = 6 // depth of the back-garden zone along +z direction
+const GARDEN_DEPTH = 6 // depth of the back-garden zone along -z (north)
 
 const WALL_THICKNESS = 0.15
 const WALL_HEIGHT = 2.7


### PR DESCRIPTION
Piece 1 of #362, split out because it's a comment-only change with no design decision attached.

`packages/mcp/src/templates/two-bedroom.ts:13-14` documents the coordinate system — `x` east/west, `z` north/south, positive z points south. `garden-house.ts` uses the same convention but never states it, which is why #362 read the two templates as disagreeing about north. They don't: `wall_n` is at `-HOUSE_D`, `wall_s` at `+HOUSE_D`, and `zone_garden` extends to `-HOUSE_D - GARDEN_DEPTH`, i.e. further into −z. The geometry agrees; only the prose was missing.

Two changes, both comments:

- Copy the coordinate-system paragraph into the `garden-house.ts` header.
- Fix the `GARDEN_DEPTH` comment, which said "along +z direction" while the garden is built at `-HOUSE_D - GARDEN_DEPTH` (−z).

No behaviour change; `templates.test.ts` unaffected. The substantive half of #362 — a first-class `northDirection` on Site/Building plus the MCP contract — stays open and needs a schema design call first.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes in an MCP template file with no logic or schema impact.
> 
> **Overview**
> **Documentation-only** update to `garden-house.ts` so its north/south convention matches `two-bedroom.ts` and the actual geometry.
> 
> Adds a **coordinate system** note in the file header: `[x, z]` on the XZ plane, positive **z** is **south**. Corrects the `GARDEN_DEPTH` comment from “along +z” to **along −z (north)**, aligning prose with how the garden zone is built at `-HOUSE_D - GARDEN_DEPTH`.
> 
> No runtime or template output changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b586e1149b5fb3319e69fdd71597e3d52a45c2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->