### PR TITLE
fix(core): keep numeric sanitize diagnostics fail-safe

### DIFF
--- a/packages/core/src/store/actions/node-actions.ts
+++ b/packages/core/src/store/actions/node-actions.ts
@@ -459,14 +459,24 @@ function formatNumericValue(value: number) {
   return String(value)
 }
 
-function numericSanitizeIssuesToMessage(issues: NumericSanitizeIssue[]): string {
-  return issues
-    .map((issue) => {
-      const path = issue.path.map(String).join('.') || '<root>'
-      const to = issue.to === undefined ? '' : ` -> ${formatNumericValue(issue.to)}`
-      return `${path}: ${formatNumericValue(issue.from)} ${issue.action}${to}`
-    })
-    .join('; ')
+export function numericSanitizeIssuesToMessage(
+  issues: NumericSanitizeIssue[] | null | undefined,
+): string {
+  if (!Array.isArray(issues)) return ''
+
+  try {
+    return issues
+      .map((issue) => {
+        const path = Array.isArray(issue?.path)
+          ? issue.path.map(String).join('.') || '<root>'
+          : '<unknown>'
+        const to = issue?.to === undefined ? '' : ` -> ${formatNumericValue(issue.to)}`
+        return `${path}: ${formatNumericValue(issue?.from)} ${issue?.action ?? 'sanitized'}${to}`
+      })
+      .join('; ')
+  } catch {
+    return '<diagnostic unavailable>'
+  }
 }
 
 function warnSanitizedNodeMutation(
@@ -474,11 +484,18 @@ function warnSanitizedNodeMutation(
   nodeId: AnyNodeId,
   issues: NumericSanitizeIssue[],
 ) {
-  console.warn(
-    `[Scene] Sanitized invalid numeric node ${mutation}`,
-    nodeId,
-    numericSanitizeIssuesToMessage(issues),
-  )
+  let message = '<diagnostic unavailable>'
+  try {
+    message = numericSanitizeIssuesToMessage(issues)
+  } catch {
+    // Reporting must never interrupt a node mutation.
+  }
+
+  try {
+    console.warn(`[Scene] Sanitized invalid numeric node ${mutation}`, nodeId, message)
+  } catch {
+    // A broken diagnostic sink must not interrupt a node mutation either.
+  }
 }
 
 function parseCreatedNode(node: AnyNode, parentId: AnyNodeId | null): AnyNode {

--- a/packages/core/src/store/actions/node-mutation-sanitize.test.ts
+++ b/packages/core/src/store/actions/node-mutation-sanitize.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import type { AnyNode, AnyNodeId } from '../../schema/types'
 import useScene from '../use-scene'
+import { numericSanitizeIssuesToMessage } from './node-actions'
 
 type RafFn = (cb: (t: number) => void) => number
 ;(globalThis as unknown as { requestAnimationFrame?: RafFn }).requestAnimationFrame ??= ((
@@ -87,6 +88,21 @@ function shelf() {
   return useScene.getState().nodes[SHELF_ID] as Extract<AnyNode, { type: 'shelf' }>
 }
 
+describe('numeric sanitization diagnostics', () => {
+  test('formats missing and non-array issue paths defensively', () => {
+    const issues = [
+      { from: Infinity, action: 'dropped' },
+      { path: 'width', from: Number.NaN, action: 'dropped' },
+    ] as never
+
+    expect(numericSanitizeIssuesToMessage(issues)).toBe(
+      '<unknown>: Infinity dropped; <unknown>: NaN dropped',
+    )
+    expect(numericSanitizeIssuesToMessage(null)).toBe('')
+    expect(numericSanitizeIssuesToMessage(undefined)).toBe('')
+  })
+})
+
 describe('node mutation numeric sanitization', () => {
   beforeEach(() => {
     useScene.setState({
@@ -169,6 +185,29 @@ describe('node mutation numeric sanitization', () => {
 
     const panel = useScene.getState().nodes[SOLAR_PANEL_ID] as { name?: string }
     expect(panel.name).toBe('Updated panel')
+  })
+
+  test('updateNodes continues through schema-invalid numeric updates when reporting throws', () => {
+    const originalConsoleWarn = console.warn
+    console.warn = () => {
+      throw new Error('diagnostic sink failed')
+    }
+
+    try {
+      useScene.getState().updateNodes([
+        { id: SHELF_ID, data: { width: Infinity } as Partial<AnyNode> },
+        {
+          id: SOLAR_PANEL_ID,
+          data: { name: 'Updated after invalid numeric value' } as Partial<AnyNode>,
+        },
+      ])
+    } finally {
+      console.warn = originalConsoleWarn
+    }
+
+    expect(shelf().width).toBe(1.2)
+    const panel = useScene.getState().nodes[SOLAR_PANEL_ID] as { name?: string }
+    expect(panel.name).toBe('Updated after invalid numeric value')
   })
 
   test('sanitizes non-finite numeric values during create', () => {


### PR DESCRIPTION
## Sentry issues

- `MONOREPO-EDITOR-MK` — `TypeError: Cannot read properties of undefined (reading 'join')`
- `MONOREPO-EDITOR-MJ` — related same-second downstream render failure; this change addresses the shared invalid-update path but does not claim a separate MJ fix.

## Root cause

An invalid numeric node update correctly entered the sanitizer, but its warning formatter assumed every runtime `NumericSanitizeIssue.path` was an array and called `.join()` unconditionally. That made the error reporter throw inside `updateNodesAction`, masking the original schema-validation failure and aborting the remaining update batch. `NumericSanitizeIssue.path` is statically required, and all current `sanitizeNumericValue` call paths start from `[]` and extend with array spreads, so no reproducible in-source producer of an undefined path was found; the Sentry payload demonstrates the runtime invariant was nevertheless violated.

## What changed

- make numeric issue formatting tolerate null/undefined issue lists and missing/non-array paths, with a final non-throwing fallback
- isolate both message construction and the warning sink so diagnostics can never interrupt node mutation
- add regressions for missing paths and for a batched `updateNodes` call continuing after schema-invalid numeric data even when warning output throws

## Verification

- `bun test packages/core/src/store/actions/node-mutation-sanitize.test.ts` — PASS: 11 passed, 0 failed
- `bun biome lint packages/core/src/store/actions/node-actions.ts packages/core/src/store/actions/node-mutation-sanitize.test.ts` — PASS: checked 2 files, no fixes applied
- `git diff --check` — PASS

This is unverified against production traffic and needs review before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to diagnostic logging around existing sanitization; behavior change is fail-safe continuation of mutations with added defensive formatting.
> 
> **Overview**
> Hardens **numeric sanitization warning** formatting so bad diagnostic data cannot abort node create/update batches (fixes Sentry `path.join` on undefined).
> 
> **`numericSanitizeIssuesToMessage`** is exported and now accepts null/undefined issue lists, treats missing or non-array `path` as `<unknown>`, and falls back to `<diagnostic unavailable>` instead of throwing.
> 
> **`warnSanitizedNodeMutation`** wraps both message building and `console.warn` in try/catch so a broken formatter or logging sink never interrupts mutations.
> 
> Adds tests for defensive issue formatting and for **`updateNodes`** applying later updates when `console.warn` throws after an invalid numeric patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def7b3157fcb4416847b46fbebe1649cdc1ff103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->