### PR TITLE
Add Mint plugin to Pascal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
-# Optional environment variables — the editor works without any of these
+# Optional environment variables
 
 # Dev server port (default: 3002, set in .env.defaults)
 # PORT=3002
+
+# Public editor origin used by Mint OAuth and same-origin checks.
+# Set this when Pascal is hosted outside editor.pascal.app.
+# MINT_PASCAL_HOST_ORIGIN=https://pascal.example.com

--- a/SETUP.md
+++ b/SETUP.md
@@ -24,8 +24,9 @@ cp .env.example .env
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `PORT` | No | Dev server port (default: 3002) |
+| `MINT_PASCAL_HOST_ORIGIN` | No | Public editor origin used by Mint sign-in and request checks. Set it for self-hosted deployments. |
 
-The editor works fully without any environment variables.
+Local development and the official hosted editor work without any environment variables.
 
 ## Docker
 
@@ -35,6 +36,13 @@ docker compose up -d
 
 The editor will be running at **http://localhost:3000**. Saved scenes live in
 the `pascal-data` volume, so they survive `docker compose down`.
+
+Docker defaults `MINT_PASCAL_HOST_ORIGIN` to `http://localhost:3000`. Override
+it when hosting Pascal at another origin:
+
+```bash
+MINT_PASCAL_HOST_ORIGIN=https://pascal.example.com docker compose up -d
+```
 
 Keep the container port at 3000: the `/scenes` page fetches its own API through
 a base URL that only `NEXT_PUBLIC_APP_URL` can override, and Next inlines that

--- a/apps/editor/app/api/plugins/mint/[...path]/route.ts
+++ b/apps/editor/app/api/plugins/mint/[...path]/route.ts
@@ -1,0 +1,8 @@
+import { handleMintPascalRequest } from '@mint/pascal-plugin/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const route = (request: Request) => handleMintPascalRequest(request)
+
+export { route as GET, route as POST }

--- a/apps/editor/app/api/plugins/mint/[...path]/route.ts
+++ b/apps/editor/app/api/plugins/mint/[...path]/route.ts
@@ -4,6 +4,9 @@ import { BASE_URL } from '@/lib/utils'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const route = (request: Request) => handleMintPascalRequest(request, { origin: BASE_URL })
+const route = (request: Request) =>
+  handleMintPascalRequest(request, {
+    origin: process.env.MINT_PASCAL_HOST_ORIGIN ?? BASE_URL,
+  })
 
 export { route as GET, route as POST }

--- a/apps/editor/app/api/plugins/mint/[...path]/route.ts
+++ b/apps/editor/app/api/plugins/mint/[...path]/route.ts
@@ -1,8 +1,9 @@
 import { handleMintPascalRequest } from '@mint/pascal-plugin/server'
+import { BASE_URL } from '@/lib/utils'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const route = (request: Request) => handleMintPascalRequest(request)
+const route = (request: Request) => handleMintPascalRequest(request, { origin: BASE_URL })
 
 export { route as GET, route as POST }

--- a/apps/editor/app/globals.css
+++ b/apps/editor/app/globals.css
@@ -4,6 +4,7 @@
 @source "../../../packages/editor/src";
 @source "../../../packages/nodes/src";
 @source "../../../node_modules/@pascal-app/plugin-trees/src";
