### PR TITLE
docs(mcp): make from_brief state how to bind a scene

### DIFF
--- a/packages/mcp/src/prompts/from-brief.ts
+++ b/packages/mcp/src/prompts/from-brief.ts
@@ -6,8 +6,9 @@ import { SCENE_DESIGN_GUIDANCE } from './scene-guidance'
 const PREAMBLE = [
   'You are a Pascal 3D scene designer.',
   'You have access to semantic scene tools and the lower-level `apply_patch` tool. Prefer semantic construction/room/opening/furnishing tools for architectural work, and use `apply_patch` for bulk graph edits that need exact control.',
-  'If the user asks for a new project, call `create_project` before building. Use `create_house_from_brief` for a fast starter, then refine with semantic tools. Semantic tools update the browser-visible draft; call `save_scene` with `saveMode: "checkpoint"` only for meaningful milestones, then call `verify_scene` and `get_project_status`, and return the final `editorUrl`.',
+  'Bind an active scene before mutating anything. Call `create_project` for a new project, `list_scenes` then `load_scene` for an existing one, or `create_house_from_brief` to create and load a starter in one step. Without a bound scene, mutations apply in memory only — they are not persisted and never appear in the browser.',
   'Build incrementally with visible progress. Starting from an empty scene, first create/load a Site and Building, then create occupied Levels and `create_story_shell` once per story before detailed rooms, openings, furniture, a dedicated roof level via `create_roof`, and landscaping.',
+  'Semantic tools update the browser-visible draft. Call `save_scene` with `saveMode: "checkpoint"` only for meaningful milestones, then call `verify_scene` and `get_project_status`, and return the final `editorUrl`.',
   'Respect these invariants:',
   '  - Levels live under a Building.',
   '  - Walls, fences, zones, slabs, ceilings, roofs, stairs live under a Level.',
@@ -33,7 +34,11 @@ export function buildFromBriefPrompt(args: {
   parts.push(
     '',
     '## Task',
-    'Produce tool calls that realise the brief within the stated constraints. For a new project, call create_project first. Use create_house_from_brief for a fast starter or prefer create_story_shell/create_room/add_door/add_window/create_stair_between_levels/create_roof/furnish_room for architectural layout, use apply_patch for exact bulk graph work, call save_scene with saveMode: "checkpoint" only when the design reaches a meaningful milestone, then call validate_scene, verify_scene, and get_project_status.',
+    'Produce tool calls that realise the brief within the stated constraints.',
+    '1. Bind a scene — `create_project` (new), `list_scenes` then `load_scene` (existing), or `create_house_from_brief` (starter template).',
+    '2. Build the design — `create_story_shell` for exterior shells, `create_room`/`add_door`/`add_window`/`create_stair_between_levels`/`furnish_room` for interior layout, `create_roof` for roofing, `apply_patch` for exact bulk graph work.',
+    '3. Finish — call `validate_scene`, `verify_scene`, and `get_project_status`, then return the `editorUrl`.',
+    'Call `save_scene` with `saveMode: "checkpoint"` only when the design reaches a meaningful milestone.',
   )
   return parts.join('\n')
 }
@@ -44,7 +49,7 @@ export function registerFromBrief(server: McpServer, _bridge: SceneOperations): 
     {
       title: 'Generate a Pascal scene from a brief',
       description:
-        'Produces a plan of apply_patch calls to create a scene from a natural-language brief.',
+        'Generate a Pascal 3D scene from a natural-language brief. Binds an active scene, then produces semantic tool calls to realise the design.',
       argsSchema: {
         brief: z.string(),
         constraints: z.string().optional(),

--- a/packages/mcp/src/prompts/prompts.test.ts
+++ b/packages/mcp/src/prompts/prompts.test.ts
@@ -98,6 +98,19 @@ describe('from_brief', () => {
     expect(text).not.toContain('## Constraints')
     expect(text).toContain('Studio')
   })
+
+  test('buildFromBriefPrompt names every way to bind a scene', () => {
+    const text = buildFromBriefPrompt({ brief: 'Studio' })
+    for (const tool of ['create_project', 'list_scenes', 'load_scene', 'create_house_from_brief']) {
+      expect(text).toContain(tool)
+    }
+  })
+
+  test('buildFromBriefPrompt states the consequence of not binding a scene', () => {
+    const text = buildFromBriefPrompt({ brief: 'Studio' }).toLowerCase()
+    expect(text).toContain('in memory only')
+    expect(text).toContain('never appear in the browser')
+  })
 })
 
 describe('iterate_on_feedback', () => {


### PR DESCRIPTION
Salvages the prompt-text portion of #561 with attribution to @Srujanreddy1234, whose report is what surfaced this.

### The gap

`from_brief`'s only guidance about scene binding was conditional on the user's phrasing:

> If the user asks for a new project, call `create_project` before building.

A brief that doesn't read as "new project" — "add a garage", "lay out the second floor" — leaves the model with no instruction to bind anything. `packages/mcp` then runs the mutations against an unbound scene, which is a no-op as far as the user can tell: nothing persists, nothing shows up in the browser, and no tool returns an error. The prompt never mentioned that consequence, so the model had no reason to treat binding as a precondition.

### What changed

- Names all three ways to bind, unconditionally and up front: `create_project` (new), `list_scenes` + `load_scene` (existing), `create_house_from_brief` (create and load a starter in one step). `list_scenes`/`load_scene` were never mentioned at all, which is the actual hole — there was no documented path to an *existing* project.
- States the consequence: *"mutations apply in memory only — they are not persisted and never appear in the browser."* Rules are followed more reliably when the cost of skipping them is stated.
- Splits the save/verify/return-`editorUrl` sequence into its own line. It was appended to the binding sentence, which made a four-clause instruction out of two unrelated ones.
- Task section becomes bind / build / finish. It was a single 90-word line; ordering was there but not legible.
- Fixes the registered tool description, which still advertised *"produces a plan of apply_patch calls."* The prompt has steered toward semantic tools for a while, so the description was describing an older version of itself — and it's the string an MCP client shows when picking a prompt.

Two tests pin the parts that carry the behavior, since prompt text has no other guard against silently regressing: every binding tool is named, and the consequence sentence is present.

### Scope

Prompt strings and one tool description. No runtime change, no tool signature change, no new dependency.

`bun run check` clean (1601 files), `check-types` 9/9, `packages/mcp` tests 326 → 328, 0 fail.

### Relationship to #561

#561 bundled this text with a runtime change to `publishLiveSceneSnapshot()`. That runtime change is worth doing but has four open blockers, the load-bearing one being that gating on `hasStore` breaks `pascal-mcp --stdio` — the README quick start fails on the first `create_wall`. I said in review I'd take the text as its own PR so it wouldn't sit behind that work, so here it is.

#561 stays open for the runtime fix, which stands on its own merits: `publishLiveSceneSnapshot()` returning silently when no scene is bound is a real defect. This PR makes the prompt stop *causing* the unbound state; it doesn't make the unbound state loud, which is what #561 is for.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and description strings only; no runtime, tool signatures, or persistence behavior changes.
> 
> **Overview**
> Updates the **`from_brief`** MCP prompt so models must **bind an active scene before any mutations**, instead of only mentioning `create_project` when the brief sounds like a “new project.”
> 
> The preamble now documents all three paths—**`create_project`**, **`list_scenes` + `load_scene`**, and **`create_house_from_brief`**—and spells out that without binding, edits stay **in memory only** and **never show in the browser**. Save/verify/`editorUrl` guidance is on its own line, and the **## Task** section is reordered into bind → build → finish with semantic tools called out. The registered prompt **description** no longer claims the flow is mainly **`apply_patch`**.
> 
> Two tests lock in that every binding tool is named and the unbound-scene consequence text remains in **`buildFromBriefPrompt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3dbdffc475282335b35463ce7774c4bcb0741a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->