### PR TITLE
feat(cli): publish the local editor manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,31 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  cli-smoke:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Smoke-test the packed CLI and editor runtime
+        env:
+          PASCAL_PORTABLE_BUILD: "1"
+        run: |
+          bun run build --filter editor
+          cd packages/cli
+          bun run build
+          bun run stage-runtime
+          bun run smoke-runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
           - nodes
           - mcp
           - ifc-converter
+          - cli
           - all
       bump:
         description: "Version bump (beta publishes a prerelease on the beta dist-tag)"
@@ -32,7 +33,36 @@ on:
         default: false
 
 jobs:
+  cli-smoke:
+    if: inputs.package == 'cli' || inputs.package == 'all'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Smoke-test the packed CLI and editor runtime
+        env:
+          PASCAL_PORTABLE_BUILD: "1"
+        run: |
+          bun run build --filter editor
+          cd packages/cli
+          bun run build
+          bun run stage-runtime
+          bun run smoke-runtime
+
   release:
+    needs: cli-smoke
+    if: ${{ !cancelled() && (needs.cli-smoke.result == 'success' || needs.cli-smoke.result == 'skipped') }}
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -43,6 +73,8 @@ jobs:
           fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@v4
         with:
@@ -96,7 +128,7 @@ jobs:
           # peerDeps sync below must use shell vars, not env indirection.
           declare -A NEW_VERSIONS
 
-          for pkg in core viewer editor nodes mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter cli; do
             if [ "$TARGET" = "$pkg" ] || [ "$TARGET" = "all" ]; then
               CUR=$(jq -r '.version' packages/$pkg/package.json)
               NEW=$(bump_version "$CUR")
@@ -111,9 +143,9 @@ jobs:
 
           # Sync inter-package references in peerDependencies and devDependencies.
           # Anything that references a bumped @pascal-app/* package is updated to ^NEW.
-          for pkg in core viewer editor nodes mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter cli; do
             FILE=packages/$pkg/package.json
-            for dep in core viewer editor nodes mcp ifc-converter; do
+            for dep in core viewer editor nodes mcp ifc-converter cli; do
               VAL="${NEW_VERSIONS[$dep]}"
               [ -z "$VAL" ] && continue
               jq --arg name "@pascal-app/$dep" --arg v "^$VAL" '
@@ -124,10 +156,21 @@ jobs:
           done
 
           echo "=== @pascal-app/* refs after sync ==="
-          for pkg in core viewer editor nodes mcp ifc-converter; do
+          for pkg in core viewer editor nodes mcp ifc-converter cli; do
             echo "--- packages/$pkg/package.json ---"
             jq '{ peerDependencies: (.peerDependencies // {} | with_entries(select(.key | startswith("@pascal-app/")))), devDependencies: (.devDependencies // {} | with_entries(select(.key | startswith("@pascal-app/")))) }' packages/$pkg/package.json
           done
+
+      - name: Validate portable editor runtime
+        if: inputs.package == 'cli' || inputs.package == 'all'
+        env:
+          PASCAL_PORTABLE_BUILD: "1"
+        run: |
+          bun run build --filter editor
+          cd packages/cli
+          bun run build
+          bun run stage-runtime
+          bun run smoke-runtime
 
       - name: Build & publish core
         if: inputs.package == 'core' || inputs.package == 'all'
@@ -139,6 +182,8 @@ jobs:
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/core@$CORE_VERSION"
             npm publish --dry-run --access public --tag "$NPM_TAG"
+          elif npm view "@pascal-app/core@$CORE_VERSION" version >/dev/null 2>&1; then
+            echo "📦 @pascal-app/core@$CORE_VERSION is already published; continuing release recovery"
           else
             npm publish --access public --tag "$NPM_TAG"
             echo "📦 Published @pascal-app/core@$CORE_VERSION"
@@ -154,6 +199,8 @@ jobs:
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/viewer@$VIEWER_VERSION"
             npm publish --dry-run --access public --tag "$NPM_TAG"
+          elif npm view "@pascal-app/viewer@$VIEWER_VERSION" version >/dev/null 2>&1; then
+            echo "📦 @pascal-app/viewer@$VIEWER_VERSION is already published; continuing release recovery"
           else
             npm publish --access public --tag "$NPM_TAG"
             echo "📦 Published @pascal-app/viewer@$VIEWER_VERSION"
@@ -168,6 +215,8 @@ jobs:
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/editor@$EDITOR_VERSION"
             npm publish --dry-run --access public --tag "$NPM_TAG"
+          elif npm view "@pascal-app/editor@$EDITOR_VERSION" version >/dev/null 2>&1; then
+            echo "📦 @pascal-app/editor@$EDITOR_VERSION is already published; continuing release recovery"
           else
             npm publish --access public --tag "$NPM_TAG"
             echo "📦 Published @pascal-app/editor@$EDITOR_VERSION"
@@ -183,6 +232,8 @@ jobs:
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/nodes@$NODES_VERSION"
             npm publish --dry-run --access public --tag "$NPM_TAG"
+          elif npm view "@pascal-app/nodes@$NODES_VERSION" version >/dev/null 2>&1; then
+            echo "📦 @pascal-app/nodes@$NODES_VERSION is already published; continuing release recovery"
           else
             npm publish --access public --tag "$NPM_TAG"
             echo "📦 Published @pascal-app/nodes@$NODES_VERSION"
@@ -198,6 +249,8 @@ jobs:
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/mcp@$MCP_VERSION"
             npm publish --dry-run --access public --tag "$NPM_TAG"
+          elif npm view "@pascal-app/mcp@$MCP_VERSION" version >/dev/null 2>&1; then
+            echo "📦 @pascal-app/mcp@$MCP_VERSION is already published; continuing release recovery"
           else
             npm publish --access public --tag "$NPM_TAG"
             echo "📦 Published @pascal-app/mcp@$MCP_VERSION"
@@ -215,9 +268,27 @@ jobs:
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/ifc-converter@$IFC_CONVERTER_VERSION"
             npm publish --dry-run --access public --tag "$NPM_TAG"
+          elif npm view "@pascal-app/ifc-converter@$IFC_CONVERTER_VERSION" version >/dev/null 2>&1; then
+            echo "📦 @pascal-app/ifc-converter@$IFC_CONVERTER_VERSION is already published; continuing release recovery"
           else
             npm publish --access public --tag "$NPM_TAG"
             echo "📦 Published @pascal-app/ifc-converter@$IFC_CONVERTER_VERSION"
+          fi
+
+      - name: Publish CLI
+        if: inputs.package == 'cli' || inputs.package == 'all'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd packages/cli
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            echo "🏜️ Dry run — would publish @pascal-app/cli@$CLI_VERSION"
+            npm publish --ignore-scripts --dry-run --access public --tag "$NPM_TAG"
+          elif npm view "@pascal-app/cli@$CLI_VERSION" version >/dev/null 2>&1; then
+            echo "📦 @pascal-app/cli@$CLI_VERSION is already published; continuing release recovery"
+          else
+            npm publish --ignore-scripts --access public --tag "$NPM_TAG"
+            echo "📦 Published @pascal-app/cli@$CLI_VERSION"
           fi
 
       - name: Commit version bumps & tag
@@ -251,11 +322,19 @@ jobs:
             PKGS="$PKGS @pascal-app/ifc-converter@$IFC_CONVERTER_VERSION"
             TAGS="$TAGS @pascal-app/ifc-converter@$IFC_CONVERTER_VERSION"
           fi
+          if [ -n "$CLI_VERSION" ]; then
+            PKGS="$PKGS @pascal-app/cli@$CLI_VERSION"
+            TAGS="$TAGS @pascal-app/cli@$CLI_VERSION"
+          fi
 
-          git commit -m "release:${PKGS}"
+          if git diff --cached --quiet; then
+            echo "No version-file changes; tagging the current release commit"
+          else
+            git commit -m "release:${PKGS}"
+          fi
 
           for TAG in $TAGS; do
             git tag "$TAG"
           done
 
-          git push origin HEAD:main $TAGS
+          git push --atomic origin HEAD:main $TAGS

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ A 3D building editor built with React Three Fiber and WebGPU.
 
 https://github.com/user-attachments/assets/8b50e7cf-cebe-4579-9cf3-8786b35f7b6b
 
