### PR TITLE
docs: define plugin viewer appearance contract

### DIFF
--- a/wiki/architecture/materials-and-themes.md
+++ b/wiki/architecture/materials-and-themes.md
@@ -62,6 +62,28 @@ So picking the Mediterranean theme gives a blue roof + warm walls without touchi
 
 Each of these reads `shading`/`textures`/`colorPreset`/`sceneTheme` from `useViewer` (or receives them threaded from `GeometrySystem`) and **must include `sceneTheme` in its material cache key and its rebuild dependency array**, or theme switches won't re-colour. `GeometrySystem` marks every geometry node dirty on any of those changing.
 
+### External plugin renderers
+
+Plugin renderers follow the same four axes through the public `@pascal-app/viewer`
+surface. For an imported hierarchy, capture its authored materials once and apply
+this mapping reactively:
+
+| Host state | Imported material |
+|---|---|
+| Colored + Rendered | Authored material |
+| Colored + Solid | Cached Lambert variant retaining colour, albedo map, alpha, and slots |
+| Monochrome | `createSurfaceRoleMaterial(surfaceRole, colorPreset, side, sceneTheme)` |
+
+The adapter belongs to the plugin renderer because it owns the hierarchy and knows
+which surfaces are furnishing, glazing, or another role. Material swaps happen on
+preference changes, never in `useFrame`. Restore authored materials before disposing
+the loader-owned hierarchy, dispose only plugin-owned variants, and leave host-cached
+role materials alone.
+
+Edges and the expensive render pipeline do not need a plugin material hook: they are
+screen-space host passes over `SCENE_LAYER`. Placement ghosts should use the editor
+overlay layer so they remain crisp and do not enter the scene depth/normal targets.
+
 ## Scene themes
 
 A `SceneTheme` (`lib/scene-themes.ts`) bundles everything that defines a "look":

--- a/wiki/architecture/plugin-authoring.md
+++ b/wiki/architecture/plugin-authoring.md
@@ -104,6 +104,35 @@ import { useDragAction, EDITOR_LAYER } from '@pascal-app/editor'
 
 The packages are **peer dependencies**, not normal dependencies — the host app owns the version. A plugin that pins its own copy of `@pascal-app/core` would create two registries and silently fail. (npm peer-dep resolution catches this at install time.)
 
+## Following viewer appearance and performance preferences
+
+A custom `renderer` owns its materials, so it must follow the same host appearance
+axes as built-in nodes. Subscribe read-only to `useViewer` for `shading`, `textures`,
+`colorPreset`, and `sceneTheme`; do not add plugin-specific quality toggles or copy
+those values into scene data.
+
+- **Colored + Rendered** keeps an imported model's authored materials.
+- **Colored + Solid** uses `createDefaultMaterial(..., 'solid')` or another cached
+  `MeshLambertNodeMaterial` variant. Preserve the authored albedo map, colour,
+  transparency, and material slots, but omit PBR-only maps that defeat the cheaper
+  Solid path.
+- **Monochrome** uses `createSurfaceRoleMaterial(def.surfaceRole, colorPreset, side,
+  sceneTheme)`. Imported props normally declare `surfaceRole: 'furnishing'`.
+- Capture authored materials once when the model loads, cache variants per source
+  material, swap only when preferences change, and restore before disposal. Never
+  clone materials per frame, mutate loader-cached authored materials, or dispose a
+  material returned from a host cache.
+
+`shadows`, `edges`, and the Solid/Rendered post-processing cost are host-global.
+Normal plugin geometry stays on `SCENE_LAYER`, so the light rig and depth/normal
+pipeline include it automatically. Editor-only placement previews belong on
+`OVERLAY_LAYER` / `EDITOR_LAYER`; that keeps ghosts out of shadow, SSGI, and ink-edge
+passes. A plugin only needs to manage `castShadow` / `receiveShadow` for transparent
+or overlay meshes rather than duplicating the host settings.
+
+See [materials and themes](materials-and-themes.md#external-plugin-renderers) for the
+material lifecycle pattern.
+
 ## Lifecycle
 
 ```mermaid
@@ -180,7 +209,7 @@ A plugin's own data versioning is `schemaVersion` on each `NodeDefinition`. The 
 - **Materials** — there's no `plugin.materials` slot. Use `createMaterial` from `@pascal-app/viewer` inside your `def.renderer` / `def.system`.
 - **Floor-plan primitives** — the `FloorplanGeometry` union is host-owned. To draw something the union can't express, fall back to `def.renderer` and render through a different 2D mount (or open an issue).
 - **Panels / sidebar UI in the core manifest** — host-specific. Export an `EditorHostPanel` separately for hosts that use `@pascal-app/editor`.
-- **Stores** — plugins create their own Zustand stores; they don't extend `useScene`, `useEditor`, or `useViewer`. Host stores are not part of the v1 plugin surface.
+- **Stores** — plugins create their own Zustand stores; they don't extend `useScene`, `useEditor`, or `useViewer`. A renderer may subscribe read-only to exported host presentation state such as `useViewer` appearance axes, but must not treat host stores as plugin-owned state.
 - **Routes / pages** — plugins are visualisation + interaction code, not full app surfaces. Hosting a settings page belongs to the app.
 
 The boundary stays narrow on purpose so the contract is shippable. Each "not yet" item is a plan, not a "never."


### PR DESCRIPTION
## Summary\n- require custom renderers to follow host shading, material, theme, shadow, and edge preferences\n- document the imported-material lifecycle for Colored, Solid, and Monochrome modes\n- clarify that plugins may read exported viewer presentation state without extending host stores\n\n## Testing\n- documentation-only change\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Wiki-only changes with no runtime or API modifications.
> 
> **Overview**
> **Documents the plugin viewer appearance contract** so external `renderer` authors know they must read `shading`, `textures`, `colorPreset`, and `sceneTheme` from `useViewer` (read-only) and map imported GLB materials to Colored+Rendered, Colored+Solid, and Monochrome modes using the same helpers as built-ins (`createDefaultMaterial`, `createSurfaceRoleMaterial`), with capture/cache/swap-on-preference-change and safe disposal rules.
> 
> **Adds a cross-linked “External plugin renderers” section** under materials & themes with the host-state → material mapping table and notes that edges/post-processing are host-global on `SCENE_LAYER` while placement ghosts belong on overlay/editor layers.
> 
> **Clarifies plugin boundaries** in plugin-authoring: shadows/edges are host-global; plugins may subscribe to exported presentation state without extending host stores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4451c7e6561ed9eb6367fdfa94663298cb38cdae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->