### PR TITLE
chore: drop the stale NEXT_PUBLIC_GOOGLE_MAPS_API_KEY docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,4 @@
 # Optional environment variables — the editor works without any of these
 
-# Google Maps API key (enables address search)
-# NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
-
 # Dev server port (default: 3002, set in .env.defaults)
 # PORT=3002

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,7 +23,6 @@ cp .env.example .env
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` | No | Enables address search in the editor |
 | `PORT` | No | Dev server port (default: 3002) |
 
 The editor works fully without any environment variables.


### PR DESCRIPTION
`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is documented in two places and read by none.

```
$ grep -rn "GOOGLE_MAPS" apps packages --include='*.ts' --include='*.tsx'
(no matches)
```

The only references are `SETUP.md:26` and `.env.example:4`, and there's no geocoder anywhere in the tree — no Nominatim, Mapbox, Geoapify or Places call — so the "address search" the variable promises doesn't exist in this app. Setting it does nothing.

Docs that advertise a non-existent knob cost real time: someone provisions a Google Cloud key, sets it, sees no address search, and goes looking for the bug in their setup.

Noticed while reviewing #268, where I said I'd clean it up separately.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, config, or security impact.
> 
> **Overview**
> Removes **documentation only** for `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`, which is not read anywhere in the app and does not enable address search.
> 
> **`.env.example`** no longer lists the commented Google Maps key block. **`SETUP.md`** drops the variable from the optional env table so setup docs match what the editor actually uses (`PORT` remains the only documented optional var).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec501fcfcd907fb2c79dedc10bb444ab1799b16f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->