### PR TITLE
nodes: stop tracking elevator dirty state

### DIFF
--- a/packages/nodes/src/elevator/definition.test.ts
+++ b/packages/nodes/src/elevator/definition.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  type AnyNodeDefinition,
+  type AnyNodeId,
+  ElevatorNode,
+  nodeRegistry,
+  registerNode,
+  useScene,
+} from '@pascal-app/core'
+import { elevatorDefinition } from './definition'
+
+describe('elevatorDefinition', () => {
+  // The elevator has no dirty consumer: it ships no `def.geometry` (so
+  // GeometrySystem skips it and never calls clearDirty), and none of its
+  // three systems (runtime / interaction / opening) read `dirtyNodes`.
+  // Without the opt-out, the scene-load full markDirty leaves the elevator
+  // permanently dirty — perf HUD shows "DIRTY 1", the frame limiter never
+  // sees an idle scene (elevator has `def.system`, so its dirty mark counts
+  // as pending render work), and post-processing scheduling sees a non-zero
+  // dirty count forever.
+  test('opts out of dirty tracking — no system ever clears its dirty mark', () => {
+    expect(elevatorDefinition.dirtyTracking).toBe(false)
+  })
+
+  describe('markDirty with the registered definition', () => {
+    beforeEach(() => {
+      nodeRegistry._reset()
+      registerNode(elevatorDefinition as unknown as AnyNodeDefinition)
+    })
+
+    afterEach(() => {
+      nodeRegistry._reset()
+    })
+
+    // Membership asserts (not set size/equality): the scene store is a module
+    // singleton, and subscribers leaked by other test files can add their own
+    // dirty marks when `setState` fires.
+    test('scene-load style markDirty leaves no permanent elevator residue', () => {
+      const elevator = ElevatorNode.parse({
+        id: 'elevator_dirty_test' as never,
+        type: 'elevator',
+      })
+      useScene.setState({
+        nodes: { [elevator.id]: elevator } as never,
+        rootNodeIds: [elevator.id],
+        dirtyNodes: new Set<AnyNodeId>(),
+      } as never)
+
+      useScene.getState().markDirty(elevator.id as AnyNodeId)
+
+      expect(useScene.getState().dirtyNodes.has(elevator.id as AnyNodeId)).toBe(false)
+    })
+  })
+})

--- a/packages/nodes/src/elevator/definition.ts
+++ b/packages/nodes/src/elevator/definition.ts
@@ -242,6 +242,9 @@ export const elevatorDefinition: NodeDefinition<typeof ElevatorNode> = {
   parametrics: elevatorParametrics,
   handles: elevatorHandles,
 
+  // No dirty consumer rebuilds this kind — see NodeDefinition.dirtyTracking.
+  dirtyTracking: false,
+
   renderer: {
     kind: 'parametric',
     module: () => import('./renderer'),


### PR DESCRIPTION
## What does this PR do?

Stops renderer-driven elevator nodes from entering the shared `dirtyNodes` rebuild queue. Elevators have no `def.geometry`, `capabilities.floorPlaced`, or legacy dirty consumer, so scene-load and mutation marks were never cleared and the performance HUD remained at `DIRTY 1 (1 elevator)`. The definition now uses the existing `dirtyTracking: false` contract, with a regression test covering both the declaration and scene-load-style `markDirty` behavior.

## How to test

1. Run `bun test packages/core/src/store/use-scene-dirty-tracking.test.ts packages/core/src/store/use-scene-elevator-migration.test.ts packages/core/src/systems/elevator packages/nodes/src/elevator/definition.test.ts`; expect 17 passing tests.
2. Run `bun test packages/nodes/src`; expect 946 passing tests, 1 skipped, and 0 failures.
3. Run `bunx turbo run build --filter=@pascal-app/nodes...` and `bun run check`; expect the Core, Viewer, and Nodes builds plus Biome checks to pass.

## Screenshots / screen recording

N/A — internal dirty-queue scheduling fix; no editor UI or elevator geometry output changes.

## Checklist

- [ ] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to dirty-queue bookkeeping for one node kind; no auth, data, or elevator geometry/rendering logic changes.
> 
> **Overview**
> Sets **`dirtyTracking: false`** on the elevator node definition so scene-load and mutation **`markDirty`** calls no longer leave elevators in the shared **`dirtyNodes`** queue.
> 
> Elevators have no geometry rebuild or other dirty consumer that clears those marks, which previously kept the perf HUD at **DIRTY 1**, blocked idle-frame detection (elevator **`def.system`** counts as pending work), and skewed post-processing scheduling. A new **`definition.test.ts`** asserts the flag and that registered **`markDirty`** does not retain the elevator id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c59acaa3e14c7c4da7d56db4839fab15d5ca47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->