+@source "../../../node_modules/@mint/pascal-plugin/src";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/editor/lib/bootstrap.ts
+++ b/apps/editor/lib/bootstrap.ts
@@ -1,3 +1,4 @@
+import { mintHostPanel, mintPlugin } from '@mint/pascal-plugin'
 import {
   type AnyNodeDefinition,
   discoverPlugins,
@@ -85,6 +86,8 @@ export async function loadExternalPlugins(): Promise<void> {
 // so it is registered separately from the core plugin manifest.
 extendPluginDiscovery(async () => [treesPlugin])
 registerEditorHostPanel(treesHostPanel)
+extendPluginDiscovery(async () => [mintPlugin])
+registerEditorHostPanel(mintHostPanel)
 
 loadBuiltinsSync()
 void loadExternalPlugins()

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -25,6 +25,7 @@ const nextConfig: NextConfig = {
     '@pascal-app/editor',
     '@pascal-app/mcp',
     '@pascal-app/plugin-trees',
+    '@mint/pascal-plugin',
     '@dgreenheck/ez-tree',
   ],
   turbopack: {

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
+    "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#v0.1.4",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",
     "@pascal-app/editor": "*",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#v0.1.4",
+    "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",
     "@pascal-app/editor": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@iconify/react": "^6.0.2",
+        "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#v0.1.4",
         "@number-flow/react": "^0.6.0",
         "@pascal-app/core": "*",
         "@pascal-app/editor": "*",
@@ -507,6 +508,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@mediapipe/tasks-vision": ["@mediapipe/tasks-vision@0.10.17", "", {}, "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="],
+
+    "@mint/pascal-plugin": ["@mint/pascal-plugin@github:mintdotgg/mint-pascal-plugin#bd3248d", { "peerDependencies": { "@pascal-app/core": ">=0.9.2 <1.0.0 || 1.0.0-beta.1 || 1.0.0-beta.3", "@pascal-app/editor": ">=0.9.2 <1.0.0 || 1.0.0-beta.1 || 1.0.0-beta.3", "@pascal-app/viewer": ">=0.9.2 <1.0.0 || 1.0.0-beta.1 || 1.0.0-beta.3", "react": "^18 || ^19", "three": "^0.185" } }, "mintdotgg-mint-pascal-plugin-bd3248d"],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@iconify/react": "^6.0.2",
-        "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#v0.1.4",
+        "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
         "@number-flow/react": "^0.6.0",
         "@pascal-app/core": "*",
         "@pascal-app/editor": "*",
@@ -509,7 +509,7 @@
 
     "@mediapipe/tasks-vision": ["@mediapipe/tasks-vision@0.10.17", "", {}, "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="],
 
-    "@mint/pascal-plugin": ["@mint/pascal-plugin@github:mintdotgg/mint-pascal-plugin#bd3248d", { "peerDependencies": { "@pascal-app/core": ">=0.9.2 <1.0.0 || 1.0.0-beta.1 || 1.0.0-beta.3", "@pascal-app/editor": ">=0.9.2 <1.0.0 || 1.0.0-beta.1 || 1.0.0-beta.3", "@pascal-app/viewer": ">=0.9.2 <1.0.0 || 1.0.0-beta.1 || 1.0.0-beta.3", "react": "^18 || ^19", "three": "^0.185" } }, "mintdotgg-mint-pascal-plugin-bd3248d"],
+    "@mint/pascal-plugin": ["@mint/pascal-plugin@github:mintdotgg/mint-pascal-plugin#902c546", { "peerDependencies": { "@pascal-app/core": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "@pascal-app/editor": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "@pascal-app/viewer": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "react": "^18 || ^19", "three": "^0.185" } }, "mintdotgg-mint-pascal-plugin-902c546"],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - "3000:3000"
     environment:
       NODE_ENV: production
+      # Public editor origin used by Mint OAuth and same-origin checks.
+      MINT_PASCAL_HOST_ORIGIN: ${MINT_PASCAL_HOST_ORIGIN:-http://localhost:3000}
       # Scene database location. Without the volume below, every saved project is
       # discarded when the container is recreated.
       PASCAL_DATA_DIR: /data


### PR DESCRIPTION
## Summary

- Add and register the Mint plugin and editor panel.
- Route Mint OAuth and API requests through one same-origin host endpoint.
- Support trusted runtime origins for self-hosted Pascal deployments.
- Pin Mint plugin v0.1.5 by immutable commit with verified Pascal 1.0.0-beta.4 compatibility.

Mint tokens remain in host-only HttpOnly cookies and are never exposed to the browser package.

## Tested

- `bun check`
- `bun check-types`
- `bun --filter editor build`
- Custom-origin OAuth redirect and forged-forwarded-header smoke tests

Plugin release: https://github.com/mintdotgg/mint-pascal-plugin/releases/tag/v0.1.5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces server-side OAuth/session handling for a third-party integration; token handling depends on the plugin’s HttpOnly cookie design but still expands the auth attack surface.
> 
> **Overview**
> Wires **Mint** into the editor the same way as the trees plugin: **`@mint/pascal-plugin`** is added (GitHub-pinned), **`mintPlugin`** is discovered and **`mintHostPanel`** is registered at bootstrap, and the package is included in **Next transpilation** and **Tailwind `@source`** so its UI styles compile.
> 
> Adds a **same-origin catch-all API route** at `app/api/plugins/mint/[...path]` that delegates GET/POST to **`handleMintPascalRequest`** with the app **`BASE_URL`**, so Mint OAuth and API traffic run through the host rather than the browser bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04b2c220f0bc3f50ca4617a9eb6627ab8bf042f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
