### PR TITLE
fix(editor): scope slab room paint to the clicked slab's level

### DIFF
--- a/packages/editor/src/lib/paint-scope.test.ts
+++ b/packages/editor/src/lib/paint-scope.test.ts
@@ -81,8 +81,8 @@ describe('paintScopeLabel', () => {
 function item(id: string, assetId: string): ItemNode {
   return { id, type: 'item', asset: { id: assetId } } as unknown as ItemNode
 }
-function slab(id: string, polygon: Array<[number, number]>): SlabNode {
-  return { id, type: 'slab', polygon } as unknown as SlabNode
+function slab(id: string, polygon: Array<[number, number]>, levelId = 'l1'): SlabNode {
+  return { id, type: 'slab', polygon, parentId: levelId } as unknown as SlabNode
 }
 function wall(
   id: string,
@@ -450,5 +450,61 @@ describe('resolvePaintScopeTargets', () => {
       spaces: [space],
     })
     expect(keys(result).sort()).toEqual(['inA:surface', 'inB:surface'])
+  })
+
+  it('slab room stops at the level boundary', () => {
+    // Stacked storeys share a footprint, so the upper slab's centroid sits inside
+    // the ground floor's space polygon. Painting downstairs must not reach it.
+    const ground = slab(
+      'ground',
+      [
+        [1, 1],
+        [3, 1],
+        [3, 3],
+        [1, 3],
+      ],
+      'l1',
+    )
+    const upstairs = slab(
+      'upstairs',
+      [
+        [1, 1],
+        [3, 1],
+        [3, 3],
+        [1, 3],
+      ],
+      'l2',
+    )
+    const footprint: Array<[number, number]> = [
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ]
+    const result = resolve({
+      node: ground,
+      role: 'surface',
+      scope: 'room',
+      nodes: [ground, upstairs],
+      spaces: [
+        {
+          id: 's1',
+          levelId: 'l1',
+          polygon: footprint,
+          wallIds: [],
+          boundaryFaces: [],
+          isExterior: false,
+        },
+        {
+          id: 's2',
+          levelId: 'l2',
+          polygon: footprint,
+          wallIds: [],
+          boundaryFaces: [],
+          isExterior: false,
+        },
+      ],
+    })
+    expect(keys(result)).toEqual(['ground:surface'])
   })
 })

--- a/packages/editor/src/lib/paint-scope.ts
+++ b/packages/editor/src/lib/paint-scope.ts
@@ -355,13 +355,19 @@ export function resolvePaintScopeTargets(args: {
   if (node.type === 'slab' && scope === 'room') {
     const centroid = polygonCentroid((node as SlabNode).polygon)
     if (!centroid) return single
-    const space = Object.values(spaces).find((candidate) =>
-      pointInPolygon2D(centroid, candidate.polygon),
+    // Space polygons are per-level footprints, and stacked storeys share a
+    // footprint — so the level has to gate both the space lookup and the fan-out
+    // or one click paints the floor above too.
+    const levelId = node.parentId ?? resolveLevelId(node, nodes)
+    if (!levelId) return single
+    const space = Object.values(spaces).find(
+      (candidate) => candidate.levelId === levelId && pointInPolygon2D(centroid, candidate.polygon),
     )
     if (!space) return single
     return Object.values(nodes)
       .filter((other) => {
         if (other.type !== 'slab') return false
+        if ((other.parentId ?? resolveLevelId(other, nodes)) !== levelId) return false
         const otherCentroid = polygonCentroid((other as SlabNode).polygon)
         return otherCentroid != null && pointInPolygon2D(otherCentroid, space.polygon)
       })


### PR DESCRIPTION
Room-scope paint on a slab spreads to slabs on **other levels**. In a two-storey building — where stacked floors share a footprint by definition — painting a ground-floor slab also repaints the slab directly above it.

Found while reviewing #554; this one is on `main` today and unrelated to that PR.

## Cause

`resolvePaintScopeTargets` gates on `space.levelId` in every wall path — `resolveWallPaintSpace` (`paint-scope.ts:169`), `connectedExteriorBoundaries` (`:205`), `wallTargetsForBoundaries` (`:276`). The slab path gated on nothing: it picked the first space whose polygon contains the slab's centroid, then fanned out to every slab whose centroid falls in that polygon, regardless of level.

Since space polygons are per-level footprints and storeys stack, both lookups match the wrong level as readily as the right one.

## Fix

Gate both the space lookup and the fan-out on the clicked slab's level, using `node.parentId ?? resolveLevelId(...)` — the same definition of level membership space-detection uses (`space-detection.ts:1532` filters a level's slabs by `node.parentId === levelId`).

## Why no test caught it

The existing `slab()` fixture built nodes without `parentId`:

```ts
function slab(id: string, polygon: Array<[number, number]>): SlabNode {
  return { id, type: 'slab', polygon } as unknown as SlabNode
}
```

So the level dimension was invisible to the whole slab suite. Real slabs always carry a parent — `packages/nodes/src/slab/tool.tsx:72` calls `createNode(slab, levelId)`, and reconciliation creates them with `{ node, parentId: levelId }`. The fixture now takes a level (defaulting to `'l1'`, so existing cases are unaffected).

Added `slab room stops at the level boundary`: two slabs with identical polygons on `l1` and `l2`, one space per level. Verified it fails against unpatched `paint-scope.ts` (`["ground:surface", "upstairs:surface"]`) and passes with it.

Only `wall` and `slab` declare `capabilities.paint.roomScope`, and walls were already correct — so this was the only affected kind.

## Gates

`check` 1600 files clean · `check-types` 9/9 · `test` 12/12, paint-scope 27 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized fix to paint target resolution with a regression test; no auth, data, or API surface changes.
> 
> **Overview**
> **Room-scope slab painting** no longer bleeds onto slabs on other storeys when floors share the same footprint.
> 
> `resolvePaintScopeTargets` now resolves the clicked slab’s level (`parentId ?? resolveLevelId`) and uses it for both the space polygon lookup and the fan-out to other slabs—matching how wall room paint already gates on `levelId`.
> 
> Tests: the `slab()` helper sets `parentId` (default `l1`), and **`slab room stops at the level boundary`** asserts stacked `l1`/`l2` slabs with identical polygons only paint the ground slab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7f7032619d9b55ceb9f9ce069251296d6160e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->