### PR TITLE
docs: document the docker workflow

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -27,6 +27,20 @@ cp .env.example .env
 
 The editor works fully without any environment variables.
 
+## Docker
+
+```bash
+docker compose up -d
+```
+
+The editor will be running at **http://localhost:3000**. Saved scenes live in
+the `pascal-data` volume, so they survive `docker compose down`.
+
+Keep the container port at 3000: the `/scenes` page fetches its own API through
+a base URL that only `NEXT_PUBLIC_APP_URL` can override, and Next inlines that
+value at build time, so remapping the port to something else makes the page
+return 500.
+
 ## Monorepo Structure
 
 ```


### PR DESCRIPTION
Docker support landed in #268, but nothing in `SETUP.md` or `README.md` mentions it — the only way to discover it was to notice `docker-compose.yml` in the file listing.

Adds a short section with the one command, where saved scenes live, and the port constraint. That last one is worth writing down because the failure is non-obvious: remap the host port and `/scenes` returns 500, since the page derives its own API base URL from a value Next inlines at build time.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or application code impact.
> 
> **Overview**
> **`SETUP.md`** now documents how to run the editor with Docker after support landed elsewhere without setup instructions.
> 
> The new section covers `docker compose up -d`, **http://localhost:3000**, and persistence via the **`pascal-data`** volume across `docker compose down`. It also warns not to remap the container port: **`/scenes`** builds its API base from **`NEXT_PUBLIC_APP_URL`**, which Next inlines at build time, so a different host port can surface as a non-obvious **500** on that page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8be743ef487e554c114fab1810a36c9826223ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->