### PR TITLE
fix(editor): cap the function-tree category grid so the item list stays reachable

### DIFF
--- a/packages/editor/src/components/ui/sidebar/panels/items-panel/function-tree-panel.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/items-panel/function-tree-panel.tsx
@@ -118,9 +118,14 @@ export function FunctionTreePanel({
     <div className="flex h-full flex-col">
       {/* Root nodes as a category grid — icon when available, otherwise a
           two-letter abbreviation, with the full name in a hover tooltip.
-          Mirrors the Build tab's tile grid so the two panels read the same. */}
+          Mirrors the Build tab's tile grid so the two panels read the same.
+
+          `functionTree` is embedder-supplied and unbounded, and these tiles are
+          `aspect-square`, so row count grows with it while the item list below is
+          the only scroller. Without the cap a large taxonomy pushes the list out
+          of the panel entirely and nothing can scroll it back. */}
       <TooltipProvider delayDuration={0} disableHoverableContent>
-        <div className="grid shrink-0 grid-cols-5 gap-1.5 border-border/70 border-b p-2">
+        <div className="grid max-h-[40%] shrink-0 grid-cols-5 gap-1.5 overflow-y-auto border-border/70 border-b p-2">
           {functionTree.map((root) => {
             const isActive = activeRoot?.slug === root.slug
             return (


### PR DESCRIPTION
The defensive fix I offered @yanrin13 in #562. That issue's bug is in our hosted `RoomsPanel`, which isn't in this repo — but the same layout shape exists here and *is* reachable.

## The shape

`FunctionTreePanel` renders root categories as `grid shrink-0 grid-cols-5` with `aspect-square` tiles (`function-tree-panel.tsx:124`), above the only scroller in the panel:

```tsx
<div className="min-h-0 flex-1 overflow-y-auto p-3">   // :240
```

Column count is fixed at 5, so **row** count is `ceil(functionTree.length / 5)` and each row is as tall as it is wide. Because the header is `shrink-0`, `flex-1` on the list resolves toward zero as the header grows — past roughly 20 categories the list is off-panel with no way to scroll it back.

## Why this one and not its sibling

The other header in this panel family, `furnishTools` (`items-panel/index.tsx:197`), is the same `shrink-0` pattern but is a static 6-item array in `ui/action-menu/furnish-tools.tsx` — bounded by code, so it can't reach this state. I left it alone.

`functionTree` is different: it's a prop, supplied by the embedder (`items-panel/index.tsx:60`, `functionTree: FunctionTreeNode[]`), so its length crosses the embedding boundary and this package can't bound it. That's exactly the invariant #562 broke — a header whose height is driven by data rather than by code.

## Fix

```diff
-<div className="grid shrink-0 grid-cols-5 gap-1.5 border-border/70 border-b p-2">
+<div className="grid max-h-[40%] shrink-0 grid-cols-5 gap-1.5 overflow-y-auto border-border/70 border-b p-2">
```

The header degrades to scrolling instead of consuming the panel. No visual change at today's category counts — `max-h` only engages once the grid would exceed 40% of panel height.

One note: I first wrote this with `subtle-scrollbar`, the class the hosted app and several components here use alongside `overflow-y-auto`. It has no definition anywhere in this repo — it comes from the hosted app's stylesheet — so including it would have been a silent no-op. Dropped it; the scrollbar is the browser default, consistent with other open-source-side scrollers.

## Gates

`check` 1600 files clean · `check-types` 9/9 · `test` 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small layout/CSS fix in the items sidebar with no auth, data, or API changes.
> 
> **Overview**
> **Caps the embedder-supplied root category tile grid** in `FunctionTreePanel` so a large `functionTree` cannot grow the header past the panel and squeeze the item list to zero height.
> 
> The root grid gains `max-h-[40%]` and `overflow-y-auto`, so extra categories scroll inside the header instead of stealing space from the only main scroller below. A comment documents that `functionTree` is unbounded and `aspect-square` tiles make row count scale with data.
> 
> **No behavior change** at typical category counts—the limit only applies when the grid would exceed ~40% of panel height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938220802e952f706cd9b60cfffdcbb390925529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->