### PR TITLE
fix(core): stabilize collinear wall junction ordering

### DIFF
--- a/packages/core/src/systems/wall/wall-mitering.test.ts
+++ b/packages/core/src/systems/wall/wall-mitering.test.ts
@@ -79,6 +79,21 @@ describe('wall miter boundary sides', () => {
   })
 })
 
+describe('deterministic junction ordering', () => {
+  test('same wall set produces the same miter data regardless of input order', () => {
+    const thickWall = (id: string, thickness: number, end: [number, number]) =>
+      ({ ...wall(id, [0, 0], end), thickness }) as WallNode
+    const wide = thickWall('wide', 0.6, [4, 0])
+    const narrow = thickWall('narrow', 0.2, [4, 0])
+    const branch = thickWall('branch', 0.4, [0, 4])
+
+    const forward = calculateLevelMiters([wide, narrow, branch]).junctionData.get('0,0')
+    const reversed = calculateLevelMiters([narrow, wide, branch]).junctionData.get('0,0')
+
+    expect(forward).toEqual(reversed)
+  })
+})
+
 describe('junction grid prefilter', () => {
   function thickWall(
     id: string,

--- a/packages/core/src/systems/wall/wall-mitering.ts
+++ b/packages/core/src/systems/wall/wall-mitering.ts
@@ -357,8 +357,13 @@ function calculateJunctionIntersections(
     }
   }
 
-  // Sort by outgoing angle
-  processedWalls.sort((a, b) => a.angle - b.angle)
+  // Sort by outgoing angle, then by wall ID so equal-angle walls produce the
+  // same pairing regardless of scene iteration order.
+  processedWalls.sort((a, b) => {
+    const angleOrder = a.angle - b.angle
+    if (angleOrder !== 0) return angleOrder
+    return a.wallId < b.wallId ? -1 : a.wallId > b.wallId ? 1 : 0
+  })
 
   const wallIntersections = new Map<string, { left?: Point2D; right?: Point2D }>()
   const n = processedWalls.length


### PR DESCRIPTION
## Summary

- make exactly-collinear wall junction ordering deterministic by using wall ID as the stable tie-breaker after outgoing angle
- add a regression test that compares the same wall set in forward and reversed input order

Closes #581

## Validation

- `npx --yes bun@1.3.0 test packages/core/src/systems/wall/wall-mitering.test.ts` passed: 12 tests, 0 failures, 145 expectations
- `npx --yes bun@1.3.0 x biome lint packages/core/src/systems/wall/wall-mitering.ts packages/core/src/systems/wall/wall-mitering.test.ts` passed
- `git diff --check` passed

The near-equal-angle epsilon behavior mentioned in the issue is intentionally out of scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to junction sort order in wall rendering geometry; behavior only affects equal-angle cases and is covered by a new test.
> 
> **Overview**
> **Wall miter junctions** at shared corners now sort connected walls by outgoing angle and, when angles match (collinear overlaps), by **wall ID** so adjacent-wall pairing and intersection geometry no longer depend on how walls are ordered in the input array.
> 
> A regression test asserts that `calculateLevelMiters` yields identical `junctionData` for the same wall set in forward vs reversed order at a multi-wall junction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02aae8daf19a417adb3b1ce9ccd22a26dddf0080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->