### PR TITLE
fix: preserve scene materials across every persistence boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Preserve custom scene materials across save, load, clone, fork, and live sync. Materials were dropped at every persistence boundary, so a scene reopened with default surfaces. Collections were dropped on MCP import for the same reason.
+
 ## 1.0.0-beta.1 (2026-07-30)
 
 The first Pascal Editor 1.0 beta. Relative to

--- a/apps/editor/components/scene-loader.tsx
+++ b/apps/editor/components/scene-loader.tsx
@@ -14,6 +14,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { type PersistedSceneGraph, sceneGraphSignature } from '@/lib/scene-signature'
 import { cn } from '@/lib/utils'
 import { BuildTab } from './build-tab'
 import { CommunityViewerToolbarLeft, CommunityViewerToolbarRight } from './viewer-toolbar'
@@ -71,26 +72,13 @@ interface SceneLoaderProps {
   meta: SceneMeta
 }
 
-type SceneGraphWithCollections = SceneGraph & {
-  collections?: Record<string, unknown>
-}
-
 interface LiveSceneEvent {
   eventId: number
   sceneId: string
   version: number
   kind: string
   createdAt: string
-  graph: SceneGraphWithCollections
-}
-
-function sceneGraphSignature(graph: SceneGraphWithCollections): string {
-  return JSON.stringify({
-    nodes: graph.nodes,
-    rootNodeIds: graph.rootNodeIds,
-    collections: graph.collections,
-    installedPlugins: graph.installedPlugins,
-  })
+  graph: PersistedSceneGraph
 }
 
 /**

--- a/apps/editor/lib/graph-schema.test.ts
+++ b/apps/editor/lib/graph-schema.test.ts
@@ -165,3 +165,52 @@ test('treats an unnamespaced unknown type as a foreign node', () => {
       .success,
   ).toBe(false)
 })
+
+const MATERIAL_ID = 'mat_a1b2c3d4e5f6g7h8'
+const material = (overrides: Record<string, unknown> = {}) => ({
+  id: MATERIAL_ID,
+  name: 'Oak',
+  material: { preset: 'wood', ...overrides },
+})
+
+test('keeps materials in the parsed output', () => {
+  const graph = { ...buildGraph({}), materials: { [MATERIAL_ID]: material() } }
+  const res = apiGraphSchema.safeParse(graph)
+
+  expect(res.success).toBe(true)
+  expect(res.data?.materials).toEqual(graph.materials)
+})
+
+// A material's texture is a URL the editor loads, so it is held to the same
+// `AssetUrl` allowlist as every other URL-shaped field in the graph.
+test('rejects a material texture URL outside the allowlist', () => {
+  for (const url of ['ftp://host/a.png', 'javascript:alert(1)']) {
+    const graph = {
+      ...buildGraph({}),
+      materials: { [MATERIAL_ID]: material({ texture: { url } }) },
+    }
+    expect(apiGraphSchema.safeParse(graph).success).toBe(false)
+  }
+})
+
+test('accepts a material texture URL inside the allowlist', () => {
+  const graph = {
+    ...buildGraph({}),
+    materials: {
+      [MATERIAL_ID]: material({ texture: { url: 'https://cdn.example.com/oak.png' } }),
+    },
+  }
+
+  expect(apiGraphSchema.safeParse(graph).success).toBe(true)
+})
+
+// The routes persist this schema's output, so validation must not double as
+// normalization: a save has to store the palette it was handed.
+test('does not rewrite materials it accepts', () => {
+  const sparse = { id: MATERIAL_ID, name: 'Oak', material: { properties: { color: '#886644' } } }
+  const graph = { ...buildGraph({}), materials: { [MATERIAL_ID]: sparse } }
+  const res = apiGraphSchema.safeParse(graph)
+
+  expect(res.success).toBe(true)
+  expect(res.data?.materials?.[MATERIAL_ID]).toEqual(sparse)
+})

--- a/apps/editor/lib/graph-schema.ts
+++ b/apps/editor/lib/graph-schema.ts
@@ -1,4 +1,4 @@
-import { AnyNode, AssetUrl, BaseNode } from '@pascal-app/core/schema'
+import { AnyNode, AssetUrl, BaseNode, SceneMaterial } from '@pascal-app/core/schema'
 import { z } from 'zod'
 
 /**
@@ -100,6 +100,15 @@ export const apiGraphSchema = z
     nodes: z.record(z.string(), z.unknown()),
     rootNodeIds: z.array(z.string()),
     collections: z.unknown().optional(),
+    // `unknown` here, validated in `superRefine` below — the same split the
+    // nodes get, and for the same reason: the routes persist this schema's
+    // *output*, so a validating shape would also rewrite what gets stored.
+    // `SceneMaterial` injects `MaterialProperties` defaults and drops unknown
+    // keys, which would make every save silently normalize the caller's
+    // palette. Materials still have to be checked, because they carry texture
+    // URLs that `MaterialSchema` routes through `AssetUrl` — this schema is
+    // where that allowlist is enforced.
+    materials: z.record(z.string(), z.unknown()).optional(),
     installedPlugins: z.array(z.string().min(1)).optional(),
   })
   .superRefine((value, ctx) => {
@@ -108,6 +117,18 @@ export const apiGraphSchema = z
         ctx.addIssue({
           code: 'custom',
           path: ['nodes', nodeId, ...issue.path],
+          message: issue.message,
+        })
+      }
+    }
+
+    for (const [materialId, material] of Object.entries(value.materials ?? {})) {
+      const res = SceneMaterial.safeParse(material)
+      if (res.success) continue
+      for (const issue of res.error.issues) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['materials', materialId, ...issue.path],
           message: issue.message,
         })
       }

--- a/apps/editor/lib/scene-signature.test.ts
+++ b/apps/editor/lib/scene-signature.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'bun:test'
+import { type PersistedSceneGraph, sceneGraphSignature } from './scene-signature'
+
+const NODE_ID = 'level_a1b2c3d4e5f6g7h8'
+const MATERIAL_ID = 'mat_a1b2c3d4e5f6g7h8'
+
+const graph = (overrides: Partial<PersistedSceneGraph> = {}) =>
+  ({
+    nodes: { [NODE_ID]: { object: 'node', id: NODE_ID, type: 'level', level: 0 } },
+    rootNodeIds: [NODE_ID],
+    ...overrides,
+  }) as PersistedSceneGraph
+
+// The echo check compares a raw SSE payload against the store after
+// `setScene` ran, and `setScene` always writes these three keys. A payload
+// that omits them — which is exactly what MCP live sync sends — must still
+// match, or every remote update looks like a local edit and gets saved back.
+test('an omitted field signs the same as its applied default', () => {
+  expect(sceneGraphSignature(graph())).toBe(
+    sceneGraphSignature(graph({ collections: {}, materials: {}, installedPlugins: [] })),
+  )
+})
+
+// Conversely, every field the save body carries has to be signed. An unsigned
+// field makes a local edit that touches only that field read as an echo, and
+// the save is skipped — the change is silently lost.
+test('changing any signed field changes the signature', () => {
+  const base = sceneGraphSignature(graph())
+
+  expect(
+    sceneGraphSignature(
+      graph({ materials: { [MATERIAL_ID]: { id: MATERIAL_ID, name: 'Oak', material: {} } } }),
+    ),
+  ).not.toBe(base)
+  expect(
+    sceneGraphSignature(graph({ collections: { col_1: { id: 'col_1', nodeIds: [] } } })),
+  ).not.toBe(base)
+  expect(sceneGraphSignature(graph({ installedPlugins: ['@pascal-app/plugin-trees'] }))).not.toBe(
+    base,
+  )
+})

--- a/apps/editor/lib/scene-signature.ts
+++ b/apps/editor/lib/scene-signature.ts
@@ -1,0 +1,27 @@
+import type { SceneGraph } from '@pascal-app/editor'
+
+export type PersistedSceneGraph = SceneGraph & {
+  collections?: Record<string, unknown>
+}
+
+/**
+ * Identity of a graph for echo detection, compared across a boundary that
+ * normalizes: one side is a raw SSE payload, the other is the editor's state
+ * after `applySceneGraphToEditor` ran. `setScene` always writes `collections`,
+ * `materials` and `installedPlugins`, so a payload that omits them (MCP live
+ * sync emits exactly that) has to serialize the same as the store that
+ * defaulted them, or the echo reads as a local edit and gets saved back.
+ *
+ * Every field the PUT body carries has to appear here. A field that is
+ * persisted but unsigned makes a local change to *only* that field
+ * indistinguishable from an echo, and the save is skipped.
+ */
+export function sceneGraphSignature(graph: PersistedSceneGraph): string {
+  return JSON.stringify({
+    nodes: graph.nodes,
+    rootNodeIds: graph.rootNodeIds,
+    collections: graph.collections ?? {},
+    materials: graph.materials ?? {},
+    installedPlugins: graph.installedPlugins ?? [],
+  })
+}

