### PR TITLE
ci: pin bun to 1.3.14 in the quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,17 @@ concurrency:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
+      # Pinned to match `packageManager` in package.json. Unpinned, this floats
+      # to whatever bun is latest, so a bun release can break the gate with no
+      # change in the repo — and CI then disagrees with what contributors run.
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.0
+          bun-version: 1.3.14
 
       - name: Install
         run: bun install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "engines": {
     "node": ">=20.9.0"
   },
-  "packageManager": "bun@1.3.0",
+  "packageManager": "bun@1.3.14",
   "overrides": {
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",


### PR DESCRIPTION
Housekeeping. Three files, one version number.

`.github/workflows/ci.yml` used `oven-sh/setup-bun@v2` with no `bun-version`, so the gate that decides whether every PR is mergeable ran against whatever bun happened to be latest. That's a build that can go red with no change in the repo — and it can also go *green* on a runtime no contributor is using. `mcp-ci.yml` did pin, but to `1.3.0`, so the two workflows exercised different runtimes on overlapping code.

`packageManager` in the root `package.json` also read `bun@1.3.0` while the committed `bun.lock` is produced by 1.3.14. Now all three say `1.3.14`.

Also adds `permissions: contents: read` to the `quality` job. `mcp-ci.yml` already scopes its token that way; the default is broader than a lint-typecheck-test-build job needs.

No behaviour change for contributors already on 1.3.x. Anyone on an older bun will now get a clear version mismatch from `packageManager` rather than a confusing lockfile diff.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and toolchain version alignment only; no application, auth, or runtime behavior changes.
> 
> **Overview**
> **Aligns Bun to 1.3.14** across the main quality workflow, `mcp-ci`, and root `packageManager` so CI, lockfile tooling, and local dev agree on the same runtime.
> 
> The **`quality` job** in `ci.yml` now pins `oven-sh/setup-bun` to **1.3.14** (previously floated to latest) and adds **`permissions: contents: read`**, matching the tighter token scope already used in `mcp-ci`. **`mcp-ci.yml`** bumps its pin from **1.3.0** to **1.3.14**. Root **`package.json`** `packageManager` moves from **bun@1.3.0** to **bun@1.3.14** to match the committed lockfile.
> 
> Contributors already on 1.3.14 see no behavior change; older Bun installs should hit a clearer `packageManager` mismatch instead of surprise CI or lockfile drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9a85daccf0695a5dc5d09c407d8f21ef92128c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->