### PR TITLE
fix(cli): support flat standalone dependencies

### DIFF
--- a/packages/cli/scripts/stage-runtime.ts
+++ b/packages/cli/scripts/stage-runtime.ts
@@ -74,7 +74,8 @@ async function removeUnusedSharp(root: string): Promise<void> {
   let entries: string[] = []
   try {
     entries = await readdir(bunModules)
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
     return
   }
   await Promise.all(
@@ -89,7 +90,14 @@ async function removeUnusedSharp(root: string): Promise<void> {
 async function flattenBunNodeModules(root: string): Promise<void> {
   const nodeModules = path.join(root, 'node_modules')
   const bunNodeModules = path.join(nodeModules, '.bun/node_modules')
-  for (const entry of await readdir(bunNodeModules, { withFileTypes: true })) {
+  let entries
+  try {
+    entries = await readdir(bunNodeModules, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    return
+  }
+  for (const entry of entries) {
     if (entry.name.startsWith('@') && entry.isDirectory()) {
       const scope = path.join(bunNodeModules, entry.name)
       for (const packageEntry of await readdir(scope, { withFileTypes: true })) {


### PR DESCRIPTION
## Summary
- allow runtime staging when a clean standalone build already has flat dependencies and no Bun linkage directory
- preserve real filesystem errors instead of silently treating them as optional directories

## Verification
- `bunx biome check packages/cli/scripts/stage-runtime.ts`
- `bun run --cwd packages/cli check-types`
- `bun test packages/cli/src` (20 passed)
- `bun run --cwd packages/cli prepublishOnly`
- packed-tarball smoke from a synthetic flat standalone runtime with no `.bun/node_modules`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to optional-directory handling in the CLI packaging script; no auth, data, or runtime behavior changes beyond avoiding false failures on flat layouts.
> 
> **Overview**
> **Runtime staging** now tolerates standalone builds that already ship **flat `node_modules`** and lack Bun’s `.bun` / `.bun/node_modules` layout.
> 
> `removeUnusedSharp` and `flattenBunNodeModules` no longer treat every `readdir` failure as “optional”: only **`ENOENT`** is ignored; other filesystem errors propagate so real staging problems aren’t swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc82aeeaee6baed65de8cf9403a14506fc3b5dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->