--- a/packages/core/src/utils/clone-scene-graph.test.ts
+++ b/packages/core/src/utils/clone-scene-graph.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { CollectionId } from '../schema/collections'
+import type { SceneMaterialId } from '../schema/scene-material'
 import type { AnyNode, AnyNodeId } from '../schema/types'
 import {
   cloneLevelSubtree,
@@ -46,9 +47,48 @@ function makeSceneGraph(): SceneGraph {
         nodeIds: ['scan_1', 'guide_1'] as AnyNodeId[],
       },
     },
+    materials: {
+      ['mat_1' as SceneMaterialId]: {
+        id: 'mat_1',
+        name: 'Oak',
+        material: { preset: 'wood' },
+      },
+    },
     installedPlugins: ['pascal:trees'],
   }
 }
+
+describe('scene material palette', () => {
+  // Nodes reference materials through `slots` values shaped `scene:mat_…`.
+  // Those are opaque strings to the node remapping, so the ids they point at
+  // have to survive a clone unchanged or every reference dangles.
+  test('cloneSceneGraph carries materials over with their ids intact', () => {
+    const source = makeSceneGraph()
+    const cloned = cloneSceneGraph(source)
+
+    expect(cloned.materials).toEqual(source.materials)
+  })
+
+  test('cloneSceneGraph deep-copies materials', () => {
+    const source = makeSceneGraph()
+    const cloned = cloneSceneGraph(source)
+    const material = cloned.materials?.['mat_1' as SceneMaterialId]
+    expect(material).toBeDefined()
+    if (!material) return
+
+    material.name = 'Mutated'
+    expect(source.materials?.['mat_1' as SceneMaterialId]?.name).toBe('Oak')
+  })
+
+  // A palette entry is authored content in its own right. Stripping the scan
+  // node that happened to use it must not take the material with it.
+  test('forkSceneGraph keeps materials when stripping scans', () => {
+    const source = makeSceneGraph()
+    const forked = forkSceneGraph(source)
+
+    expect(forked.materials).toEqual(source.materials)
+  })
+})
 
 describe('forkSceneGraph', () => {
   test('strips scan and guide nodes by default', () => {

--- a/packages/core/src/utils/clone-scene-graph.ts
+++ b/packages/core/src/utils/clone-scene-graph.ts
@@ -6,11 +6,13 @@ import {
 import type { AnyNode, AnyNodeId } from '../schema'
 import { generateId } from '../schema/base'
 import type { Collection, CollectionId } from '../schema/collections'
+import type { SceneMaterial, SceneMaterialId } from '../schema/scene-material'
 
 export type SceneGraph = {
   nodes: Record<AnyNodeId, AnyNode>
   rootNodeIds: AnyNodeId[]
   collections?: Record<CollectionId, Collection>
+  materials?: Record<SceneMaterialId, SceneMaterial>
   installedPlugins?: string[]
 }
 
@@ -32,7 +34,7 @@ function extractIdPrefix(id: string): string {
  * - Multi-scene in-memory scenarios
  */
 export function cloneSceneGraph(sceneGraph: SceneGraph): SceneGraph {
-  const { nodes, rootNodeIds, collections, installedPlugins } = sceneGraph
+  const { nodes, rootNodeIds, collections, materials, installedPlugins } = sceneGraph
 
   // Build ID mapping: old ID -> new ID
   const idMap = new Map<string, string>()
@@ -164,6 +166,12 @@ export function cloneSceneGraph(sceneGraph: SceneGraph): SceneGraph {
     nodes: clonedNodes,
     rootNodeIds: clonedRootNodeIds,
     ...(clonedCollections && { collections: clonedCollections }),
+    // Material ids are deliberately *not* remapped. Nodes point at these
+    // through `slots` values shaped `scene:mat_…` — opaque strings that the
+    // node remapping above copies verbatim, since `idMap` only covers node
+    // ids. Minting fresh material ids here would orphan every one of those
+    // refs and the clone would render with default materials.
+    ...(materials && { materials: structuredClone(materials) }),
     ...(installedPlugins && { installedPlugins: [...installedPlugins] }),
   }
 }
@@ -304,7 +312,7 @@ export function forkSceneGraph(
     return cloneSceneGraph(sceneGraph)
   }
 
-  const { nodes, rootNodeIds, collections, installedPlugins } = sceneGraph
+  const { nodes, rootNodeIds, collections, materials, installedPlugins } = sceneGraph
 
   // First, identify scan and guide node IDs to exclude (user-uploaded imagery)
   const excludedNodeIds = new Set<string>()
@@ -366,6 +374,11 @@ export function forkSceneGraph(
     nodes: filteredNodes,
     rootNodeIds: filteredRootNodeIds,
     ...(filteredCollections && { collections: filteredCollections }),
+    // Kept whole rather than filtered to the surviving nodes: a palette entry
+    // is authored content in its own right, and dropping the scan node that
+    // happened to be its only user would silently delete a material the fork's
+    // owner can still pick from the palette.
+    ...(materials && { materials }),
     ...(installedPlugins && { installedPlugins }),
   })
 }

--- a/packages/mcp/src/bridge/scene-bridge.test.ts
+++ b/packages/mcp/src/bridge/scene-bridge.test.ts
@@ -439,6 +439,29 @@ describe('SceneBridge', () => {
       expect(bridge.exportJSON().installedPlugins).toEqual(['pascal:trees'])
     })
 
+    // `setScene` resets `collections` and `materials` to `{}` unless they are
+    // in its `extra` bag, so anything applied after it is silently discarded.
+    // These two round trips are what catch a regression back to that.
+    test('loadJSON round-trips the material palette', () => {
+      const materials = {
+        mat_1: { id: 'mat_1', name: 'Oak', material: { preset: 'wood' } },
+      }
+      bridge.loadJSON({ ...bridge.exportJSON(), materials } as never)
+
+      expect(bridge.exportJSON().materials).toEqual(materials)
+    })
+
+    test('loadJSON round-trips collections', () => {
+      const snap = bridge.exportJSON()
+      const nodeId = Object.keys(snap.nodes)[0]!
+      const collections = {
+        collection_1: { id: 'collection_1', name: 'Refs', nodeIds: [nodeId] },
+      }
+      bridge.loadJSON({ ...snap, collections } as never)
+
+      expect(bridge.exportJSON().collections).toEqual(collections)
+    })
+
     test('legacy graphs do not become explicitly uninstalled on export', () => {
       const snap = bridge.exportJSON()
       const { installedPlugins: _installedPlugins, ...legacy } = snap

--- a/packages/mcp/src/bridge/scene-bridge.ts
+++ b/packages/mcp/src/bridge/scene-bridge.ts
@@ -20,6 +20,9 @@ export type ActiveSceneMeta = Pick<
   'id' | 'name' | 'projectId' | 'ownerId' | 'thumbnailUrl' | 'version'
 >
 
+/** The `extra` bag `setScene` accepts — collections, materials, plugin state. */
+type SetSceneExtra = Parameters<ReturnType<typeof useScene.getState>['setScene']>[2]
+
 /**
  * Headless bridge to the `@pascal-app/core` Zustand store.
  *
@@ -59,11 +62,15 @@ export class SceneBridge {
   }
 
   /** Replace entire scene (undoable via Zundo). */
-  setScene(nodes: Record<AnyNodeId, AnyNode>, rootNodeIds: AnyNodeId[]): void {
-    useScene.getState().setScene(nodes, rootNodeIds)
+  setScene(
+    nodes: Record<AnyNodeId, AnyNode>,
+    rootNodeIds: AnyNodeId[],
+    extra?: SetSceneExtra,
+  ): void {
+    useScene.getState().setScene(nodes, rootNodeIds, extra)
   }
 
-  /** Full snapshot for export, including collections. */
+  /** Full snapshot for export, including collections and the material palette. */
   exportJSON(): SceneGraph & { collections: Record<string, unknown> } {
     const state = useScene.getState()
     // Deep-clone so callers can't mutate store state directly.
@@ -72,6 +79,7 @@ export class SceneBridge {
         nodes: state.nodes,
         rootNodeIds: state.rootNodeIds,
         collections: state.collections ?? {},
+        materials: state.materials ?? {},
         ...(state.hasExplicitPluginInstallState || state.installedPlugins.length > 0
           ? { installedPlugins: state.installedPlugins }
           : {}),
@@ -119,13 +127,25 @@ export class SceneBridge {
       }
     }
 
-    this.setScene(nodes as Record<AnyNodeId, AnyNode>, rootNodeIds as AnyNodeId[])
-    if (Array.isArray(obj.installedPlugins)) {
-      useScene.getState().setInstalledPlugins(
-        obj.installedPlugins.filter((id): id is string => typeof id === 'string'),
-        { explicit: true },
-      )
-    }
+    const record = (value: unknown) =>
+      value && typeof value === 'object' && !Array.isArray(value) ? value : undefined
+    const collections = record(obj.collections) as NonNullable<SetSceneExtra>['collections']
+    const materials = record(obj.materials) as NonNullable<SetSceneExtra>['materials']
+    const installedPlugins = Array.isArray(obj.installedPlugins)
+      ? obj.installedPlugins.filter((id): id is string => typeof id === 'string')
+      : undefined
+
+    // One `setScene` call rather than a follow-up `setInstalledPlugins`:
+    // `setScene` overwrites `collections` and `materials` with `{}` whenever
+    // they aren't in the `extra` bag, so anything applied afterwards is lost.
+    // It also marks every node dirty at the end, and `markDirty` skips nodes
+    // whose plugin isn't installed — so plugin state has to be in place by
+    // then or plugin-owned nodes never get validated.
+    this.setScene(nodes as Record<AnyNodeId, AnyNode>, rootNodeIds as AnyNodeId[], {
+      ...(collections && { collections }),
+      ...(materials && { materials }),
+      ...(installedPlugins && { installedPlugins, hasExplicitPluginInstallState: true }),
+    })
   }
 
   /** Read a single node, or `null` if not present. */

--- a/packages/mcp/src/operations/scene-operations.test.ts
+++ b/packages/mcp/src/operations/scene-operations.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { SceneGraph } from '@pascal-app/core/clone-scene-graph'
+import { SceneBridge } from '../bridge/scene-bridge'
 import { SqliteSceneStore } from '../storage/sqlite-scene-store'
 import { createSceneOperations } from './scene-operations'
 
@@ -75,5 +76,19 @@ describe('SceneOperationsFacade scene events', () => {
       }),
     ).toBeNull()
     await expect(operations.listSceneEvents('live')).rejects.toThrow('scene_events_unavailable')
+  })
+})
+
+// `exportSceneGraph` hand-copies fields off `exportJSON`, so a field it omits
+// is dropped from everything that persists through it — `save_scene`,
+// `publishLiveSceneSnapshot`, and variant generation.
+describe('SceneOperationsFacade exportSceneGraph', () => {
+  test('carries the material palette off the bridge', () => {
+    const bridge = new SceneBridge()
+    const materials = { mat_1: { id: 'mat_1', name: 'Oak', material: { preset: 'wood' } } }
+    bridge.loadJSON({ ...makeGraph(), materials } as never)
+    const operations = createSceneOperations({ bridge })
+
+    expect(operations.exportSceneGraph().materials).toEqual(materials)
   })
 })

--- a/packages/mcp/src/operations/scene-operations.ts
+++ b/packages/mcp/src/operations/scene-operations.ts
@@ -150,6 +150,7 @@ class SceneOperationsFacade implements SceneOperations {
       nodes: exported.nodes,
       rootNodeIds: exported.rootNodeIds,
       collections: exported.collections as SceneGraph['collections'],
+      materials: exported.materials,
       installedPlugins: exported.installedPlugins,
     }
   }

--- a/packages/mcp/src/storage/sqlite-scene-store.test.ts
+++ b/packages/mcp/src/storage/sqlite-scene-store.test.ts
@@ -113,6 +113,40 @@ describe('SqliteSceneStore', () => {
     expect(loaded!.name).toBe('Kitchen')
   })
 
+  // `GraphSchema` strips any key it doesn't name, so a field missing from it
+  // is dropped on load without an error — the save looks like it worked.
+  test('round-trips collections, materials and installed plugins', async () => {
+    const graph = makeGraph({
+      collections: {
+        collection_1: { id: 'collection_1', name: 'Refs', nodeIds: ['site_abc'] },
+      } as SceneGraph['collections'],
+      materials: {
+        mat_1: { id: 'mat_1', name: 'Oak', material: { preset: 'wood' } },
+      } as SceneGraph['materials'],
+      installedPlugins: ['pascal:trees'],
+    })
+    await store.save({ id: 'full', name: 'Full', graph })
+
+    store.close()
+    store = createStore(rootDir)
+
+    expect((await store.load('full'))?.graph).toEqual(graph)
+  })
+
+  // Nothing validates a graph on the way in, and `parseGraph` throws on a
+  // shape mismatch, so a strict read schema would make an odd stored value
+  // permanently unloadable rather than merely odd.
+  test('loads a stored scene whose material does not match the strict schema', async () => {
+    const graph = makeGraph({
+      materials: {
+        mat_1: { id: 'mat_1', material: { texture: { url: 'ftp://host/a.png' } } },
+      } as unknown as SceneGraph['materials'],
+    })
+    await store.save({ id: 'odd', name: 'Odd', graph })
+
+    expect((await store.load('odd'))?.graph).toEqual(graph)
+  })
+
   test('stores optional metadata verbatim', async () => {
     await store.save({
       id: 'meta-test',

--- a/packages/mcp/src/storage/sqlite-scene-store.ts
+++ b/packages/mcp/src/storage/sqlite-scene-store.ts
@@ -70,10 +70,18 @@ interface ProjectPlaceholder {
   updatedAt: string
 }
 
+// `z.object()` strips keys it doesn't name, so every field that must survive a
+// save→load round trip has to be listed here. Values stay `unknown` rather than
+// being validated against `SceneMaterial`/`Collection`: nothing validates on the
+// way in, and `parseGraph` throws, so a strict shape here would let one odd
+// stored value make a saved scene permanently unloadable. Validation belongs on
+// the write path, where the caller can still react to it.
 const GraphSchema = z.object({
   nodes: z.record(z.string(), z.unknown()),
   rootNodeIds: z.array(z.string()),
   collections: z.record(z.string(), z.unknown()).optional(),
+  materials: z.record(z.string(), z.unknown()).optional(),
+  installedPlugins: z.array(z.string()).optional(),
 })
 
 /**


### PR DESCRIPTION
Rebased and reworked version of #560, co-authored with @ShiroKSH, whose diagnosis and layering this follows. Closes #560.

### The bug

A custom scene material survived nothing. `materials` was missing from the `SceneGraph` type, so every layer that rebuilds a graph field-by-field silently omitted it. Reopen a scene and it came back with default surfaces.

Probed on `main` before touching anything — all eight of these dropped the palette:

| Boundary | On `main` |
|---|---|
| `cloneSceneGraph` | keys: `collections, installedPlugins, nodes, rootNodeIds` |
| `forkSceneGraph` | same |
| bridge `exportJSON` | same |
| bridge `loadJSON` | `materials` → `{}` |
| bridge `loadJSON` | **`collections` → `{}`** (see below) |
| `exportSceneGraph` | `materials` absent — this is the MCP persist path |
| SQLite `save` → `load` | `z.object()` strips it |
| API `graph-schema` | `z.object()` strips it |

Nodes reference materials through `slots` values shaped `scene:mat_…`. Those are opaque strings to the clone remapping, so material ids are carried over **unchanged** — minting fresh ones would orphan every reference and the clone would render with defaults anyway.

### Two bugs found while fixing the round trip

**1. `loadJSON` dropped collections too**, for a different reason than materials. It applied plugin state in a second call *after* `setScene`, and `setScene` resets `collections` and `materials` to `{}` whenever they aren't in its `extra` bag — so anything applied afterwards is discarded. Everything now goes in one call.

That also fixes dirty-tracking for plugin-owned nodes: `setScene` marks every node dirty at the end, and `markDirty` returns early for a node whose plugin isn't in `installedPlugins`. Installing plugins afterwards meant those nodes were never marked, so they never got validated.

**2. The echo-suppression signature omitted `materials`, which lost user edits.** `scene-loader.tsx` skips a save when the graph signature matches the last remote payload. Since the signature ignored `materials`, a local edit that touched *only* the palette signed identically to that payload — so it read as an echo and the save was skipped. Verified against main's signature function: a material-only change produced a byte-identical signature.

The signature now also defaults the three fields `setScene` unconditionally writes. Without that, a payload that omits them — which is exactly what MCP live sync sends — can never match the store that defaulted them, so every remote update looks like a local edit and gets saved back, bumping the version. `scene-signature.ts` exists so this is testable; the two tests there both fail against main's version.

### Where materials get validated

At the network boundary, not on read-back:

- **API schema** (`graph-schema.ts`) holds materials to `SceneMaterial` in `superRefine`. They carry texture URLs, and `MaterialSchema` routes every one through `AssetUrl` — this schema is where that allowlist is enforced, so passing materials through as `unknown` would have reopened the Phase 3 risk on a field the editor loads. Confirmed `ftp://` and `javascript:` are rejected.
- It validates **without transforming**, matching how nodes are already handled here. The routes persist this schema's *output*, and `SceneMaterial` injects `MaterialProperties` defaults and strips unknown keys — so a validating shape would make every save silently rewrite the caller's palette. Measured: a sparse material grew from 1 property to 6.
- **SQLite read path stays permissive** (`z.record(z.string(), z.unknown())`). Nothing validates on write and `parseGraph` *throws*, so a strict read shape would turn one odd stored value into a permanently unloadable scene. There's a test that saves a material with an `ftp://` texture and asserts it still loads — a stored row must never become unreadable. This is the one place I diverged from #560, which put `SceneMaterial` on the read path.

### Verification

End-to-end probe over the real store, all eight boundaries — every one failed on `main`, all pass here:

```
PASS  cloneSceneGraph keeps materials          PASS  exportSceneGraph keeps materials
PASS  forkSceneGraph keeps materials           PASS  sqlite save->reopen->load keeps materials
PASS  bridge loadJSON->exportJSON materials    PASS  sqlite keeps collections
PASS  bridge loadJSON->exportJSON collections  PASS  sqlite keeps installedPlugins
```

Full CI gate green locally: `bun run check` 1603 files clean, `check-types` 9/9, `bun run test` 12/12 tasks, `bun run build` 7/7.

11 tests added across the five layers, each pinning a boundary that silently dropped data rather than erroring — that's the failure mode here, so a type alone wouldn't hold the line.

### Credit

The diagnosis is @ShiroKSH's, and so is the call to fix it in `packages/core` and `packages/mcp` rather than only in `apps/editor` — that matters, because the hosted app forks scenes through `@pascal-app/core/clone-scene-graph`, so an app-only fix would have left both npm consumers and production broken. What I changed from #560: kept the echo-suppression timer instead of removing it, moved material validation from the SQLite read path to the API write path, dropped the one-line `isRemoteSceneEcho` wrapper, and rebased onto the 1.0-beta CHANGELOG.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scene persistence, live-sync save suppression, and API graph validation (material texture URLs); behavior is well covered by new boundary tests but mistakes could still lose data or reject saves.
> 
> **Overview**
> Fixes custom **scene materials** being stripped whenever a graph crossed a persistence boundary (save/load, clone/fork, MCP export/import, SQLite round-trip, API validation). **`materials`** is now part of the core `SceneGraph` and is deep-copied on clone/fork with **stable material ids** (node `scene:mat_…` refs are not remapped).
> 
> **MCP bridge:** `exportJSON` / `exportSceneGraph` include materials; **`loadJSON`** passes collections, materials, and `installedPlugins` in a **single** `setScene` `extra` bag so they are not wiped when `setScene` defaults missing fields.
> 
> **Editor:** Shared **`sceneGraphSignature`** includes `materials`, `collections`, and `installedPlugins` (with defaults matching `setScene`) so live-sync echo suppression does not skip saves for palette-only changes or treat every remote update as local.
> 
> **API `apiGraphSchema`:** Accepts and validates materials via `SceneMaterial.safeParse` (texture URLs / `AssetUrl`) **without normalizing** stored palette entries. **SQLite `GraphSchema`** lists `materials` (and `installedPlugins`) for round-trip but stays permissive on read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a80faee9305fbcc848f46f8f823093f02f8ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->