+## Run the Editor Locally
+
+When `@pascal-app/cli` is available on npm, Node.js 22.13 or newer can create a
+persistent local Pascal installation without cloning this repository:
+
+```bash
+npx @pascal-app/cli editor
+```
+
+The CLI starts the editor in the background at `http://pascal.localhost:<port>` and
+keeps projects in `~/.pascal/data/pascal.db`. See [Run Pascal
+locally](https://editor.pascal.app/docs/developers/local-editor) for pnpm/Bun commands,
+lifecycle management, updates, storage paths, and troubleshooting.
+
 ## Using Published Packages
 
 The viewer runtime and built-in node definitions are separate packages. Install the full built-in
@@ -31,7 +45,8 @@ See the [`@pascal-app/viewer` quick start](packages/viewer/README.md#usage) for 
 
 ## Repository Architecture
 
-This is a Turborepo monorepo with four main runtime packages:
+This is a Turborepo monorepo with the reusable editor packages, the standalone app,
+and the CLI that distributes it:
 
 ```
 editor/
@@ -42,6 +57,7 @@ editor/
 │   ├── viewer/          # 3D rendering runtime and shared systems
 │   ├── editor/          # Editing tools and UI components
 │   ├── nodes/           # Built-in node definitions, renderers, and systems
+│   ├── cli/             # Persistent local editor installer and process manager
 │   └── ui/              # Shared UI components
 ```
 
@@ -53,6 +69,7 @@ editor/
 | **@pascal-app/viewer** | 3D rendering via React Three Fiber, shared render systems, default camera/controls, and post-processing |
 | **@pascal-app/editor** | Editing tools, panels, selection, and direct-manipulation UI |
 | **@pascal-app/nodes** | Built-in registry plugin with node definitions, renderers, geometry, and systems |
+| **@pascal-app/cli** | Installs and manages a versioned standalone editor runtime and persistent local data |
 | **apps/editor** | Standalone Next.js host for the editor packages |
 
 The **viewer** renders the scene with sensible defaults. The **editor** extends it with interactive tools, selection management, and editing capabilities.

--- a/SETUP.md
+++ b/SETUP.md
@@ -49,6 +49,24 @@ a base URL that only `NEXT_PUBLIC_APP_URL` can override, and Next inlines that
 value at build time, so remapping the port to something else makes the page
 return 500.
 
+## CLI-managed editor
+
+When `@pascal-app/cli` is available on npm, Node.js 22.13 or newer can install a
+persistent local runtime, start it in the background, and open it in the browser
+without a repository checkout:
+
+```bash
+npx @pascal-app/cli editor
+```
+
+Use `npx @pascal-app/cli doctor` to check the runtime, storage, and process state. Saved
+scenes live in `~/.pascal/data/pascal.db` independently from installed runtime versions.
+The CLI retains old runtime versions for rollback and warns after more than three have
+accumulated. It also replaces a damaged copy of its bundled runtime on the next start;
+neither operation modifies the data directory.
+The complete command and storage reference is in [Run Pascal
+locally](https://editor.pascal.app/docs/developers/local-editor).
+
 ## Monorepo Structure
 
 ```

--- a/apps/editor/app/api/health/route.ts
+++ b/apps/editor/app/api/health/route.ts
@@ -1,3 +1,9 @@
 export function GET() {
-  return Response.json({ status: 'ok', app: 'editor', timestamp: new Date().toISOString() })
+  return Response.json({
+    status: 'ok',
+    app: 'editor',
+    version: process.env.PASCAL_RUNTIME_VERSION ?? null,
+    instanceId: process.env.PASCAL_INSTANCE_ID ?? null,
+    timestamp: new Date().toISOString(),
+  })
 }

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -1,6 +1,14 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type { NextConfig } from 'next'
 
+const appDirectory = path.dirname(fileURLToPath(import.meta.url))
+const portableBuild = process.env.PASCAL_PORTABLE_BUILD === '1'
+
 const nextConfig: NextConfig = {
+  ...(portableBuild
+    ? { output: 'standalone' as const, outputFileTracingRoot: path.join(appDirectory, '../..') }
+    : {}),
   logging: {
     browserToTerminal: true,
   },
@@ -42,7 +50,9 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
-    unoptimized: process.env.NEXT_PUBLIC_ASSETS_CDN_URL?.startsWith('http://localhost') ?? false,
+    unoptimized:
+      portableBuild ||
+      (process.env.NEXT_PUBLIC_ASSETS_CDN_URL?.startsWith('http://localhost') ?? false),
     remotePatterns: [
       {
         protocol: 'https',

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "editor",
@@ -94,6 +95,18 @@
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.184.0",
         "typescript": "7.0.2",
+      },
+    },
+    "packages/cli": {
+      "name": "@pascal-app/cli",
+      "version": "0.1.0",
+      "bin": {
+        "pascal": "./dist/bin/pascal.js",
+      },
+      "devDependencies": {
+        "@pascal/typescript-config": "*",
+        "@types/node": "^22.19.20",
+        "typescript": "6.0.3",
       },
     },
     "packages/core": {
@@ -509,7 +522,7 @@
 
     "@mediapipe/tasks-vision": ["@mediapipe/tasks-vision@0.10.17", "", {}, "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="],
 
-    "@mint/pascal-plugin": ["@mint/pascal-plugin@github:mintdotgg/mint-pascal-plugin#902c546", { "peerDependencies": { "@pascal-app/core": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "@pascal-app/editor": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "@pascal-app/viewer": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "react": "^18 || ^19", "three": "^0.185" } }, "mintdotgg-mint-pascal-plugin-902c546"],
+    "@mint/pascal-plugin": ["@mint/pascal-plugin@github:mintdotgg/mint-pascal-plugin#902c546", { "peerDependencies": { "@pascal-app/core": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "@pascal-app/editor": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "@pascal-app/viewer": ">=0.9.2 <1.0.0 || >=1.0.0-beta.1 <1.0.0", "react": "^18 || ^19", "three": "^0.185" } }, "mintdotgg-mint-pascal-plugin-902c546", "sha512-/itUH9r9OIP8ZPrklW8iWe6B2SDOtlL1m8r9hlVM4Rw5josYtDdkDKQ37FbanvxxuUKcQnukHbtxWe3svRaCrQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -693,6 +706,8 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.69.0", "", { "os": "win32", "cpu": "x64" }, "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA=="],
 
+    "@pascal-app/cli": ["@pascal-app/cli@workspace:packages/cli"],
+
     "@pascal-app/core": ["@pascal-app/core@workspace:packages/core"],
 
     "@pascal-app/editor": ["@pascal-app/editor@workspace:packages/editor"],
@@ -705,7 +720,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-trees": ["@pascal-app/plugin-trees@github:pascalorg/plugin-trees#56d978c", { "dependencies": { "@dgreenheck/ez-tree": "^1.1.0" }, "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-trees-56d978c"],
+    "@pascal-app/plugin-trees": ["@pascal-app/plugin-trees@github:pascalorg/plugin-trees#56d978c", { "dependencies": { "@dgreenheck/ez-tree": "^1.1.0" }, "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-trees-56d978c", "sha512-16VzWot1oadvxCPqsRwMJbaP0a3u5FESFy7F7++pY5wAAFq9JTFwzHvKAsllrY5TZ5TJ7Y5vSqvbmQk8sy8HaA=="],
 
     "@pascal-app/viewer": ["@pascal-app/viewer@workspace:packages/viewer"],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "release:editor": "gh workflow run release.yml -f package=editor -f bump=patch",
     "release:nodes": "gh workflow run release.yml -f package=nodes -f bump=patch",
     "release:mcp": "gh workflow run release.yml -f package=mcp -f bump=patch",
+    "release:cli": "gh workflow run release.yml -f package=cli -f bump=patch",
     "release:minor": "gh workflow run release.yml -f package=all -f bump=minor",
     "release:major": "gh workflow run release.yml -f package=all -f bump=major"
   },

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pascal Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,4 +52,6 @@ install plugin code from GitHub or npm. Linux and Windows support is not verifie
 
 See the full [CLI guide](https://editor.pascal.app/docs/developers/local-editor) for
 commands, updates, storage paths, security behavior, current platform coverage, and
-troubleshooting.
+troubleshooting. Plugin publishers can use the separate
+[plugin authoring guide](https://editor.pascal.app/docs/developers/plugins) for the
+manifest, node, panel, host-integration, privacy, and testing contracts.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,55 @@
+# `@pascal-app/cli`
+
+Install, run, and manage a persistent local installation of the open-source Pascal
+Editor without cloning its repository. Node.js 22.13 or newer is required.
+
+```bash
+npx @pascal-app/cli editor
+```
+
+pnpm and Bun package runners can launch the same executable. npm must remain available
+because `pascal update` uses it to resolve published releases:
+
+```bash
+pnpm dlx @pascal-app/cli editor
+bunx @pascal-app/cli editor
+```
+
+The first run copies the bundled editor into `~/.pascal/runtime/<version>`, starts it on
+loopback, waits for its health endpoint, and opens `http://pascal.localhost:<port>`.
+Projects remain in `~/.pascal/data/pascal.db` when the CLI or editor is updated.
+Passing `--port` only affects a new process; an already healthy editor is reused at its
+existing URL.
+
+Install globally if you prefer the shorter command:
+
+```bash
+npm install --global @pascal-app/cli
+pascal editor
+```
+
+```bash
+pascal status
+pascal logs --follow
+pascal restart
+pascal stop
+# Guarded recovery when the recorded editor is alive but unhealthy:
+pascal stop --force
+pascal doctor
+pascal info --json
+pascal project list
+pascal plugin list
+```
+
+Updates health-check a candidate runtime and restore the previous runtime if activation
+fails. Installed versions are retained to support rollback, so `pascal doctor` warns when
+more than three versions have accumulated. A later `pascal editor` run replaces a damaged
+copy of its bundled runtime without touching project data. Detached logs rotate at 10 MiB.
+
+Use `pascal editor --foreground --no-open` for attached logs and debugging. The initial
+release supports macOS. It does not install a startup service, bind beyond loopback, or
+install plugin code from GitHub or npm. Linux and Windows support is not verified yet.
+
+See the full [CLI guide](https://editor.pascal.app/docs/developers/local-editor) for
+commands, updates, storage paths, security behavior, current platform coverage, and
+troubleshooting.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@pascal-app/cli",
+  "version": "0.1.0",
+  "description": "Install and manage a local Pascal editor",
+  "type": "module",
+  "bin": {
+    "pascal": "dist/bin/pascal.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "build-runtime": "cd ../../apps/editor && PASCAL_PORTABLE_BUILD=1 bun run build",
+    "check-types": "tsc --build --pretty false && tsc --project tsconfig.scripts.json --pretty false",
+    "stage-runtime": "bun run scripts/stage-runtime.ts",
+    "smoke-runtime": "bun run scripts/smoke-packed-runtime.ts",
+    "test": "bun test src",
+    "prepublishOnly": "bun run check-types && bun run build && bun run test && bun run build-runtime && bun run stage-runtime && bun run smoke-runtime"
+  },
+  "devDependencies": {
+    "@pascal/typescript-config": "*",
+    "@types/node": "^22.19.20",
+    "typescript": "6.0.3"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "keywords": [
+    "pascal",
+    "editor",
+    "3d",
+    "architecture",
+    "cli"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pascalorg/editor.git",
+    "directory": "packages/cli"
+  },
+  "license": "MIT",
+  "homepage": "https://editor.pascal.app/docs/developers/local-editor",
+  "bugs": "https://github.com/pascalorg/editor/issues"
+}

--- a/packages/cli/scripts/smoke-packed-runtime.ts
+++ b/packages/cli/scripts/smoke-packed-runtime.ts
@@ -1,0 +1,142 @@
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const smokeRoot = await mkdtemp(path.join(os.tmpdir(), 'pascal-cli-smoke-'))
+let tarballPath: string | null = null
+let smokeExecutable: string | null = null
+const smokeEnvironment = {
+  ...process.env,
+  PASCAL_HOME: path.join(smokeRoot, 'home'),
+  PASCAL_NO_OPEN: '1',
+}
+
+try {
+  const pack = await run('npm', ['pack', '--json', '--ignore-scripts'], packageDirectory)
+  const packResult = JSON.parse(pack.stdout) as
+    | Array<PackedArtifact>
+    | Record<string, PackedArtifact>
+  const artifact = Array.isArray(packResult) ? packResult[0] : Object.values(packResult)[0]
+  if (!artifact) throw new Error('npm pack did not return an artifact')
+  tarballPath = path.join(packageDirectory, artifact.filename)
+  enforceArtifactBudget(artifact)
+
+  const installDirectory = path.join(smokeRoot, 'install')
+  await run('npm', ['install', '--ignore-scripts', '--prefix', installDirectory, tarballPath])
+  smokeExecutable = path.join(installDirectory, 'node_modules/@pascal-app/cli/dist/bin/pascal.js')
+
+  const started = JSON.parse(
+    (
+      await run(
+        process.execPath,
+        [smokeExecutable, 'editor', '--no-open', '--port', '0', '--json'],
+        undefined,
+        smokeEnvironment,
+      )
+    ).stdout,
+  ) as { pid: number; port: number; url: string }
+  const rootResponse = await fetch(`http://127.0.0.1:${started.port}/`)
+  if (!rootResponse.ok) throw new Error(`editor root returned ${rootResponse.status}`)
+  const scenesResponse = await fetch(`${started.url}/scenes`)
+  if (!scenesResponse.ok) throw new Error(`editor scenes returned ${scenesResponse.status}`)
+  const repeatedStart = JSON.parse(
+    (
+      await run(
+        process.execPath,
+        [smokeExecutable, 'editor', '--no-open', '--port', '0', '--json'],
+        undefined,
+        smokeEnvironment,
+      )
+    ).stdout,
+  ) as { alreadyRunning: boolean; pid: number; port: number }
+  if (
+    !repeatedStart.alreadyRunning ||
+    repeatedStart.pid !== started.pid ||
+    repeatedStart.port !== started.port
+  ) {
+    throw new Error('a repeated editor command did not reuse the managed process')
+  }
+  await run(
+    process.execPath,
+    [smokeExecutable, 'project', 'list', '--json'],
+    undefined,
+    smokeEnvironment,
+  )
+  await run(process.execPath, [smokeExecutable, 'doctor', '--json'], undefined, smokeEnvironment)
+  await run(process.execPath, [smokeExecutable, 'stop', '--json'], undefined, smokeEnvironment)
+  smokeExecutable = null
+
+  console.log(
+    `Packed runtime smoke passed (${formatMb(artifact.size)} MB compressed, ${formatMb(artifact.unpackedSize)} MB unpacked, ${artifact.entryCount} files).`,
+  )
+} finally {
+  if (smokeExecutable) {
+    await run(
+      process.execPath,
+      [smokeExecutable, 'stop', '--force', '--json'],
+      undefined,
+      smokeEnvironment,
+    ).catch(() => undefined)
+  }
+  if (tarballPath) await rm(tarballPath, { force: true })
+  await rm(smokeRoot, { recursive: true, force: true })
+}
+
+interface PackedArtifact {
+  filename: string
+  size: number
+  unpackedSize: number
+  entryCount: number
+}
+
+function enforceArtifactBudget(artifact: {
+  size: number
+  unpackedSize: number
+  entryCount: number
+}): void {
+  const maximumSize = 105 * 1024 * 1024
+  const maximumUnpackedSize = 160 * 1024 * 1024
+  const maximumEntryCount = 4_000
+  if (
+    artifact.size > maximumSize ||
+    artifact.unpackedSize > maximumUnpackedSize ||
+    artifact.entryCount > maximumEntryCount
+  ) {
+    throw new Error(
+      `packed CLI exceeds its release budget: ${formatMb(artifact.size)} MB compressed, ${formatMb(artifact.unpackedSize)} MB unpacked, ${artifact.entryCount} files`,
+    )
+  }
+}
+
+async function run(
+  command: string,
+  args: string[],
+  cwd?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ stdout: string; stderr: string }> {
+  const executable = process.platform === 'win32' && command === 'npm' ? 'npm.cmd' : command
+  const child = spawn(executable, args, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] })
+  const stdout: Buffer[] = []
+  const stderr: Buffer[] = []
+  child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk))
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk))
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', (code) => resolve(code ?? 1))
+  })
+  const result = {
+    stdout: Buffer.concat(stdout).toString('utf8'),
+    stderr: Buffer.concat(stderr).toString('utf8'),
+  }
+  if (exitCode !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed (${exitCode}): ${result.stderr}`)
+  }
+  return result
+}
+
+function formatMb(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(1)
+}

--- a/packages/cli/scripts/stage-runtime.ts
+++ b/packages/cli/scripts/stage-runtime.ts
@@ -1,0 +1,174 @@
+import { chmod, cp, mkdir, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const repositoryRoot = path.resolve(packageDirectory, '../..')
+const appDirectory = path.join(repositoryRoot, 'apps/editor')
+const standaloneDirectory = path.join(appDirectory, '.next/standalone')
+const standaloneAppDirectory = path.join(standaloneDirectory, 'apps/editor')
+const outputDirectory = path.join(packageDirectory, 'dist/runtime')
+
+const packageJson = JSON.parse(
+  await readFile(path.join(packageDirectory, 'package.json'), 'utf8'),
+) as {
+  version: string
+}
+
+await chmod(path.join(packageDirectory, 'dist/bin/pascal.js'), 0o755)
+await assertFile(path.join(standaloneAppDirectory, 'server.js'))
+await rm(outputDirectory, { recursive: true, force: true })
+await mkdir(path.dirname(outputDirectory), { recursive: true })
+await cp(standaloneDirectory, outputDirectory, { recursive: true, dereference: false })
+
+await cp(path.join(appDirectory, 'public'), path.join(outputDirectory, 'apps/editor/public'), {
+  recursive: true,
+  force: true,
+})
+await cp(
+  path.join(appDirectory, '.next/static'),
+  path.join(outputDirectory, 'apps/editor/.next/static'),
+  { recursive: true, force: true },
+)
+
+await removeUnusedSharp(outputDirectory)
+await flattenBunNodeModules(outputDirectory)
+await materializeSymlinks(outputDirectory)
+await rm(path.join(outputDirectory, 'node_modules/.bun'), { recursive: true, force: true })
+const nativeFiles = await findNativeModules(outputDirectory)
+if (nativeFiles.length > 0) {
+  throw new Error(`portable runtime contains native modules:\n${nativeFiles.join('\n')}`)
+}
+
+await writeFile(
+  path.join(outputDirectory, 'runtime-manifest.json'),
+  `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      version: packageJson.version,
+      entrypoint: 'apps/editor/server.js',
+      healthPath: '/api/health',
+    },
+    null,
+    2,
+  )}\n`,
+)
+
+console.log(`Staged Pascal editor runtime ${packageJson.version} at ${outputDirectory}`)
+
+async function assertFile(filePath: string): Promise<void> {
+  try {
+    await readFile(filePath)
+  } catch {
+    throw new Error(
+      `standalone editor build not found at ${filePath}; run PASCAL_PORTABLE_BUILD=1 bun run build from apps/editor first`,
+    )
+  }
+}
+
+async function removeUnusedSharp(root: string): Promise<void> {
+  const nodeModules = path.join(root, 'node_modules')
+  await rm(path.join(nodeModules, 'sharp'), { recursive: true, force: true })
+  await rm(path.join(nodeModules, '@img'), { recursive: true, force: true })
+  const bunModules = path.join(nodeModules, '.bun')
+  let entries: string[] = []
+  try {
+    entries = await readdir(bunModules)
+  } catch {
+    return
+  }
+  await Promise.all(
+    entries
+      .filter(
+        (entry) => entry === 'sharp' || entry.startsWith('sharp@') || entry.startsWith('@img+'),
+      )
+      .map((entry) => rm(path.join(bunModules, entry), { recursive: true, force: true })),
+  )
+}
+
+async function flattenBunNodeModules(root: string): Promise<void> {
+  const nodeModules = path.join(root, 'node_modules')
+  const bunNodeModules = path.join(nodeModules, '.bun/node_modules')
+  for (const entry of await readdir(bunNodeModules, { withFileTypes: true })) {
+    if (entry.name.startsWith('@') && entry.isDirectory()) {
+      const scope = path.join(bunNodeModules, entry.name)
+      for (const packageEntry of await readdir(scope, { withFileTypes: true })) {
+        await copyLinkedPackage(
+          path.join(scope, packageEntry.name),
+          path.join(nodeModules, entry.name, packageEntry.name),
+        )
+      }
+    } else {
+      await copyLinkedPackage(
+        path.join(bunNodeModules, entry.name),
+        path.join(nodeModules, entry.name),
+      )
+    }
+  }
+}
+
+async function copyLinkedPackage(source: string, destination: string): Promise<void> {
+  let target: string
+  try {
+    target = await realpath(source)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
+  }
+  await rm(destination, { recursive: true, force: true })
+  await mkdir(path.dirname(destination), { recursive: true })
+  await cp(target, destination, { recursive: true, dereference: false })
+}
+
+async function materializeSymlinks(root: string): Promise<void> {
+  const resolvedRoot = path.resolve(root)
+  for (let pass = 0; pass < 100; pass += 1) {
+    const links = await findSymlinks(root)
+    if (links.length === 0) return
+
+    for (const link of links) {
+      let target: string
+      try {
+        target = await realpath(link)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+        await rm(link, { force: true })
+        continue
+      }
+      if (!target.startsWith(`${resolvedRoot}${path.sep}`)) {
+        throw new Error(`portable runtime symlink escapes its root: ${link}`)
+      }
+      await rm(link, { force: true })
+      await cp(target, link, { recursive: true, dereference: false })
+    }
+  }
+  throw new Error('portable runtime contains a cyclic symlink')
+}
+
+async function findSymlinks(root: string): Promise<string[]> {
+  const result: string[] = []
+  const walk = async (directory: string): Promise<void> => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name)
+      if (absolute === path.join(root, 'node_modules/.bun')) continue
+      if (entry.isSymbolicLink()) result.push(absolute)
+      else if (entry.isDirectory()) await walk(absolute)
+    }
+  }
+  await walk(root)
+  return result
+}
+
+async function findNativeModules(root: string): Promise<string[]> {
+  const result: string[] = []
+  const walk = async (directory: string): Promise<void> => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name)
+      if (entry.isDirectory()) await walk(absolute)
+      else if (entry.isFile() && entry.name.endsWith('.node'))
+        result.push(path.relative(root, absolute))
+    }
+  }
+  await walk(root)
+  return result.sort()
+}

--- a/packages/cli/src/bin/pascal.ts
+++ b/packages/cli/src/bin/pascal.ts
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { parseArgs } from 'node:util'
+import { openBrowser } from '../browser.js'
+import { collectInfo, runDoctor } from '../diagnostics.js'
+import {
+  activateEditorRuntime,
+  followLog,
+  getEditorStatus,
+  readLogTail,
+  restartEditor,
+  startEditor,
+  stopEditor,
+} from '../editor-process.js'
+import { CliError, toCliError } from '../errors.js'
+import { readJsonFile } from '../json-files.js'
+import { resolvePascalPaths } from '../paths.js'
+import { installBundledRuntime } from '../runtime.js'
+import { version } from '../version.js'
+
+const HELP = `Pascal — local 3D editor
+
+USAGE:
+  pascal editor [--foreground] [--no-open] [--port <n>]
+  pascal start [--foreground] [--port <n>]
+  pascal stop | restart | status | open
+  pascal logs [--follow] [--lines <n>]
+  pascal update [--version <version>]
+  pascal doctor [--json]
+  pascal info [--json]
+  pascal project list [--json]
+  pascal project open <id>
+  pascal plugin list [--json]
+
+Run "pascal --help" for the command reference.
+`
+
+const paths = resolvePascalPaths()
+
+async function main(): Promise<void> {
+  const [command = 'help', ...args] = process.argv.slice(2)
+  if (command === '--version' || command === '-v') return print(version)
+  if (command === '--help' || command === '-h' || command === 'help') return print(HELP)
+  if (args.includes('--help') || args.includes('-h')) return print(HELP)
+
+  switch (command) {
+    case 'editor':
+      return runStart(args, true)
+    case 'start':
+      return runStart(args, false)
+    case 'stop':
+      return runStop(args)
+    case 'restart':
+      return runRestart(args)
+    case 'status':
+      return runStatus(args)
+    case 'open':
+      return runOpen(args)
+    case 'logs':
+      return runLogs(args)
+    case 'doctor':
+      return runDoctorCommand(args)
+    case 'info':
+      return runInfo(args)
+    case 'update':
+      return runUpdate(args)
+    case 'project':
+      return runProject(args)
+    case 'plugin':
+      return runPlugin(args)
+    case '_install-runtime':
+      return output(true, await installBundledRuntime(paths, undefined, { activate: false }), '')
+    default:
+      throw new CliError('unknown_command', `Unknown command: ${command}`, { command }, 2)
+  }
+}
+
+async function runStart(args: string[], shouldOpen: boolean): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    strict: true,
+    options: {
+      foreground: { type: 'boolean', default: false },
+      open: { type: 'boolean', default: shouldOpen },
+      'no-open': { type: 'boolean', default: false },
+      port: { type: 'string' },
+      json: { type: 'boolean', default: false },
+      help: { type: 'boolean', short: 'h', default: false },
+    },
+  })
+  if (values.help) return print(HELP)
+  const port = parseIntegerOption(values.port, 'port')
+  const result = await startEditor({ paths, port, foreground: values.foreground })
+  if (values.open && !values['no-open']) openBrowser(result.state.url)
+  output(
+    values.json,
+    { ...result.state, alreadyRunning: result.alreadyRunning },
+    result.alreadyRunning
+      ? `Pascal is already running at ${result.state.url}`
+      : `Pascal is running at ${result.state.url}`,
+  )
+  if (result.child) {
+    const exitCode = await new Promise<number>((resolve) =>
+      result.child?.once('exit', (code, signal) => resolve(code ?? (signal ? 1 : 0))),
+    )
+    process.exitCode = exitCode
+  }
+}
+
+async function runStop(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    strict: true,
+    options: {
+      force: { type: 'boolean', default: false },
+      json: { type: 'boolean', default: false },
+    },
+  })
+  const stopped = await stopEditor(paths, { force: values.force })
+  output(values.json, { stopped }, stopped ? 'Pascal stopped.' : 'Pascal is not running.')
+}
+
+async function runRestart(args: string[]): Promise<void> {
+  const json = booleanOption(args, 'json')
+  const result = await restartEditor(paths)
+  output(json, result.state, `Pascal restarted at ${result.state.url}`)
+}
+
+async function runStatus(args: string[]): Promise<void> {
+  const json = booleanOption(args, 'json')
+  const status = await getEditorStatus(paths)
+  output(
+    json,
+    status,
+    status.healthy
+      ? `Pascal ${status.state?.version} is running at ${status.state?.url}`
+      : status.running
+        ? 'Pascal has a running but unhealthy process.'
+        : status.installed
+          ? `Pascal ${status.runtime?.version} is installed and stopped.`
+          : 'Pascal is not installed.',
+  )
+  if (status.running && !status.healthy) process.exitCode = 1
+}
+
+async function runOpen(args: string[]): Promise<void> {
+  const json = booleanOption(args, 'json')
+  const status = await getEditorStatus(paths)
+  if (!status.healthy || !status.state)
+    throw new CliError('editor_stopped', 'Pascal is not running.')
+  openBrowser(status.state.url)
+  output(json, { url: status.state.url }, status.state.url)
+}
+
+async function runLogs(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    strict: true,
+    options: {
+      follow: { type: 'boolean', short: 'f', default: false },
+      lines: { type: 'string', default: '100' },
+    },
+  })
+  const lines = parseIntegerOption(values.lines ?? '100', 'lines')
+  if (lines === undefined || lines < 1) {
+    throw new CliError('invalid_option', '--lines must be a positive integer.', undefined, 2)
+  }
+  print(await readLogTail(paths.editorLog, lines))
+  if (values.follow) await followLog(paths.editorLog)
+}
+
+async function runDoctorCommand(args: string[]): Promise<void> {
+  const json = booleanOption(args, 'json')
+  const checks = await runDoctor(paths)
+  output(
+    json,
+    { checks },
+    checks
+      .map(
+        (check) =>
+          `${check.status === 'pass' ? '✓' : check.status === 'warn' ? '!' : '✗'} ${check.message}`,
+      )
+      .join('\n'),
+  )
+  if (checks.some((check) => check.status === 'fail')) process.exitCode = 1
+}
+
+async function runInfo(args: string[]): Promise<void> {
+  const json = booleanOption(args, 'json')
+  const info = await collectInfo(paths)
+  output(
+    json,
+    info,
+    [
+      `CLI: ${version}`,
+      `Node: ${info.cli.node}`,
+      `Home: ${paths.root}`,
+      `Runtime: ${info.editor.runtime?.version ?? 'not installed'}`,
+      `Editor: ${info.editor.healthy ? info.editor.state?.url : 'stopped'}`,
+      `Plugins: ${info.plugins.length}`,
+    ].join('\n'),
+  )
+}
+
+async function runUpdate(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    strict: true,
+    options: { version: { type: 'string' }, json: { type: 'boolean', default: false } },
+  })
+  const target = values.version ?? 'latest'
+  if (!isAllowedUpdateVersion(target)) {
+    throw new CliError(
+      'invalid_version',
+      '--version must be an exact semantic version or the "latest" tag.',
+      undefined,
+      2,
+    )
+  }
+  let candidate
+  if (target === version) {
+    candidate = await installBundledRuntime(paths, undefined, { activate: false })
+  } else {
+    const spec = `@pascal-app/cli@${target}`
+    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    if (!values.json) print(`Installing ${spec}...`)
+    let result: Awaited<ReturnType<typeof spawnAndCapture>>
+    try {
+      result = await spawnAndCapture(
+        npm,
+        [
+          'exec',
+          '--yes',
+          '--ignore-scripts',
+          `--package=${spec}`,
+          '--',
+          'pascal',
+          '_install-runtime',
+        ],
+        !values.json,
+      )
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new CliError(
+          'npm_unavailable',
+          'npm is required to install another Pascal runtime. Install Node.js with npm and try again.',
+        )
+      }
+      throw error
+    }
+    if (result.exitCode !== 0) {
+      throw new CliError('update_failed', `Unable to install ${spec}.`, {
+        stderr: result.stderr.trim() || undefined,
+      })
+    }
+    try {
+      candidate = JSON.parse(result.stdout) as {
+        schemaVersion: 1
+        version: string
+        directory: string
+      }
+    } catch {
+      throw new CliError('update_failed', `The installer for ${spec} returned invalid output.`)
+    }
+  }
+  const activation = await activateEditorRuntime(paths, candidate)
+  output(
+    values.json,
+    activation,
+    `Pascal runtime ${activation.runtime.version} is active${activation.restarted ? ' and the editor was restarted' : ''}.`,
+  )
+}
+
+async function runProject(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args
+  if (subcommand === 'list') {
+    const json = booleanOption(rest, 'json')
+    const status = await requireRunningEditor()
+    const response = await fetch(`http://127.0.0.1:${status.state.port}/api/scenes`)
+    if (!response.ok)
+      throw new CliError('project_list_failed', `Scene API returned ${response.status}.`)
+    const body = (await response.json()) as { scenes?: Array<{ id: string; name: string }> }
+    output(
+      json,
+      body,
+      body.scenes?.length
+        ? body.scenes.map((scene) => `${scene.id}\t${scene.name}`).join('\n')
+        : 'No projects yet.',
+    )
+    return
+  }
+  if (subcommand === 'open') {
+    const { values, positionals } = parseArgs({
+      args: rest,
+      strict: true,
+      allowPositionals: true,
+      options: { json: { type: 'boolean', default: false } },
+    })
+    if (positionals.length !== 1) {
+      throw new CliError('invalid_option', 'Use "pascal project open <id>".', undefined, 2)
+    }
+    const status = await requireRunningEditor()
+    const url = `${status.state.url}/scene/${encodeURIComponent(positionals[0]!)}`
+    openBrowser(url)
+    return output(values.json, { url }, url)
+  }
+  throw new CliError(
+    'unknown_command',
+    'Use "pascal project list" or "pascal project open <id>".',
+    undefined,
+    2,
+  )
+}
+
+async function runPlugin(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args
+  if (subcommand === 'list') {
+    const json = booleanOption(rest, 'json')
+    const storedLock = await readJsonFile<{ schemaVersion?: unknown; plugins?: unknown }>(
+      paths.pluginLock,
+    )
+    if (storedLock && (storedLock.schemaVersion !== 1 || !Array.isArray(storedLock.plugins))) {
+      throw new CliError('invalid_plugin_state', 'The managed plugin lock is invalid.')
+    }
+    const lock = {
+      schemaVersion: 1 as const,
+      plugins: storedLock ? (storedLock.plugins as unknown[]) : [],
+    }
+    output(
+      json,
+      lock,
+      lock.plugins.length ? JSON.stringify(lock.plugins, null, 2) : 'No plugins installed.',
+    )
+    return
+  }
+  throw new CliError(
+    'plugin_command_unavailable',
+    'Plugin installation is not enabled in this CLI release yet. Use "pascal plugin list".',
+    undefined,
+    2,
+  )
+}
+
+async function requireRunningEditor() {
+  const status = await getEditorStatus(paths)
+  if (!status.healthy || !status.state) throw new CliError('editor_stopped', 'Start Pascal first.')
+  return { ...status, state: status.state }
+}
+
+function booleanOption(args: string[], name: string): boolean {
+  const { values } = parseArgs({
+    args,
+    strict: true,
+    options: { [name]: { type: 'boolean', default: false } },
+  })
+  return Boolean(values[name])
+}
+
+function parseIntegerOption(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined
+  if (!/^\d+$/.test(value)) {
+    throw new CliError('invalid_option', `--${name} must be an integer.`, undefined, 2)
+  }
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) {
+    throw new CliError('invalid_option', `--${name} is outside the supported range.`, undefined, 2)
+  }
+  return parsed
+}
+
+function output(json: boolean | undefined, value: unknown, human: string): void {
+  print(json ? JSON.stringify(value, null, 2) : human)
+}
+
+function print(value: string): void {
+  process.stdout.write(value.endsWith('\n') ? value : `${value}\n`)
+}
+
+async function spawnAndCapture(
+  command: string,
+  args: string[],
+  streamStderr = false,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+  const stdout: Buffer[] = []
+  const stderr: Buffer[] = []
+  let capturedBytes = 0
+  let captureError: CliError | undefined
+  let forceKill: ReturnType<typeof setTimeout> | undefined
+  const terminateInstaller = (error: CliError) => {
+    captureError ??= error
+    child.kill('SIGTERM')
+    forceKill ??= setTimeout(() => child.kill('SIGKILL'), 5_000)
+  }
+  const capture = (target: Buffer[]) => (chunk: Buffer) => {
+    capturedBytes += chunk.byteLength
+    if (capturedBytes > 4 * 1024 * 1024) {
+      terminateInstaller(
+        new CliError('update_failed', 'The package installer produced more than 4 MiB of output.'),
+      )
+      return
+    }
+    target.push(chunk)
+  }
+  const captureStdout = capture(stdout)
+  const captureStderr = capture(stderr)
+  child.stdout?.on('data', captureStdout)
+  child.stderr?.on('data', (chunk: Buffer) => {
+    if (streamStderr) process.stderr.write(chunk)
+    captureStderr(chunk)
+  })
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      terminateInstaller(
+        new CliError('update_timeout', 'The package installer did not finish within 10 minutes.'),
+      )
+    }, 10 * 60_000)
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      if (forceKill) clearTimeout(forceKill)
+      reject(error)
+    })
+    child.once('exit', (code) => {
+      clearTimeout(timeout)
+      if (forceKill) clearTimeout(forceKill)
+      captureError ? reject(captureError) : resolve(code ?? 1)
+    })
+  })
+  return {
+    exitCode,
+    stdout: Buffer.concat(stdout).toString('utf8').trim(),
+    stderr: Buffer.concat(stderr).toString('utf8'),
+  }
+}
+
+function isAllowedUpdateVersion(value: string): boolean {
+  return (
+    value === 'latest' ||
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(value)
+  )
+}
+
+main().catch((error) => {
+  const cliError = toCliError(error)
+  const wantsJson = process.argv.includes('--json')
+  if (wantsJson) {
+    process.stderr.write(
+      `${JSON.stringify({ error: cliError.code, message: cliError.message, details: cliError.details })}\n`,
+    )
+  } else {
+    process.stderr.write(`Error: ${cliError.message}\n`)
+  }
+  process.exitCode = cliError.exitCode
+})

