### PR TITLE
fix(ifc): avoid merging adjacent wall assemblies

### DIFF
--- a/packages/ifc-converter/src/cleanup.ts
+++ b/packages/ifc-converter/src/cleanup.ts
@@ -199,11 +199,21 @@ function toWallSegment(wall: WallNode): WallSegment | null {
 }
 
 function wallLineTolerance(a: WallSegment, b: WallSegment) {
-  return Math.max(0.06, Math.min(0.14, Math.max(a.thickness, b.thickness) * 0.5))
+  // Fragments must share essentially the same centerline. A tolerance based on
+  // half the wall thickness can collapse adjacent walls whose faces merely meet.
+  return Math.max(0.005, Math.min(0.025, Math.max(a.thickness, b.thickness) * 0.1))
 }
 
 function wallHeightCompatible(a: WallSegment, b: WallSegment) {
   return Math.abs(a.height - b.height) <= WALL_HEIGHT_TOLERANCE
+}
+
+function wallMaterialCompatible(a: WallSegment, b: WallSegment) {
+  const materialA = (a.wall.metadata as { material?: unknown } | undefined)?.material
+  const materialB = (b.wall.metadata as { material?: unknown } | undefined)?.material
+  const nameA = typeof materialA === 'string' ? materialA : null
+  const nameB = typeof materialB === 'string' ? materialB : null
+  return nameA === nameB
 }
 
 function wallIntervalsCompatible(a: WallSegment, b: WallSegment, maxJoinGap: number) {
@@ -220,6 +230,7 @@ function wallsCanMerge(a: WallSegment, b: WallSegment, maxJoinGap: number) {
   if (Math.abs(a.angleBucket - b.angleBucket) > 1) return false
   if (Math.abs(a.offset - b.offset) > wallLineTolerance(a, b)) return false
   if (!wallHeightCompatible(a, b)) return false
+  if (!wallMaterialCompatible(a, b)) return false
   return wallIntervalsCompatible(a, b, maxJoinGap)
 }
 

--- a/packages/ifc-converter/src/cleanup.ts
+++ b/packages/ifc-converter/src/cleanup.ts
@@ -208,12 +208,26 @@ function wallHeightCompatible(a: WallSegment, b: WallSegment) {
   return Math.abs(a.height - b.height) <= WALL_HEIGHT_TOLERANCE
 }
 
+function wallMaterialSignature(segment: WallSegment): string | null {
+  const metadata = segment.wall.metadata as
+    | { material?: unknown; materialLayers?: unknown }
+    | undefined
+  const material = typeof metadata?.material === 'string' ? metadata.material : null
+  const layers = Array.isArray(metadata?.materialLayers)
+    ? metadata.materialLayers.map((layer) => {
+        const value = layer as { name?: unknown; thickness?: unknown }
+        return [
+          typeof value.name === 'string' ? value.name : null,
+          typeof value.thickness === 'number' ? value.thickness : null,
+        ]
+      })
+    : []
+  if (material === null && layers.length === 0) return null
+  return JSON.stringify({ material, layers })
+}
+
 function wallMaterialCompatible(a: WallSegment, b: WallSegment) {
-  const materialA = (a.wall.metadata as { material?: unknown } | undefined)?.material
-  const materialB = (b.wall.metadata as { material?: unknown } | undefined)?.material
-  const nameA = typeof materialA === 'string' ? materialA : null
-  const nameB = typeof materialB === 'string' ? materialB : null
-  return nameA === nameB
+  return wallMaterialSignature(a) === wallMaterialSignature(b)
 }
 
 function wallIntervalsCompatible(a: WallSegment, b: WallSegment, maxJoinGap: number) {

--- a/packages/ifc-converter/tests/cleanup.test.ts
+++ b/packages/ifc-converter/tests/cleanup.test.ts
@@ -130,6 +130,69 @@ describe('simplifyConvertedSceneGraph', () => {
     expect(Object.values(nodes).filter((node) => node.type === 'wall')).toHaveLength(2)
   })
 
+  it('does not merge walls with different IFC material layer assemblies', () => {
+    const exterior = wall('wall_exterior', [0, 0], [2, 0])
+    const interior = wall('wall_interior', [2.9, 0], [5, 0])
+    exterior.metadata = {
+      materialLayers: [
+        { name: 'Gypsum', thickness: 0.013 },
+        { name: 'Stud', thickness: 0.09 },
+      ],
+    }
+    interior.metadata = {
+      materialLayers: [
+        { name: 'Gypsum', thickness: 0.013 },
+        { name: 'Concrete', thickness: 0.2 },
+      ],
+    }
+    const nodes: Record<string, AnyNode> = {
+      level_1: level('level_1', ['wall_exterior', 'wall_interior']),
+      wall_exterior: exterior,
+      wall_interior: interior,
+    }
+
+    const stats = simplifyConvertedSceneGraph(nodes)
+
+    expect(stats.removedMergedWalls).toBe(0)
+    expect(Object.values(nodes).filter((node) => node.type === 'wall')).toHaveLength(2)
+  })
+
+  it('does not merge a layer-tagged wall with an untagged wall', () => {
+    const tagged = wall('wall_tagged', [0, 0], [2, 0])
+    tagged.metadata = { materialLayers: [{ name: 'Concrete', thickness: 0.2 }] }
+    const nodes: Record<string, AnyNode> = {
+      level_1: level('level_1', ['wall_tagged', 'wall_unknown']),
+      wall_tagged: tagged,
+      wall_unknown: wall('wall_unknown', [2.9, 0], [5, 0]),
+    }
+
+    const stats = simplifyConvertedSceneGraph(nodes)
+
+    expect(stats.removedMergedWalls).toBe(0)
+    expect(Object.values(nodes).filter((node) => node.type === 'wall')).toHaveLength(2)
+  })
+
+  it('merges walls with identical IFC material layer assemblies', () => {
+    const first = wall('wall_a', [0, 0], [2, 0])
+    const second = wall('wall_b', [2.9, 0], [5, 0])
+    const materialLayers = [
+      { name: 'Gypsum', thickness: 0.013 },
+      { name: 'Stud', thickness: 0.09 },
+    ]
+    first.metadata = { materialLayers }
+    second.metadata = { materialLayers: [...materialLayers] }
+    const nodes: Record<string, AnyNode> = {
+      level_1: level('level_1', ['wall_a', 'wall_b']),
+      wall_a: first,
+      wall_b: second,
+    }
+
+    const stats = simplifyConvertedSceneGraph(nodes)
+
+    expect(stats.removedMergedWalls).toBe(1)
+    expect(Object.values(nodes).filter((node) => node.type === 'wall')).toHaveLength(1)
+  })
+
   it('reprojects openings from removed walls onto the merged wall', () => {
     const nodes: Record<string, AnyNode> = {
       level_1: level('level_1', ['wall_a', 'wall_b']),

--- a/packages/ifc-converter/tests/cleanup.test.ts
+++ b/packages/ifc-converter/tests/cleanup.test.ts
@@ -85,6 +85,51 @@ describe('simplifyConvertedSceneGraph', () => {
     expect((nodes.level_1 as { children: string[] }).children).toEqual([keptWall?.id])
   })
 
+  it('does not merge parallel wall fragments on centerlines offset by two inches', () => {
+    const nodes: Record<string, AnyNode> = {
+      level_1: level('level_1', ['wall_a', 'wall_b']),
+      wall_a: wall('wall_a', [0, 0], [2, 0]),
+      wall_b: wall('wall_b', [2, 0.0508], [4, 0.0508]),
+    }
+
+    const stats = simplifyConvertedSceneGraph(nodes)
+
+    expect(stats.removedMergedWalls).toBe(0)
+    expect(Object.values(nodes).filter((node) => node.type === 'wall')).toHaveLength(2)
+  })
+
+  it('does not merge collinear wall fragments with different IFC materials', () => {
+    const exterior = wall('wall_exterior', [0, 0], [2, 0])
+    const interior = wall('wall_interior', [2.9, 0], [5, 0])
+    exterior.metadata = { material: 'Exterior Finish Assembly' }
+    interior.metadata = { material: 'Interior Partition Assembly' }
+    const nodes: Record<string, AnyNode> = {
+      level_1: level('level_1', ['wall_exterior', 'wall_interior']),
+      wall_exterior: exterior,
+      wall_interior: interior,
+    }
+
+    const stats = simplifyConvertedSceneGraph(nodes)
+
+    expect(stats.removedMergedWalls).toBe(0)
+    expect(Object.values(nodes).filter((node) => node.type === 'wall')).toHaveLength(2)
+  })
+
+  it('does not merge a material-tagged wall with an untagged wall', () => {
+    const tagged = wall('wall_tagged', [0, 0], [2, 0])
+    tagged.metadata = { material: 'Exterior Finish Assembly' }
+    const nodes: Record<string, AnyNode> = {
+      level_1: level('level_1', ['wall_tagged', 'wall_unknown']),
+      wall_tagged: tagged,
+      wall_unknown: wall('wall_unknown', [2.9, 0], [5, 0]),
+    }
+
+    const stats = simplifyConvertedSceneGraph(nodes)
+
+    expect(stats.removedMergedWalls).toBe(0)
+    expect(Object.values(nodes).filter((node) => node.type === 'wall')).toHaveLength(2)
+  })
+
   it('reprojects openings from removed walls onto the merged wall', () => {
     const nodes: Record<string, AnyNode> = {
       level_1: level('level_1', ['wall_a', 'wall_b']),


### PR DESCRIPTION
## Summary

- tighten the wall-fragment centerline tolerance so adjacent parallel walls are not collapsed
- require material associations to match before collinear fragments merge
- treat a tagged wall and an untagged wall as incompatible instead of silently allowing the merge
- add focused regression coverage for offset centerlines and material boundaries

## Scope

This is the cleanup-only follow-up requested in the review of #553. It changes only the IFC cleanup implementation and its tests.

## Fixture wall counts

The same unsimplified converted nodes were passed through main and this branch:

| Fixture | Input walls | main output | this PR output |
| --- | ---: | ---: | ---: |
| 01-duplex.ifc | 57 | 53 | 57 |
| 04-ifc-open-house.ifc | 4 | 4 | 4 |
| 05-paris-ground-floor.ifc | 114 | 85 | 100 |
| 10-sample-house.ifc | 5 | 5 | 5 |

For Paris, merged groups change from 15 to 8 and removed merged walls from 28 to 13. The stricter behavior intentionally preserves ambiguous wall assemblies for later inspection instead of joining nearby centerlines.

## Verification

- bun test packages/ifc-converter/tests/cleanup.test.ts — 6 passed
- Biome check on both changed files
- before/after conversion counts recorded for all four bundled fixtures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-conversion scene topology (fewer merged walls on real fixtures like Paris), which can affect downstream geometry and editing but is confined to the IFC simplification step with explicit regression tests.
> 
> **Overview**
> IFC scene-graph cleanup now **merges collinear wall fragments less aggressively**, so adjacent parallel assemblies and mismatched materials stay separate.
> 
> **Centerline tolerance** in `wallLineTolerance` drops from ~half wall thickness to ~10% (capped ~5–25 mm), so fragments offset by a couple of inches no longer collapse into one wall.
> 
> **Material gating** adds `wallMaterialSignature` / `wallMaterialCompatible` on `metadata.material` and `metadata.materialLayers`; tagged vs untagged walls are incompatible, while identical layer assemblies can still merge. `wallsCanMerge` enforces this before interval checks.
> 
> Regression tests cover offset centerlines, material/layer boundaries, and matching-layer merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0024b1edaf31a709e0d8a362986bd2e9352543dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->