### PR TITLE
docs(changelog): credit the junction-determinism and scene-materials fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- Preserve custom scene materials across save, load, clone, fork, and live sync. Materials were dropped at every persistence boundary, so a scene reopened with default surfaces. Collections were dropped on MCP import for the same reason.
+- Preserve custom scene materials across save, load, clone, fork, and live sync. Materials were dropped at every persistence boundary, so a scene reopened with default surfaces. Collections were dropped on MCP import for the same reason ([#597](https://github.com/pascalorg/editor/pull/597)) by [@ShiroKSH](https://github.com/ShiroKSH)
+- Wall junction mitering is now deterministic for exactly-collinear walls, so identical scenes produce identical geometry regardless of node iteration order ([#596](https://github.com/pascalorg/editor/pull/596)) by [@tomatotomata](https://github.com/tomatotomata)
 
 ## 1.0.0-beta.1 (2026-07-30)
 


### PR DESCRIPTION
Housekeeping. #596 and #597 both landed without a `## Unreleased` line.

Adds an entry for #596 and credits [@tomatotomata](https://github.com/tomatotomata), and adds the PR link plus [@ShiroKSH](https://github.com/ShiroKSH)'s credit to the materials entry that #597 added. Matches the 0.6.0 `… ([#N](link)) by [@user](link)` format.

The release notes are how credit for an outside fix actually surfaces, so it's worth keeping current rather than reconstructing it from `git log` at release time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only housekeeping with no runtime or build impact.
> 
> **Overview**
> Updates **`CHANGELOG.md`** under **Unreleased → Fixes** so recently merged fixes are credited in release notes.
> 
> The existing custom scene materials bullet now includes the ([#597](https://github.com/pascalorg/editor/pull/597)) link and **@ShiroKSH** attribution. A new bullet documents deterministic wall junction mitering for collinear walls ([#596](https://github.com/pascalorg/editor/pull/596)) with credit to **@tomatotomata**, matching the `0.6.0` `… ([#N](link)) by [@user](link)` format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f40b1aa8ae4ea2b2dc7eeb645682b84a8e72d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->