--- a/packages/cli/src/browser.ts
+++ b/packages/cli/src/browser.ts
@@ -1,0 +1,11 @@
+import { spawn } from 'node:child_process'
+
+export function openBrowser(url: string, environment: NodeJS.ProcessEnv = process.env): void {
+  if (environment.PASCAL_NO_OPEN === '1') return
+  const command =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open'
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url]
+  const child = spawn(command, args, { detached: true, stdio: 'ignore' })
+  child.once('error', () => {})
+  child.unref()
+}

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+const executable = path.join(import.meta.dir, 'bin/pascal.ts')
+const testRoot = await mkdtemp(path.join(os.tmpdir(), 'pascal-cli-command-test-'))
+const testHome = path.join(testRoot, 'home')
+
+afterAll(() => rm(testRoot, { recursive: true, force: true }))
+
+describe('command parsing', () => {
+  test('shows the command reference for subcommand help', async () => {
+    const result = await runCli('status', '--help')
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('pascal editor')
+  })
+
+  test('rejects a partially numeric port', async () => {
+    const result = await runCli('editor', '--port', '3000junk', '--no-open', '--json')
+
+    expect(result.exitCode).toBe(2)
+    expect(JSON.parse(result.stderr)).toMatchObject({ error: 'invalid_option' })
+  })
+
+  test('rejects a non-numeric log line count', async () => {
+    const result = await runCli('logs', '--lines', 'many')
+
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('--lines must be an integer')
+  })
+
+  test('rejects non-registry update sources before invoking npm', async () => {
+    const result = await runCli('update', '--version', 'file:/tmp/untrusted', '--json')
+
+    expect(result.exitCode).toBe(2)
+    expect(JSON.parse(result.stderr)).toMatchObject({ error: 'invalid_version' })
+  })
+
+  test('reports unknown options as command errors', async () => {
+    const result = await runCli('project', 'list', '--unknown', '--json')
+
+    expect(result.exitCode).toBe(2)
+    expect(JSON.parse(result.stderr)).toMatchObject({ error: 'invalid_option' })
+  })
+
+  test('reports a malformed plugin lock as managed-state corruption', async () => {
+    await mkdir(testHome, { recursive: true })
+    await writeFile(path.join(testHome, 'pascal.plugins.lock'), '{"schemaVersion":1}')
+
+    const result = await runCli('plugin', 'list', '--json')
+
+    expect(result.exitCode).toBe(1)
+    expect(JSON.parse(result.stderr)).toMatchObject({ error: 'invalid_plugin_state' })
+  })
+})
+
+async function runCli(...args: string[]) {
+  const child = Bun.spawn([process.execPath, executable, ...args], {
+    env: { ...process.env, PASCAL_HOME: testHome, PASCAL_NO_OPEN: '1' },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  return { exitCode, stdout, stderr }
+}

--- a/packages/cli/src/diagnostics.test.ts
+++ b/packages/cli/src/diagnostics.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { collectInfo, runDoctor } from './diagnostics.js'
+import { resolvePascalPaths } from './paths.js'
+
+test('doctor reports corrupt managed state instead of crashing', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'pascal-cli-doctor-'))
+  try {
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    await mkdir(paths.run, { recursive: true })
+    await writeFile(paths.currentRuntime, '{not-json')
+
+    const checks = await runDoctor(paths)
+
+    expect(checks).toContainEqual(expect.objectContaining({ id: 'runtime', status: 'fail' }))
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('info creates private local storage on a fresh home', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'pascal-cli-info-'))
+  try {
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+
+    await collectInfo(paths)
+
+    expect((await stat(paths.root)).mode & 0o077).toBe(0)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/packages/cli/src/diagnostics.ts
+++ b/packages/cli/src/diagnostics.ts
@@ -1,0 +1,121 @@
+import { constants } from 'node:fs'
+import { access, readdir, stat } from 'node:fs/promises'
+import { ensurePascalDirectories, getEditorStatus } from './editor-process.js'
+import { readJsonFile } from './json-files.js'
+import type { PascalPaths } from './paths.js'
+
+export interface DiagnosticCheck {
+  id: string
+  status: 'pass' | 'warn' | 'fail'
+  message: string
+}
+
+export async function runDoctor(paths: PascalPaths): Promise<DiagnosticCheck[]> {
+  const checks: DiagnosticCheck[] = []
+  const [major = 0, minor = 0] = process.versions.node
+    .split('.')
+    .slice(0, 2)
+    .map((part) => Number.parseInt(part, 10))
+  const nodeSupported = major > 22 || (major === 22 && minor >= 13)
+  checks.push({
+    id: 'node',
+    status: nodeSupported ? 'pass' : 'fail',
+    message: nodeSupported ? `Node ${process.versions.node}` : 'Node 22.13 or newer is required.',
+  })
+  try {
+    await ensurePascalDirectories(paths)
+    await access(paths.root, constants.R_OK | constants.W_OK)
+    checks.push({ id: 'storage', status: 'pass', message: `Writable: ${paths.root}` })
+    const exposed = []
+    for (const directory of [paths.root, paths.data, paths.run, paths.logs]) {
+      if (((await stat(directory)).mode & 0o077) !== 0) exposed.push(directory)
+    }
+    checks.push({
+      id: 'permissions',
+      status: exposed.length === 0 ? 'pass' : 'warn',
+      message:
+        exposed.length === 0
+          ? 'Local storage is private to the current user.'
+          : `Group or other users can access: ${exposed.join(', ')}`,
+    })
+  } catch (error) {
+    checks.push({
+      id: 'storage',
+      status: 'fail',
+      message: error instanceof Error ? error.message : 'Pascal storage is not writable.',
+    })
+  }
+  try {
+    const status = await getEditorStatus(paths)
+    checks.push({
+      id: 'runtime',
+      status: status.installed ? 'pass' : 'warn',
+      message: status.runtime
+        ? `Installed runtime ${status.runtime.version}`
+        : 'No runtime installed yet.',
+    })
+    checks.push({
+      id: 'editor',
+      status: status.healthy ? 'pass' : status.running ? 'fail' : 'warn',
+      message: status.healthy
+        ? `Healthy at ${status.state?.url}`
+        : status.running
+          ? 'A recorded editor process is running but unhealthy.'
+          : 'The editor is stopped.',
+    })
+    const runtimeVersions = (await readdir(paths.runtime, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+      .map((entry) => entry.name)
+    checks.push({
+      id: 'runtime-retention',
+      status: runtimeVersions.length > 3 ? 'warn' : 'pass',
+      message:
+        runtimeVersions.length > 3
+          ? `${runtimeVersions.length} runtime versions are retained. Review inactive versions if disk space is constrained.`
+          : `${runtimeVersions.length} runtime version(s) retained for updates and rollback.`,
+    })
+  } catch (error) {
+    checks.push({
+      id: 'runtime',
+      status: 'fail',
+      message: `Runtime or process state is invalid: ${errorMessage(error)}`,
+    })
+  }
+  try {
+    const pluginLock = await readJsonFile<{ plugins?: unknown[] }>(paths.pluginLock)
+    checks.push({
+      id: 'plugins',
+      status: pluginLock && !Array.isArray(pluginLock.plugins) ? 'fail' : 'pass',
+      message: pluginLock
+        ? `${Array.isArray(pluginLock.plugins) ? pluginLock.plugins.length : 0} plugin(s) in lock.`
+        : 'No local plugins installed.',
+    })
+  } catch (error) {
+    checks.push({
+      id: 'plugins',
+      status: 'fail',
+      message: `Plugin state is invalid: ${errorMessage(error)}`,
+    })
+  }
+  return checks
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export async function collectInfo(paths: PascalPaths) {
+  await ensurePascalDirectories(paths)
+  const [status, runtimeVersions, pluginLock] = await Promise.all([
+    getEditorStatus(paths),
+    readdir(paths.runtime).catch(() => [] as string[]),
+    readJsonFile<{ schemaVersion?: number; plugins?: unknown[] }>(paths.pluginLock),
+  ])
+  return {
+    cli: { node: process.versions.node, platform: process.platform, arch: process.arch },
+    editor: status,
+    paths,
+    runtimes: runtimeVersions.filter((entry) => !entry.startsWith('.')).sort(),
+    plugins: pluginLock?.plugins ?? [],
+  }
+}

--- a/packages/cli/src/editor-process.ts
+++ b/packages/cli/src/editor-process.ts
@@ -1,0 +1,495 @@
+import { type ChildProcess, execFile, spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { closeSync, openSync } from 'node:fs'
+import { mkdir, open, rename, rm, stat } from 'node:fs/promises'
+import net from 'node:net'
+import path from 'node:path'
+import { CliError } from './errors.js'
+import { withFileLock } from './file-lock.js'
+import { readJsonFile, writeJsonFile } from './json-files.js'
+import type { PascalPaths } from './paths.js'
+import {
+  type ActiveRuntime,
+  activateRuntime,
+  installBundledRuntime,
+  readActiveRuntime,
+  readRuntimeManifest,
+} from './runtime.js'
+
+export interface EditorState {
+  schemaVersion: 1
+  pid: number
+  version: string
+  port: number
+  host: '127.0.0.1'
+  url: string
+  instanceId: string
+  runtimeDirectory: string
+  startedAt: string
+}
+
+export interface EditorStatus {
+  installed: boolean
+  running: boolean
+  healthy: boolean
+  state: EditorState | null
+  runtime: ActiveRuntime | null
+}
+
+export interface StartEditorOptions {
+  paths: PascalPaths
+  port?: number
+  foreground?: boolean
+  sourceDirectory?: string
+}
+
+export interface StartEditorResult {
+  state: EditorState
+  alreadyRunning: boolean
+  child?: ChildProcess
+}
+
+export interface StopEditorOptions {
+  force?: boolean
+}
+
+export interface RuntimeActivationResult {
+  runtime: ActiveRuntime
+  restarted: boolean
+}
+
+export async function ensurePascalDirectories(paths: PascalPaths): Promise<void> {
+  await Promise.all(
+    [paths.root, paths.runtime, paths.data, paths.plugins, paths.run, paths.logs].map((directory) =>
+      mkdir(directory, { recursive: true, mode: 0o700 }),
+    ),
+  )
+}
+
+export async function getEditorStatus(paths: PascalPaths): Promise<EditorStatus> {
+  const [runtime, state] = await Promise.all([
+    readActiveRuntime(paths),
+    readJsonFile<EditorState>(paths.state),
+  ])
+  if (state?.schemaVersion !== 1 || typeof state.pid !== 'number') {
+    return { installed: Boolean(runtime), running: false, healthy: false, state: null, runtime }
+  }
+  const running = isProcessRunning(state.pid)
+  const healthy = running && (await checkHealth(state))
+  return { installed: Boolean(runtime), running, healthy, state, runtime }
+}
+
+export async function startEditor(options: StartEditorOptions): Promise<StartEditorResult> {
+  return withEditorLifecycleLock(options.paths, () => startEditorUnlocked(options))
+}
+
+async function startEditorUnlocked(options: StartEditorOptions): Promise<StartEditorResult> {
+  await ensurePascalDirectories(options.paths)
+  let currentStatus: EditorStatus
+  try {
+    currentStatus = await getEditorStatus(options.paths)
+  } catch (error) {
+    if (!(error instanceof CliError) || error.code !== 'invalid_runtime') throw error
+    await stopEditorUnlocked(options.paths, { force: true })
+    await rm(options.paths.currentRuntime, { force: true })
+    await installBundledRuntime(options.paths, options.sourceDirectory)
+    currentStatus = await getEditorStatus(options.paths)
+  }
+  if (currentStatus.healthy && currentStatus.state) {
+    return { state: currentStatus.state, alreadyRunning: true }
+  }
+  if (currentStatus.running && currentStatus.state) {
+    throw new CliError(
+      'state_conflict',
+      `Process ${currentStatus.state.pid} is running but does not identify as this Pascal editor.`,
+    )
+  }
+  await rm(options.paths.state, { force: true })
+
+  let runtime = await readActiveRuntime(options.paths)
+  if (!runtime) {
+    runtime = await installBundledRuntime(options.paths, options.sourceDirectory)
+  }
+  const manifest = await readRuntimeManifest(runtime.directory)
+  const serverPath = path.resolve(runtime.directory, manifest.entrypoint)
+  const port = await findAvailablePort(options.port ?? 3000)
+  const instanceId = randomUUID()
+  const state: EditorState = {
+    schemaVersion: 1,
+    pid: 0,
+    version: runtime.version,
+    port,
+    host: '127.0.0.1',
+    url: `http://pascal.localhost:${port}`,
+    instanceId,
+    runtimeDirectory: runtime.directory,
+    startedAt: new Date().toISOString(),
+  }
+
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_ENV: 'production',
+    HOSTNAME: state.host,
+    PORT: String(port),
+    PASCAL_DATA_DIR: options.paths.data,
+    PASCAL_INSTANCE_ID: instanceId,
+    PASCAL_RUNTIME_VERSION: runtime.version,
+    MINT_PASCAL_HOST_ORIGIN: state.url,
+  }
+  const nodeBinary = process.env.PASCAL_NODE_BINARY || 'node'
+  if (!options.foreground) await rotateEditorLog(options.paths.editorLog)
+  const logDescriptor = options.foreground
+    ? undefined
+    : openSync(options.paths.editorLog, 'a', 0o600)
+  const child = spawn(nodeBinary, [serverPath], {
+    cwd: path.dirname(serverPath),
+    env: environment,
+    detached: !options.foreground,
+    stdio: options.foreground ? 'inherit' : ['ignore', logDescriptor!, logDescriptor!],
+  })
+  if (logDescriptor !== undefined) closeSync(logDescriptor)
+
+  try {
+    await waitForSpawn(child, nodeBinary)
+    if (!child.pid) throw new CliError('start_failed', 'The Pascal editor process did not start.')
+    state.pid = child.pid
+    await writeJsonFile(options.paths.state, state)
+    if (!options.foreground) child.unref()
+    await waitForHealth(state, 30_000)
+  } catch (error) {
+    if (child.pid) await terminateProcess(child.pid)
+    await rm(options.paths.state, { force: true })
+    throw error
+  }
+  return { state, alreadyRunning: false, child: options.foreground ? child : undefined }
+}
+
+export async function stopEditor(
+  paths: PascalPaths,
+  options: StopEditorOptions = {},
+): Promise<boolean> {
+  return withEditorLifecycleLock(paths, () => stopEditorUnlocked(paths, options))
+}
+
+async function stopEditorUnlocked(
+  paths: PascalPaths,
+  options: StopEditorOptions = {},
+): Promise<boolean> {
+  const state = await readJsonFile<EditorState>(paths.state)
+  if (!state || !isProcessRunning(state.pid)) {
+    await rm(paths.state, { force: true })
+    return false
+  }
+  if (!(await checkHealth(state))) {
+    if (options.force && (await matchesRecordedEditorProcess(paths, state))) {
+      await terminateProcess(state.pid)
+      await rm(paths.state, { force: true })
+      return true
+    }
+    throw new CliError(
+      'state_conflict',
+      options.force
+        ? `Refusing to stop process ${state.pid} because neither its health identity nor its operating-system command matches the recorded Pascal editor.`
+        : `Refusing to stop process ${state.pid} because its health identity is unavailable. Inspect "pascal status --json", then use "pascal stop --force" only if it is the recorded editor.`,
+    )
+  }
+  await terminateProcess(state.pid)
+  await rm(paths.state, { force: true })
+  return true
+}
+
+export async function restartEditor(paths: PascalPaths): Promise<StartEditorResult> {
+  return withEditorLifecycleLock(paths, async () => {
+    const previousPort = (await readJsonFile<EditorState>(paths.state))?.port
+    await stopEditorUnlocked(paths)
+    return startEditorUnlocked({ paths, port: previousPort })
+  })
+}
+
+export async function activateEditorRuntime(
+  paths: PascalPaths,
+  candidate: ActiveRuntime,
+): Promise<RuntimeActivationResult> {
+  return withEditorLifecycleLock(paths, async () => {
+    let previousRuntime: ActiveRuntime | null = null
+    let previousRuntimeWasInvalid = false
+    try {
+      previousRuntime = await readActiveRuntime(paths)
+    } catch (error) {
+      if (!(error instanceof CliError) || error.code !== 'invalid_runtime') throw error
+      previousRuntimeWasInvalid = true
+    }
+    let previousStatus: EditorStatus
+    if (previousRuntimeWasInvalid) {
+      const state = await readJsonFile<EditorState>(paths.state)
+      const running = Boolean(state && isProcessRunning(state.pid))
+      const healthy = Boolean(state && running && (await checkHealth(state)))
+      previousStatus = {
+        installed: false,
+        running,
+        healthy,
+        state: state ?? null,
+        runtime: null,
+      }
+    } else {
+      previousStatus = await getEditorStatus(paths)
+    }
+    if (previousStatus.running && !previousStatus.healthy) {
+      throw new CliError(
+        'state_conflict',
+        'The recorded editor process is running but unhealthy. Recover or stop it before updating.',
+      )
+    }
+    if (
+      previousRuntime?.version === candidate.version &&
+      previousRuntime.directory === candidate.directory
+    ) {
+      return { runtime: previousRuntime, restarted: false }
+    }
+
+    const wasRunning = previousStatus.healthy
+    const previousPort = previousStatus.state?.port
+    if (wasRunning) await stopEditorUnlocked(paths)
+
+    try {
+      await activateRuntime(paths, candidate.version, candidate.directory)
+      await startEditorUnlocked({ paths, port: previousPort })
+      if (!wasRunning) await stopEditorUnlocked(paths)
+      return { runtime: candidate, restarted: wasRunning }
+    } catch (error) {
+      try {
+        await stopEditorUnlocked(paths, { force: true })
+      } catch {}
+      let rollbackError: unknown
+      if (previousRuntime) {
+        try {
+          await activateRuntime(paths, previousRuntime.version, previousRuntime.directory)
+        } catch (activationError) {
+          rollbackError = activationError
+          await rm(paths.currentRuntime, { force: true })
+        }
+      } else {
+        await rm(paths.currentRuntime, { force: true })
+      }
+      if (!rollbackError && wasRunning && previousRuntime) {
+        try {
+          await startEditorUnlocked({ paths, port: previousPort })
+        } catch (restartError) {
+          rollbackError = restartError
+        }
+      }
+      if (rollbackError) {
+        throw new CliError('update_failed', 'The candidate and rollback runtimes both failed.', {
+          candidateError: errorMessage(error),
+          rollbackError: errorMessage(rollbackError),
+        })
+      }
+      throw new CliError(
+        'update_failed',
+        previousRuntime
+          ? 'The candidate runtime failed; the previous runtime was restored.'
+          : 'The candidate runtime failed and no valid previous runtime was available.',
+        {
+          candidateError: errorMessage(error),
+        },
+      )
+    }
+  })
+}
+
+export async function readLogTail(filePath: string, lines = 100): Promise<string> {
+  try {
+    const fileSize = (await stat(filePath)).size
+    const length = Math.min(fileSize, 8 * 1024 * 1024)
+    const handle = await open(filePath, 'r')
+    const buffer = Buffer.alloc(length)
+    try {
+      await handle.read(buffer, 0, length, fileSize - length)
+    } finally {
+      await handle.close()
+    }
+    return buffer
+      .toString('utf8')
+      .split(/\r?\n/)
+      .slice(-Math.max(1, lines) - 1)
+      .join('\n')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return ''
+    throw error
+  }
+}
+
+export async function followLog(filePath: string): Promise<never> {
+  let offset = 0
+  try {
+    offset = (await stat(filePath)).size
+  } catch {}
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    try {
+      const size = (await stat(filePath)).size
+      if (size < offset) offset = 0
+      if (size === offset) continue
+      const handle = await open(filePath, 'r')
+      const buffer = Buffer.alloc(Math.min(size - offset, 1024 * 1024))
+      try {
+        await handle.read(buffer, 0, buffer.length, offset)
+      } finally {
+        await handle.close()
+      }
+      process.stdout.write(buffer)
+      offset += buffer.length
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      offset = 0
+    }
+  }
+}
+
+export async function checkHealth(state: EditorState): Promise<boolean> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${state.port}/api/health`, {
+      signal: AbortSignal.timeout(1_000),
+    })
+    if (!response.ok) return false
+    const body = (await response.json()) as {
+      status?: string
+      app?: string
+      version?: string
+      instanceId?: string
+    }
+    return (
+      body.status === 'ok' &&
+      body.app === 'editor' &&
+      body.version === state.version &&
+      body.instanceId === state.instanceId
+    )
+  } catch {
+    return false
+  }
+}
+
+export async function waitForHealth(state: EditorState, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await checkHealth(state)) return
+    if (!isProcessRunning(state.pid)) {
+      throw new CliError('start_failed', 'The Pascal editor exited before becoming healthy.')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+  throw new CliError('health_timeout', `Pascal did not become healthy within ${timeoutMs}ms.`)
+}
+
+export function isProcessRunning(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+async function findAvailablePort(preferredPort: number): Promise<number> {
+  if (!Number.isInteger(preferredPort) || preferredPort < 0 || preferredPort > 65_535) {
+    throw new CliError('invalid_port', `Invalid port: ${preferredPort}`)
+  }
+  if (preferredPort === 0) return probePort(0)
+  for (let port = preferredPort; port < Math.min(preferredPort + 20, 65_536); port += 1) {
+    try {
+      return await probePort(port)
+    } catch {}
+  }
+  throw new CliError('port_unavailable', `No available port found from ${preferredPort}.`)
+}
+
+async function probePort(port: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.unref()
+    server.once('error', reject)
+    server.listen({ host: '127.0.0.1', port }, () => {
+      const address = server.address()
+      const resolvedPort = typeof address === 'object' && address ? address.port : port
+      server.close((error) => (error ? reject(error) : resolve(resolvedPort)))
+    })
+  })
+}
+
+async function terminateProcess(pid: number): Promise<void> {
+  try {
+    process.kill(pid, 'SIGTERM')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return
+    throw error
+  }
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    if (!isProcessRunning(pid)) return
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  try {
+    process.kill(pid, 'SIGKILL')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
+  }
+}
+
+async function withEditorLifecycleLock<T>(
+  paths: PascalPaths,
+  action: () => Promise<T>,
+): Promise<T> {
+  return withFileLock(
+    path.join(paths.run, 'editor-lifecycle.lock'),
+    'editor_locked',
+    'Another Pascal editor lifecycle operation is active.',
+    action,
+  )
+}
+
+async function waitForSpawn(child: ChildProcess, binary: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    child.once('spawn', resolve)
+    child.once('error', reject)
+  }).catch((error) => {
+    throw new CliError('start_failed', `Unable to launch ${binary}: ${errorMessage(error)}`)
+  })
+}
+
+async function matchesRecordedEditorProcess(
+  paths: PascalPaths,
+  state: EditorState,
+): Promise<boolean> {
+  if (process.platform === 'win32') return false
+  const runtimeDirectory = path.resolve(state.runtimeDirectory)
+  if (!runtimeDirectory.startsWith(`${path.resolve(paths.runtime)}${path.sep}`)) return false
+  let expectedEntrypoint: string
+  try {
+    const manifest = await readRuntimeManifest(runtimeDirectory)
+    expectedEntrypoint = path.resolve(runtimeDirectory, manifest.entrypoint)
+  } catch {
+    expectedEntrypoint = path.join(runtimeDirectory, 'apps/editor/server.js')
+  }
+  const command = await new Promise<string>((resolve) => {
+    execFile('ps', ['-ww', '-p', String(state.pid), '-o', 'command='], (error, stdout) => {
+      resolve(error ? '' : stdout.trim())
+    })
+  })
+  return command.includes(expectedEntrypoint)
+}
+
+async function rotateEditorLog(filePath: string): Promise<void> {
+  try {
+    if ((await stat(filePath)).size <= 10 * 1024 * 1024) return
+    const previousPath = `${filePath}.1`
+    await rm(previousPath, { force: true })
+    await rename(filePath, previousPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,30 @@
+export class CliError extends Error {
+  readonly code: string
+  readonly details?: unknown
+  readonly exitCode: number
+
+  constructor(code: string, message: string, details?: unknown, exitCode = 1) {
+    super(message)
+    this.name = 'CliError'
+    this.code = code
+    this.details = details
+    this.exitCode = exitCode
+  }
+}
+
+export function toCliError(error: unknown): CliError {
+  if (error instanceof CliError) return error
+  const nodeCode = (error as { code?: unknown })?.code
+  if (typeof nodeCode === 'string' && nodeCode.startsWith('ERR_PARSE_ARGS_')) {
+    return new CliError(
+      'invalid_option',
+      error instanceof Error ? error.message : 'Invalid command options.',
+      undefined,
+      2,
+    )
+  }
+  return new CliError(
+    'unexpected_error',
+    error instanceof Error ? error.message : 'An unexpected error occurred.',
+  )
+}

--- a/packages/cli/src/file-lock.ts
+++ b/packages/cli/src/file-lock.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, open, readFile, rm, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { CliError } from './errors.js'
+
+interface LockRecord {
+  schemaVersion: 1
+  pid: number
+  token: string
+  createdAt: string
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000
+const INVALID_LOCK_GRACE_MS = 5_000
+const MAX_LOCK_AGE_MS = 30 * 60_000
+
+export async function withFileLock<T>(
+  lockPath: string,
+  code: string,
+  message: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  await mkdir(path.dirname(lockPath), { recursive: true, mode: 0o700 })
+  const token = randomUUID()
+  const deadline = Date.now() + DEFAULT_TIMEOUT_MS
+
+  while (!(await tryAcquire(lockPath, token))) {
+    if (await reclaimStaleLock(lockPath)) continue
+    if (Date.now() >= deadline) throw new CliError(code, message)
+    await delay(100)
+  }
+
+  try {
+    return await action()
+  } finally {
+    await removeOwnedLock(lockPath, token)
+  }
+}
+
+async function tryAcquire(lockPath: string, token: string): Promise<boolean> {
+  try {
+    const handle = await open(lockPath, 'wx', 0o600)
+    try {
+      const record: LockRecord = {
+        schemaVersion: 1,
+        pid: process.pid,
+        token,
+        createdAt: new Date().toISOString(),
+      }
+      await handle.writeFile(`${JSON.stringify(record)}\n`)
+    } finally {
+      await handle.close()
+    }
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false
+    throw error
+  }
+}
+
+async function reclaimStaleLock(lockPath: string): Promise<boolean> {
+  let ageMs: number
+  try {
+    ageMs = Date.now() - (await stat(lockPath)).mtimeMs
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return true
+    throw error
+  }
+
+  let record: LockRecord | null = null
+  try {
+    record = JSON.parse(await readFile(lockPath, 'utf8')) as LockRecord
+  } catch {
+    if (ageMs < INVALID_LOCK_GRACE_MS) return false
+  }
+
+  if (isValidRecord(record) && isProcessRunning(record.pid) && ageMs < MAX_LOCK_AGE_MS) {
+    return false
+  }
+
+  try {
+    await rm(lockPath)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return true
+    throw error
+  }
+}
+
+function isValidRecord(record: LockRecord | null): record is LockRecord {
+  return Boolean(
+    record?.schemaVersion === 1 &&
+      Number.isSafeInteger(record.pid) &&
+      record.pid > 0 &&
+      typeof record.token === 'string' &&
+      typeof record.createdAt === 'string',
+  )
+}
+
+async function removeOwnedLock(lockPath: string, token: string): Promise<void> {
+  try {
+    const record = JSON.parse(await readFile(lockPath, 'utf8')) as Partial<LockRecord>
+    if (record.token === token) await rm(lockPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT' && !(error instanceof SyntaxError)) {
+      throw error
+    }
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,23 @@
+export { collectInfo, type DiagnosticCheck, runDoctor } from './diagnostics.js'
+export {
+  activateEditorRuntime,
+  type EditorState,
+  type EditorStatus,
+  ensurePascalDirectories,
+  getEditorStatus,
+  type RuntimeActivationResult,
+  restartEditor,
+  type StopEditorOptions,
+  startEditor,
+  stopEditor,
+} from './editor-process.js'
+export { CliError } from './errors.js'
+export { type PascalPaths, resolvePascalPaths } from './paths.js'
+export {
+  type ActiveRuntime,
+  installBundledRuntime,
+  type RuntimeManifest,
+  readActiveRuntime,
+  readRuntimeManifest,
+} from './runtime.js'
+export { version } from './version.js'

--- a/packages/cli/src/json-files.ts
+++ b/packages/cli/src/json-files.ts
@@ -1,0 +1,18 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8')) as T
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+}
+
+export async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  const temporaryPath = `${filePath}.${process.pid}.tmp`
+  await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  await rename(temporaryPath, filePath)
+}

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,0 +1,33 @@
+import os from 'node:os'
+import path from 'node:path'
+
+export interface PascalPaths {
+  root: string
+  runtime: string
+  data: string
+  plugins: string
+  run: string
+  logs: string
+  state: string
+  currentRuntime: string
+  pluginLock: string
+  database: string
+  editorLog: string
+}
+
+export function resolvePascalPaths(environment: NodeJS.ProcessEnv = process.env): PascalPaths {
+  const root = path.resolve(environment.PASCAL_HOME || path.join(os.homedir(), '.pascal'))
+  return {
+    root,
+    runtime: path.join(root, 'runtime'),
+    data: path.join(root, 'data'),
+    plugins: path.join(root, 'plugins'),
+    run: path.join(root, 'run'),
+    logs: path.join(root, 'logs'),
+    state: path.join(root, 'run/editor.json'),
+    currentRuntime: path.join(root, 'run/current-runtime.json'),
+    pluginLock: path.join(root, 'pascal.plugins.lock'),
+    database: path.join(root, 'data/pascal.db'),
+    editorLog: path.join(root, 'logs/editor.log'),
+  }
+}

--- a/packages/cli/src/runtime.test.ts
+++ b/packages/cli/src/runtime.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  activateEditorRuntime,
+  getEditorStatus,
+  startEditor,
+  stopEditor,
+} from './editor-process.js'
+import { resolvePascalPaths } from './paths.js'
+import { installBundledRuntime, readActiveRuntime } from './runtime.js'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('managed runtime', () => {
+  test('installs a bundled runtime outside the package-runner cache', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+
+    const active = await installBundledRuntime(paths, source)
+
+    expect(active.version).toBe('1.2.3')
+    expect(active.directory).toBe(path.join(paths.runtime, '1.2.3'))
+    expect(await Bun.file(path.join(active.directory, 'apps/editor/server.js')).exists()).toBe(true)
+  })
+
+  test('starts, identifies, and stops a detached editor while preserving data', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    await mkdir(paths.data, { recursive: true })
+    await writeFile(paths.database, 'persistent')
+
+    const started = await startEditor({ paths, port: 0, sourceDirectory: source })
+    expect(started.alreadyRunning).toBe(false)
+    expect((await getEditorStatus(paths)).healthy).toBe(true)
+    expect((await startEditor({ paths, sourceDirectory: source })).alreadyRunning).toBe(true)
+
+    expect(await stopEditor(paths)).toBe(true)
+    expect((await getEditorStatus(paths)).running).toBe(false)
+    expect(await Bun.file(paths.database).text()).toBe('persistent')
+  })
+
+  test('serializes concurrent starts into one managed editor', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+
+    const [first, second] = await Promise.all([
+      startEditor({ paths, port: 0, sourceDirectory: source }),
+      startEditor({ paths, port: 0, sourceDirectory: source }),
+    ])
+
+    expect(first.state.pid).toBe(second.state.pid)
+    expect([first.alreadyRunning, second.alreadyRunning].sort()).toEqual([false, true])
+    await stopEditor(paths)
+  })
+
+  test('reclaims an install lock whose owner is gone', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    await mkdir(paths.run, { recursive: true })
+    await writeFile(
+      path.join(paths.run, 'runtime-install.lock'),
+      JSON.stringify({
+        schemaVersion: 1,
+        pid: 999_999,
+        token: 'abandoned',
+        createdAt: new Date().toISOString(),
+      }),
+    )
+
+    expect((await installBundledRuntime(paths, source)).version).toBe('1.2.3')
+  })
+
+  test('replaces a damaged installed runtime on the next start', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    const active = await installBundledRuntime(paths, source)
+    await rm(path.join(active.directory, 'apps/editor/server.js'))
+
+    const started = await startEditor({ paths, port: 0, sourceDirectory: source })
+
+    expect(started.state.version).toBe('1.2.3')
+    expect((await getEditorStatus(paths)).healthy).toBe(true)
+    expect(await Bun.file(path.join(active.directory, 'apps/editor/server.js')).exists()).toBe(true)
+    await stopEditor(paths)
+  })
+
+  test('replaces a runtime whose manifest contains invalid JSON', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    const active = await installBundledRuntime(paths, source)
+    await writeFile(path.join(active.directory, 'runtime-manifest.json'), '{not-json')
+
+    const started = await startEditor({ paths, port: 0, sourceDirectory: source })
+
+    expect(started.state.version).toBe('1.2.3')
+    expect((await getEditorStatus(paths)).healthy).toBe(true)
+    await stopEditor(paths)
+  })
+
+  test('recovers an active-runtime pointer containing invalid JSON', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    await mkdir(paths.run, { recursive: true })
+    await writeFile(paths.currentRuntime, '{not-json')
+
+    const started = await startEditor({ paths, port: 0, sourceDirectory: source })
+
+    expect(started.state.version).toBe('1.2.3')
+    expect((await getEditorStatus(paths)).healthy).toBe(true)
+    await stopEditor(paths)
+  })
+
+  test('removes abandoned temporary runtime copies before installing', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    const abandoned = path.join(paths.runtime, '.install-abandoned')
+    await mkdir(abandoned, { recursive: true })
+    await writeFile(path.join(abandoned, 'partial'), 'incomplete')
+
+    await installBundledRuntime(paths, source)
+
+    expect(await Bun.file(path.join(abandoned, 'partial')).exists()).toBe(false)
+  })
+
+  test('allows an explicit force stop only for the recorded editor command', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    const started = await startEditor({ paths, port: 0, sourceDirectory: source })
+    await writeFile(
+      paths.state,
+      `${JSON.stringify({ ...started.state, instanceId: 'no-longer-healthy' }, null, 2)}\n`,
+    )
+
+    await expect(stopEditor(paths)).rejects.toMatchObject({ code: 'state_conflict' })
+    expect(await stopEditor(paths, { force: true })).toBe(true)
+  })
+
+  test('force-stops the recorded editor when its runtime manifest is damaged', async () => {
+    const root = await temporaryRoot()
+    const source = await fakeRuntime(root, '1.2.3')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    const started = await startEditor({ paths, port: 0, sourceDirectory: source })
+    await writeFile(path.join(started.state.runtimeDirectory, 'runtime-manifest.json'), '{not-json')
+    await writeFile(
+      paths.state,
+      `${JSON.stringify({ ...started.state, instanceId: 'no-longer-healthy' }, null, 2)}\n`,
+    )
+
+    expect(await stopEditor(paths, { force: true })).toBe(true)
+  })
+
+  test('restores the previous running runtime when a candidate fails health', async () => {
+    const root = await temporaryRoot()
+    const firstSource = await fakeRuntime(root, '1.2.3')
+    const brokenSource = await fakeRuntime(root, '2.0.0', false)
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    await startEditor({ paths, port: 0, sourceDirectory: firstSource })
+    const candidate = await installBundledRuntime(paths, brokenSource, { activate: false })
+
+    await expect(activateEditorRuntime(paths, candidate)).rejects.toMatchObject({
+      code: 'update_failed',
+    })
+    expect((await readActiveRuntime(paths))?.version).toBe('1.2.3')
+    expect((await getEditorStatus(paths)).healthy).toBe(true)
+    await stopEditor(paths)
+  })
+
+  test('health-checks an update without leaving a stopped editor running', async () => {
+    const root = await temporaryRoot()
+    const firstSource = await fakeRuntime(root, '1.2.3')
+    const secondSource = await fakeRuntime(root, '2.0.0')
+    const paths = resolvePascalPaths({ PASCAL_HOME: path.join(root, 'home') })
+    await installBundledRuntime(paths, firstSource)
+    const seeded = await startEditor({ paths, port: 0, sourceDirectory: firstSource })
+    await stopEditor(paths)
+    await writeFile(paths.state, `${JSON.stringify(seeded.state, null, 2)}\n`)
+    const candidate = await installBundledRuntime(paths, secondSource, { activate: false })
+
+    const result = await activateEditorRuntime(paths, candidate)
+
+    expect(result).toEqual({ runtime: candidate, restarted: false })
+    expect((await readActiveRuntime(paths))?.version).toBe('2.0.0')
+    expect((await getEditorStatus(paths)).running).toBe(false)
+  })
+})
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'pascal-cli-test-'))
+  roots.push(root)
+  return root
+}
+
+async function fakeRuntime(root: string, version: string, healthy = true): Promise<string> {
+  const runtime = path.join(root, `source-${version}`)
+  const app = path.join(runtime, 'apps/editor')
+  await mkdir(app, { recursive: true })
+  await writeFile(
+    path.join(runtime, 'runtime-manifest.json'),
+    JSON.stringify({
+      schemaVersion: 1,
+      version,
+      entrypoint: 'apps/editor/server.js',
+      healthPath: '/api/health',
+    }),
+  )
+  await writeFile(
+    path.join(app, 'server.js'),
+    healthy
+      ? `import http from 'node:http'
+const instanceId = process.env.PASCAL_INSTANCE_ID
+const server = http.createServer((request, response) => {
+  response.setHeader('content-type', 'application/json')
+  if (request.url === '/api/health') {
+    response.end(JSON.stringify({
+      status: 'ok',
+      app: 'editor',
+      version: process.env.PASCAL_RUNTIME_VERSION,
+      instanceId,
+    }))
+    return
+  }
+  response.end('{}')
+})
+server.listen(Number(process.env.PORT), process.env.HOSTNAME)
+process.on('SIGTERM', () => server.close(() => process.exit(0)))
+`
+      : 'process.exit(1)\n',
+  )
+  return runtime
+}

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -1,0 +1,176 @@
+import { cp, mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { CliError } from './errors.js'
+import { withFileLock } from './file-lock.js'
+import { readJsonFile, writeJsonFile } from './json-files.js'
+import type { PascalPaths } from './paths.js'
+
+export interface RuntimeManifest {
+  schemaVersion: 1
+  version: string
+  entrypoint: string
+  healthPath: string
+}
+
+export interface ActiveRuntime {
+  schemaVersion: 1
+  version: string
+  directory: string
+}
+
+export function resolveBundledRuntimeDirectory(
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  if (environment.PASCAL_BUNDLED_RUNTIME_DIR) {
+    return path.resolve(environment.PASCAL_BUNDLED_RUNTIME_DIR)
+  }
+  const moduleDirectory = path.dirname(fileURLToPath(import.meta.url))
+  return path.basename(moduleDirectory) === 'dist'
+    ? path.join(moduleDirectory, 'runtime')
+    : path.resolve(moduleDirectory, '../dist/runtime')
+}
+
+export async function readRuntimeManifest(directory: string): Promise<RuntimeManifest> {
+  let manifest: RuntimeManifest | null
+  try {
+    manifest = await readJsonFile<RuntimeManifest>(path.join(directory, 'runtime-manifest.json'))
+  } catch {
+    throw new CliError('invalid_runtime', `Invalid Pascal runtime at ${directory}.`)
+  }
+  if (
+    manifest?.schemaVersion !== 1 ||
+    typeof manifest.version !== 'string' ||
+    typeof manifest.entrypoint !== 'string' ||
+    typeof manifest.healthPath !== 'string'
+  ) {
+    throw new CliError('invalid_runtime', `Invalid Pascal runtime at ${directory}.`)
+  }
+  if (!/^[0-9A-Za-z][0-9A-Za-z._-]*$/.test(manifest.version)) {
+    throw new CliError('invalid_runtime', `Invalid runtime version: ${manifest.version}`)
+  }
+  const entrypoint = path.resolve(directory, manifest.entrypoint)
+  if (!entrypoint.startsWith(`${path.resolve(directory)}${path.sep}`)) {
+    throw new CliError('invalid_runtime', 'Runtime entrypoint escapes its installation directory.')
+  }
+  try {
+    if (!(await stat(entrypoint)).isFile()) throw new Error('not a file')
+  } catch {
+    throw new CliError('invalid_runtime', `Runtime entrypoint is missing: ${entrypoint}`)
+  }
+  return manifest
+}
+
+export async function installBundledRuntime(
+  paths: PascalPaths,
+  sourceDirectory = resolveBundledRuntimeDirectory(),
+  options: { activate?: boolean } = {},
+): Promise<ActiveRuntime> {
+  const sourceManifest = await readRuntimeManifest(sourceDirectory)
+  const targetDirectory = path.join(paths.runtime, sourceManifest.version)
+  await mkdir(paths.runtime, { recursive: true, mode: 0o700 })
+
+  return withFileLock(
+    path.join(paths.run, 'runtime-install.lock'),
+    'install_locked',
+    'Another Pascal runtime installation is active.',
+    async () => {
+      await removeAbandonedInstallDirectories(paths.runtime)
+      const installed = await readInstalledManifest(targetDirectory)
+      if (
+        installed?.version === sourceManifest.version &&
+        (await isRuntimeValid(targetDirectory, sourceManifest.version))
+      ) {
+        return options.activate === false
+          ? runtimeRecord(sourceManifest.version, targetDirectory)
+          : activateRuntime(paths, sourceManifest.version, targetDirectory)
+      }
+      const temporaryDirectory = path.join(
+        paths.runtime,
+        `.install-${sourceManifest.version}-${process.pid}`,
+      )
+      await rm(temporaryDirectory, { recursive: true, force: true })
+      await cp(sourceDirectory, temporaryDirectory, { recursive: true, dereference: false })
+      await readRuntimeManifest(temporaryDirectory)
+      await rm(targetDirectory, { recursive: true, force: true })
+      await rename(temporaryDirectory, targetDirectory)
+      return options.activate === false
+        ? runtimeRecord(sourceManifest.version, targetDirectory)
+        : activateRuntime(paths, sourceManifest.version, targetDirectory)
+    },
+  )
+}
+
+export async function readActiveRuntime(paths: PascalPaths): Promise<ActiveRuntime | null> {
+  let active: ActiveRuntime | null
+  try {
+    active = await readJsonFile<ActiveRuntime>(paths.currentRuntime)
+  } catch {
+    throw new CliError('invalid_runtime', 'The active runtime pointer is not valid JSON.')
+  }
+  if (
+    active?.schemaVersion !== 1 ||
+    typeof active.version !== 'string' ||
+    typeof active.directory !== 'string'
+  ) {
+    return null
+  }
+  const resolvedDirectory = path.resolve(active.directory)
+  if (!resolvedDirectory.startsWith(`${path.resolve(paths.runtime)}${path.sep}`)) {
+    throw new CliError('invalid_runtime', 'The active runtime is outside Pascal runtime storage.')
+  }
+  const manifest = await readRuntimeManifest(resolvedDirectory)
+  if (manifest.version !== active.version) {
+    throw new CliError('invalid_runtime', 'The active runtime version does not match its manifest.')
+  }
+  return active
+}
+
+export async function activateRuntime(
+  paths: PascalPaths,
+  version: string,
+  directory: string,
+): Promise<ActiveRuntime> {
+  const resolvedDirectory = path.resolve(directory)
+  if (!resolvedDirectory.startsWith(`${path.resolve(paths.runtime)}${path.sep}`)) {
+    throw new CliError('invalid_runtime', 'Cannot activate a runtime outside Pascal storage.')
+  }
+  const manifest = await readRuntimeManifest(resolvedDirectory)
+  if (manifest.version !== version) {
+    throw new CliError('invalid_runtime', 'Cannot activate a runtime with a mismatched version.')
+  }
+  const active: ActiveRuntime = { schemaVersion: 1, version, directory: resolvedDirectory }
+  await writeJsonFile(paths.currentRuntime, active)
+  return active
+}
+
+function runtimeRecord(version: string, directory: string): ActiveRuntime {
+  return { schemaVersion: 1, version, directory }
+}
+
+async function isRuntimeValid(directory: string, version: string): Promise<boolean> {
+  try {
+    return (await readRuntimeManifest(directory)).version === version
+  } catch {
+    return false
+  }
+}
+
+async function readInstalledManifest(directory: string): Promise<RuntimeManifest | null> {
+  try {
+    return await readJsonFile<RuntimeManifest>(path.join(directory, 'runtime-manifest.json'))
+  } catch {
+    return null
+  }
+}
+
+async function removeAbandonedInstallDirectories(runtimeDirectory: string): Promise<void> {
+  const entries = await readdir(runtimeDirectory, { withFileTypes: true })
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith('.install-'))
+      .map((entry) =>
+        rm(path.join(runtimeDirectory, entry.name), { recursive: true, force: true }),
+      ),
+  )
+}

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,7 @@
+import { readFileSync } from 'node:fs'
+
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { version: string }
+
+export const version = packageJson.version

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@pascal/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "composite": true,
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "scripts"]
+}

--- a/packages/cli/tsconfig.scripts.json
+++ b/packages/cli/tsconfig.scripts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@pascal/typescript-config/base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["scripts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,8 @@
         "POSTGRES_URL",
         "NEXT_PUBLIC_SUPABASE_URL",
         "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-        "SUPABASE_SERVICE_ROLE_KEY"
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "PASCAL_PORTABLE_BUILD"
       ]
     },
     "lint": {


### PR DESCRIPTION
## Summary
- add `@pascal-app/cli` for persistent local editor installation and lifecycle management
- package and smoke-test the standalone editor runtime, including update rollback and damaged-runtime recovery
- add CI and recoverable npm release support plus CLI documentation

## Test plan
- [x] `bun install --frozen-lockfile` with Bun 1.3.14
- [x] `bun run check`
- [x] `bun run check-types`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run prepublishOnly` in `packages/cli`
- [x] packed runtime starts at `pascal.localhost`, serves `/scenes`, and stops cleanly

Generated with OpenAI Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New distribution surface (local process manager, bundled runtime, npm publish path) plus release workflow changes; core app auth unchanged but shipping and lifecycle behavior affects all CLI users.
> 
> **Overview**
> Introduces **`@pascal-app/cli`**, a Node 22.13+ tool to install a versioned standalone editor under `~/.pascal`, start/stop it on loopback, health-check via `/api/health`, update with rollback, and recover damaged runtimes—without cloning the repo. The npm tarball bundles a **portable Next standalone** built with `PASCAL_PORTABLE_BUILD=1`, staged via `stage-runtime` and validated by `smoke-packed-runtime` (size budgets, packed install, reuse of a running process).
> 
> **CI/release:** macOS `cli-smoke` on every CI run; release adds a `cli` package option, gates publish on smoke, validates the portable runtime before CLI publish, publishes CLI with `--ignore-scripts`, and makes npm publish **idempotent** when a version already exists. Release commit/push is safer when version files are unchanged (`--atomic` push, optional skip commit).
> 
> **Editor app:** `/api/health` now returns `version` and `instanceId` from env for CLI identity checks; `next.config` enables standalone output and unoptimized images when building portable.
> 
> **Docs:** README/SETUP describe `npx @pascal-app/cli editor` and monorepo layout including `packages/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e211915431472396104c396c5611989c9d6de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->