### PR TITLE
test: codify space-detection commit visibility

### DIFF
--- a/packages/core/src/lib/space-detection.test.ts
+++ b/packages/core/src/lib/space-detection.test.ts
@@ -3,7 +3,11 @@ import { BuildingNode, CeilingNode, LevelNode, SlabNode, WallNode, ZoneNode } fr
 import type { AnyNode, AnyNodeId } from '../schema/types'
 import { resolveCeilingHeight } from '../services/level-height'
 import { getCeilingClampBound } from '../services/storey'
-import { runWithSceneCommitNodeIds, type SceneCommit, subscribeSceneCommits } from '../store/history-control'
+import {
+  runWithSceneCommitNodeIds,
+  type SceneCommit,
+  subscribeSceneCommits,
+} from '../store/history-control'
 import useScene, { clearSceneHistory } from '../store/use-scene'
 import {
   detectSpacesForLevel,

--- a/packages/core/src/lib/space-detection.test.ts
+++ b/packages/core/src/lib/space-detection.test.ts
@@ -3,7 +3,8 @@ import { BuildingNode, CeilingNode, LevelNode, SlabNode, WallNode, ZoneNode } fr
 import type { AnyNode, AnyNodeId } from '../schema/types'
 import { resolveCeilingHeight } from '../services/level-height'
 import { getCeilingClampBound } from '../services/storey'
-import { runWithSceneCommitNodeIds } from '../store/history-control'
+import { runWithSceneCommitNodeIds, type SceneCommit, subscribeSceneCommits } from '../store/history-control'
+import useScene, { clearSceneHistory } from '../store/use-scene'
 import {
   detectSpacesForLevel,
   initSpaceDetectionSync,
@@ -16,6 +17,16 @@ import {
 } from './space-detection'
 import { encodeTerrainField } from './terrain-codec'
 import { applyHeightPatch, createTerrainField, flattenPatch } from './terrain-field'
+
+type RafFn = (callback: (time: number) => void) => number
+;(globalThis as unknown as { requestAnimationFrame?: RafFn }).requestAnimationFrame ??= (
+  callback,
+) => {
+  callback(0)
+  return 0
+}
+;(globalThis as unknown as { cancelAnimationFrame?: (id: number) => void }).cancelAnimationFrame ??=
+  () => {}
 
 const square: Array<[number, number]> = [
   [0, 0],
@@ -44,6 +55,114 @@ function slab(elevation: number) {
     autoFromWalls: true,
   })
 }
+
+describe('space detection scene commit boundary', () => {
+  test('includes room reconciliation in the closing wall commit and undo step', () => {
+    const buildingId = 'building_space_commit' as AnyNodeId
+    const levelId = 'level_space_commit' as AnyNodeId
+    const walls = [
+      WallNode.parse({
+        id: 'wall_space_commit_bottom',
+        parentId: levelId,
+        start: [0, 0],
+        end: [4, 0],
+      }),
+      WallNode.parse({
+        id: 'wall_space_commit_right',
+        parentId: levelId,
+        start: [4, 0],
+        end: [4, 3],
+      }),
+      WallNode.parse({
+        id: 'wall_space_commit_top',
+        parentId: levelId,
+        start: [4, 3],
+        end: [0, 3],
+      }),
+      WallNode.parse({
+        id: 'wall_space_commit_left',
+        parentId: levelId,
+        start: [0, 3],
+        end: [0, 0],
+      }),
+    ]
+    const initialWalls = walls.slice(0, 3)
+    const building = BuildingNode.parse({
+      id: buildingId,
+      children: [levelId],
+    })
+    const level = LevelNode.parse({
+      id: levelId,
+      parentId: buildingId,
+      children: initialWalls.map((wall) => wall.id),
+      level: 0,
+      height: 2.5,
+    })
+    const initialNodes = Object.fromEntries(
+      [building, level, ...initialWalls].map((node) => [node.id, node]),
+    ) as Record<AnyNodeId, AnyNode>
+
+    // The real singleton is required to exercise zundo's commit snapshot boundary.
+    const previousSceneState = useScene.getState()
+    useScene.setState({
+      nodes: initialNodes,
+      rootNodeIds: [buildingId],
+      dirtyNodes: new Set<AnyNodeId>(),
+      collections: {},
+      materials: {},
+      installedPlugins: [],
+      readOnly: false,
+    } as never)
+    clearSceneHistory()
+
+    const commits: SceneCommit[] = []
+    const stopDetection = initSpaceDetectionSync(useScene, createEditorStoreStub())
+    const stopCommits = subscribeSceneCommits((commit) => commits.push(commit))
+
+    try {
+      const closingWall = walls[3]!
+      useScene.getState().createNode(closingWall, levelId)
+
+      const liveNodes = useScene.getState().nodes
+      const autoSlab = Object.values(liveNodes).find(
+        (node): node is SlabNode => node.type === 'slab' && node.autoFromWalls,
+      )
+      const autoCeiling = Object.values(liveNodes).find(
+        (node): node is CeilingNode => node.type === 'ceiling' && node.autoFromWalls,
+      )
+      expect(autoSlab).toBeDefined()
+      expect(autoCeiling).toBeDefined()
+
+      const localCommits = commits.filter((commit) => commit.origin === 'local')
+      expect(localCommits).toHaveLength(1)
+      const currentNodes = localCommits[0]!.current.nodes
+      expect(Object.keys(currentNodes).sort()).toEqual(Object.keys(liveNodes).sort())
+
+      const committedLevel = currentNodes[levelId] as LevelNode
+      expect(committedLevel.children).toEqual(
+        expect.arrayContaining([closingWall.id, autoSlab!.id, autoCeiling!.id]),
+      )
+      for (const wall of walls) {
+        const committedWall = currentNodes[wall.id] as WallNode
+        expect(committedWall.frontSide).toBe('interior')
+        expect(committedWall.backSide).toBe('exterior')
+      }
+      expect(useScene.temporal.getState().pastStates).toHaveLength(1)
+
+      useScene.temporal.getState().undo()
+
+      const undoneNodes = useScene.getState().nodes
+      expect(undoneNodes[closingWall.id]).toBeUndefined()
+      expect(undoneNodes[autoSlab!.id]).toBeUndefined()
+      expect(undoneNodes[autoCeiling!.id]).toBeUndefined()
+    } finally {
+      stopCommits()
+      stopDetection()
+      useScene.setState(previousSceneState, true)
+      clearSceneHistory()
+    }
+  })
+})
 
 describe('planAutoCeilingsForLevel', () => {
   test('creates auto ceilings height-less so they follow the level top', () => {

--- a/packages/core/src/lib/space-detection.test.ts
+++ b/packages/core/src/lib/space-detection.test.ts
@@ -3,6 +3,8 @@ import { BuildingNode, CeilingNode, LevelNode, SlabNode, WallNode, ZoneNode } fr
 import type { AnyNode, AnyNodeId } from '../schema/types'
 import { resolveCeilingHeight } from '../services/level-height'
 import { getCeilingClampBound } from '../services/storey'
+import { type SceneCommit, subscribeSceneCommits } from '../store/history-control'
+import useScene, { clearSceneHistory } from '../store/use-scene'
 import {
   detectSpacesForLevel,
   initSpaceDetectionSync,
@@ -14,6 +16,16 @@ import {
 } from './space-detection'
 import { encodeTerrainField } from './terrain-codec'
 import { applyHeightPatch, createTerrainField, flattenPatch } from './terrain-field'
+
+type RafFn = (callback: (time: number) => void) => number
+;(globalThis as unknown as { requestAnimationFrame?: RafFn }).requestAnimationFrame ??= (
+  callback,
+) => {
+  callback(0)
+  return 0
+}
+;(globalThis as unknown as { cancelAnimationFrame?: (id: number) => void }).cancelAnimationFrame ??=
+  () => {}
 
 const square: Array<[number, number]> = [
   [0, 0],
@@ -42,6 +54,111 @@ function slab(elevation: number) {
     autoFromWalls: true,
   })
 }
+
+describe('space detection scene commit boundary', () => {
+  test('includes room reconciliation in the closing wall commit and undo step', () => {
+    const buildingId = 'building_space_commit' as AnyNodeId
+    const levelId = 'level_space_commit' as AnyNodeId
+    const walls = [
+      WallNode.parse({
+        id: 'wall_space_commit_bottom',
+        parentId: levelId,
+        start: [0, 0],
+        end: [4, 0],
+      }),
+      WallNode.parse({
+        id: 'wall_space_commit_right',
+        parentId: levelId,
+        start: [4, 0],
+        end: [4, 3],
+      }),
+      WallNode.parse({
+        id: 'wall_space_commit_top',
+        parentId: levelId,
+        start: [4, 3],
+        end: [0, 3],
+      }),
+      WallNode.parse({
+        id: 'wall_space_commit_left',
+        parentId: levelId,
+        start: [0, 3],
+        end: [0, 0],
+      }),
+    ]
+    const initialWalls = walls.slice(0, 3)
+    const building = BuildingNode.parse({
+      id: buildingId,
+      children: [levelId],
+    })
+    const level = LevelNode.parse({
+      id: levelId,
+      parentId: buildingId,
+      children: initialWalls.map((wall) => wall.id),
+      level: 0,
+      height: 2.5,
+    })
+    const initialNodes = Object.fromEntries(
+      [building, level, ...initialWalls].map((node) => [node.id, node]),
+    ) as Record<AnyNodeId, AnyNode>
+
+    useScene.setState({
+      nodes: initialNodes,
+      rootNodeIds: [buildingId],
+      dirtyNodes: new Set<AnyNodeId>(),
+      collections: {},
+      materials: {},
+      installedPlugins: [],
+      readOnly: false,
+    } as never)
+    clearSceneHistory()
+
+    const commits: SceneCommit[] = []
+    const stopDetection = initSpaceDetectionSync(useScene, createEditorStoreStub())
+    const stopCommits = subscribeSceneCommits((commit) => commits.push(commit))
+
+    try {
+      const closingWall = walls[3]!
+      useScene.getState().createNode(closingWall, levelId)
+
+      const liveNodes = useScene.getState().nodes
+      const autoSlab = Object.values(liveNodes).find(
+        (node): node is SlabNode => node.type === 'slab' && node.autoFromWalls,
+      )
+      const autoCeiling = Object.values(liveNodes).find(
+        (node): node is CeilingNode => node.type === 'ceiling' && node.autoFromWalls,
+      )
+      expect(autoSlab).toBeDefined()
+      expect(autoCeiling).toBeDefined()
+
+      const localCommits = commits.filter((commit) => commit.origin === 'local')
+      expect(localCommits).toHaveLength(1)
+      const currentNodes = localCommits[0]!.current.nodes
+      expect(Object.keys(currentNodes).sort()).toEqual(Object.keys(liveNodes).sort())
+
+      const committedLevel = currentNodes[levelId] as LevelNode
+      expect(committedLevel.children).toEqual(
+        expect.arrayContaining([closingWall.id, autoSlab!.id, autoCeiling!.id]),
+      )
+      for (const wall of walls) {
+        const committedWall = currentNodes[wall.id] as WallNode
+        expect(committedWall.frontSide).toBe('interior')
+        expect(committedWall.backSide).toBe('exterior')
+      }
+      expect(useScene.temporal.getState().pastStates).toHaveLength(1)
+
+      useScene.temporal.getState().undo()
+
+      const undoneNodes = useScene.getState().nodes
+      expect(undoneNodes[closingWall.id]).toBeUndefined()
+      expect(undoneNodes[autoSlab!.id]).toBeUndefined()
+      expect(undoneNodes[autoCeiling!.id]).toBeUndefined()
+    } finally {
+      stopCommits()
+      stopDetection()
+      clearSceneHistory()
+    }
+  })
+})
 
 describe('planAutoCeilingsForLevel', () => {
   test('creates auto ceilings height-less so they follow the level top', () => {

--- a/packages/core/src/lib/space-detection.ts
+++ b/packages/core/src/lib/space-detection.ts
@@ -1633,6 +1633,11 @@ export function initSpaceDetectionSync(sceneStore: any, editorStore: any): () =>
   const previousSnapshots = levelStructureSnapshots(sceneStore.getState().nodes)
   let isProcessing = false
 
+  // Keep reconciliation in this synchronous store subscription. Zundo emits
+  // the originating local SceneCommit only after subscribers return, so the
+  // history-paused derived writes below join that commit's current snapshot
+  // and undo step. Running from subscribeSceneCommits would cross the snapshot
+  // boundary, and the paused writes would emit no replacement commit.
   const unsubscribe = sceneStore.subscribe((state: any) => {
     if (isProcessing) return
     if (getSceneHistoryPauseDepth() > 0) return

--- a/packages/core/src/lib/space-detection.ts
+++ b/packages/core/src/lib/space-detection.ts
@@ -2427,6 +2427,11 @@ export function initSpaceDetectionSync(
     adoptSceneBaseline(commit.current.nodes)
   })
 
+  // Keep reconciliation in this synchronous store subscription. Zundo emits
+  // the originating local SceneCommit only after subscribers return, so the
+  // history-paused derived writes below join that commit's current snapshot
+  // and undo step. Running from subscribeSceneCommits would cross the snapshot
+  // boundary, and the paused writes would emit no replacement commit.
   const unsubscribe = sceneStore.subscribe((state: any) => {
     if (isProcessing) return
     if (getSceneHistoryPauseDepth() > 0) return

--- a/wiki/architecture/README.md
+++ b/wiki/architecture/README.md
@@ -23,6 +23,7 @@ Canonical rules for code that touches `packages/core`, `packages/viewer`, `packa
 | [spatial-queries](spatial-queries.md) | Placement validation (`canPlaceOnFloor`/`Wall`/`Ceiling`) for tools |
 | [node-schemas](node-schemas.md) | Zod schema pattern for node types, `createNode`, `updateNode` |
 | [vertical-model](vertical-model.md) | Stored level heights, plane-bound wall/ceiling tops, slab placement + thickness, support hosts, clamp rules, and the load migration |
+| [space-detection](space-detection.md) | Commit and replication contract for wall-driven room reconciliation |
 | [events](events.md) | Typed event bus — emitting and listening to node and grid events |
 | [creating-rules](creating-rules.md) | How to add or update a page in this folder |
 

--- a/wiki/architecture/README.md
+++ b/wiki/architecture/README.md
@@ -25,6 +25,7 @@ Canonical rules for code that touches `packages/core`, `packages/viewer`, `packa
 | [node-schemas](node-schemas.md) | Zod schema pattern for node types, `createNode`, `updateNode` |
 | [inspector-field-limits](inspector-field-limits.md) | When a numeric inspector field may and may not have `min`/`max` — no arbitrary caps on dimensions |
 | [vertical-model](vertical-model.md) | Stored level heights, plane-bound wall/ceiling tops, slab placement + thickness, support hosts, clamp rules, and the load migration |
+| [space-detection](space-detection.md) | Commit and replication contract for wall-driven room reconciliation |
 | [events](events.md) | Typed event bus — emitting and listening to node and grid events |
 | [creating-rules](creating-rules.md) | How to add or update a page in this folder |
 

--- a/wiki/architecture/space-detection.md
+++ b/wiki/architecture/space-detection.md
@@ -1,0 +1,33 @@
+# Space Detection
+
+*Commit and replication contract for wall-driven room reconciliation.*
+
+Applies to: `packages/core/src/lib/space-detection.ts`, `packages/core/src/store/**`, and collaboration consumers of `SceneCommit`.
+
+Space detection derives room state from wall geometry. Reconciliation updates wall side classifications, creates or updates automatic slabs and ceilings, and updates their level's `children`. Those derived writes are part of the wall edit that triggered them, not a later background operation.
+
+## Local commit boundary
+
+`initSpaceDetectionSync` must remain a synchronous scene-store subscriber. A local wall mutation and all reconciliation it triggers must finish before zundo emits the mutation's `SceneCommit` snapshot.
+
+Reconciliation pauses scene history while applying derived writes. This keeps the triggering edit and its generated state in one undo step, while the outer tracked mutation still captures the final reconciled graph in `SceneCommit.current`. The emitted snapshot must therefore contain:
+
+- the triggering wall edit;
+- reconciled `frontSide` and `backSide` values;
+- generated or updated automatic slabs and ceilings; and
+- the corresponding level `children` updates.
+
+Do not schedule reconciliation from `subscribeSceneCommits`. Commit listeners run after the snapshot boundary. Because reconciliation writes are history-paused, moving the work there would neither amend the emitted snapshot nor produce a second local commit, leaving collaboration consumers unable to transmit the generated state.
+
+## Host patch consumption
+
+The originating client is the only client that reconciles a local wall edit and mints IDs for generated room surfaces. Collaboration transports the resulting before/current difference, including the generated nodes and parent updates.
+
+Receiving clients apply that transmitted graph as a host patch. Host application is history-paused and may run while the scene is read-only, so space detection must not regenerate the room locally. The receiver consumes the originator's slab and ceiling IDs and records no local undo entry or local commit for the host change.
+
+This two-sided contract prevents peers from independently minting different IDs for the same room:
+
+1. Local wall edit → synchronous reconciliation → one complete local commit and one undo step.
+2. Host patch → apply the transmitted generated state → no local reconciliation or local history entry.
+
+Changes to space-detection scheduling, history pausing, scene commit delivery, or host patch application must preserve both sides of this contract.


### PR DESCRIPTION
## What does this PR do? / ## How to test / ## Screenshots / screen recording / ## Checklist (bun dev, bun check, docs, main-branch boxes)

Preserve `initSpaceDetectionSync` as a synchronous scene-store subscriber and add a focused rationale at that integration point explaining that reconciliation must finish within the triggering local transaction before its commit snapshot is emitted. Add an architecture page that defines the two-sided replication contract: local reconciliation output is included in the originating commit, while host patches consume those nodes under read-only mode rather than re-running reconciliation. Link that page from the architecture index so future changes to space detection, history pausing, or commit delivery encounter the invariant during design review.

Fixes #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests and documentation only plus an explanatory comment; no changes to reconciliation scheduling or history pausing logic.
> 
> **Overview**
> Locks in how wall-driven room reconciliation must interact with **scene history** and **`SceneCommit`** snapshots, without changing runtime behavior in `initSpaceDetectionSync`.
> 
> Adds an **integration test** on the real `useScene` store: placing the closing wall must yield **one** local commit whose snapshot includes auto slab/ceiling, reconciled wall `frontSide`/`backSide`, and updated level `children`, and **one undo** that removes the wall and generated surfaces together. Documents in **`space-detection.ts`** that reconciliation must stay in the **synchronous** scene-store subscriber (not `subscribeSceneCommits`), because zundo emits the local commit after subscribers return and history-paused derived writes must land inside that boundary.
> 
> Introduces **`wiki/architecture/space-detection.md`** (linked from the architecture index) describing the two-sided contract: local edits reconcile synchronously into the originating commit; peers apply host patches without re-running detection or minting new IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b00703cab7712ce7a87adeaedbadee590bf0faa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->