### PR TITLE
fix(core): share vertical scene canonicalization

### DIFF
--- a/packages/core/src/store/use-scene.ts
+++ b/packages/core/src/store/use-scene.ts
@@ -32,12 +32,9 @@ import {
   type SceneMaterialId,
 } from '../schema/scene-material'
 import { type AnyNode, type AnyNodeId, AnyNode as AnyNodeSchema } from '../schema/types'
-import { deriveLegacyLevelHeight } from '../services/level-height'
-import { getCeilingClampBound } from '../services/storey'
-import { computeWallSlabSupport } from '../systems/slab/slab-support'
-import { DEFAULT_WALL_HEIGHT } from '../systems/wall/wall-footprint'
 import { healSceneNodes } from '../utils/heal-scene-graph'
 import { removeRetiredDrawingSheetNodes } from '../utils/retired-scene-nodes'
+import { migrateVerticalSceneNodes } from '../utils/vertical-scene-migration'
 import * as nodeActions from './actions/node-actions'
 import {
   areSceneSnapshotsEqual,
@@ -608,15 +605,6 @@ function migrateWallAssembly(node: Record<string, any>) {
   return assemblyThickness > 0 ? { ...wall, thickness: assemblyThickness } : wall
 }
 
-// Walls whose top lands within this of the storey plane become plane-bound;
-// ceilings whose stored height lands within this of their clamp bound become
-// follows-mode (step 3f) — same census-backed threshold for both.
-// From a prod census: the 0.15-short "hole pattern" (default 2.5 walls next to
-// a taller wall) must snap to the plane, while intentional 0.20-short walls
-// (2.5 under a 2.7 plane, 2.3 under a 2.5 plane) must keep their explicit
-// height — hence 0.20 with a strictly-less-than comparison.
-const PLANE_BOUND_EPSILON = 0.2
-
 function migrateNodes(nodes: Record<string, any>): {
   nodes: Record<string, AnyNode>
   mintedMaterials: Record<SceneMaterialId, SceneMaterial>
@@ -952,170 +940,8 @@ function migrateNodes(nodes: Record<string, any>): {
     }
   }
 
-  // Pass 3: vertical building model.
-  // A level without `height` marks a scene saved before the vertical model
-  // landed. Computed before this pass mutates anything: the stair-rise
-  // cleanup below must never run on already-migrated scenes.
-  const isLegacyScene = Object.values(patchedNodes).some(
-    (node) => node?.type === 'level' && !('height' in node),
-  )
-
-  // 3a. Ordinal renumber — always runs, per building (idempotent
-  // self-healing; MCP's create-level historically wrote its elevation PARAM
-  // into the ordinal, so fractional/duplicate ordinals exist in the wild).
-  const buildingNodes = Object.values(patchedNodes).filter((node) => node?.type === 'building')
-  const levelsByBuilding = new Map<string | null, Array<{ id: string; ordinal: number }>>()
-  for (const [id, node] of Object.entries(patchedNodes)) {
-    if (node?.type !== 'level') continue
-    // Mirrors the building resolution in services/storey.ts: an explicit
-    // parentId pointing at a building wins, membership in a building's
-    // children array is the legacy fallback, and unresolvable levels share
-    // one orphan bucket.
-    const buildingId =
-      buildingNodes.find((building) => building.id === node.parentId)?.id ??
-      buildingNodes.find((building) => getStringArray(building.children).includes(id))?.id ??
-      null
-    const bucket = levelsByBuilding.get(buildingId) ?? []
-    bucket.push({ id, ordinal: getFiniteNumber(node.level, 0) })
-    levelsByBuilding.set(buildingId, bucket)
-  }
-  for (const bucket of levelsByBuilding.values()) {
-    // Anchored at zero on purpose: ordinals are semantic — `level < 0`
-    // renders "Basement N" and `level === 0` is the ground-floor default —
-    // so negatives compact upward toward −1 and non-negatives compact down
-    // to 0. A blind 0..n renumber would rename basements.
-    const sorted = [...bucket].sort((a, b) => a.ordinal - b.ordinal)
-    const negativeCount = sorted.filter((entry) => entry.ordinal < 0).length
-    sorted.forEach((entry, index) => {
-      const nextOrdinal = index - negativeCount
-      const current = patchedNodes[entry.id]
-      if (current.level !== nextOrdinal) {
-        patchedNodes[entry.id] = { ...current, level: nextOrdinal }
-      }
-    })
-  }
-
-  // 3b. Stored storey heights: materialize the legacy stacked height verbatim
-  // (never rounded or snapped — snapping would move existing buildings).
-  // All planes derive before any wall height below mutates.
-  const legacyLevelIds = Object.entries(patchedNodes)
-    .filter(([, node]) => node?.type === 'level' && !('height' in node))
-    .map(([id]) => id)
-  const derivedHeights = new Map<string, number>()
-  for (const levelId of legacyLevelIds) {
-    derivedHeights.set(
-      levelId,
-      deriveLegacyLevelHeight(levelId, patchedNodes as Record<AnyNodeId, AnyNode>),
-    )
-  }
-
-  for (const levelId of legacyLevelIds) {
-    const plane = derivedHeights.get(levelId)!
-    const level = patchedNodes[levelId]
-    patchedNodes[levelId] = { ...level, height: plane }
-
-    // 3c. Wall-top classification against the just-written plane, using the
-    // same slab-support election as deriveLegacyLevelHeight (call shape
-    // mirrored from services/level-height.ts). Walls whose top meets the
-    // plane drop their explicit height and follow the level from now on;
-    // walls ending short (or tall) keep an explicit height — materializing
-    // the 2.5 default onto absent-height walls that end short of the plane.
-    const children = getStringArray(level.children)
-      .map((childId) => patchedNodes[childId])
-      .filter((child) => child !== undefined)
-    const slabs = children.filter((child) => child.type === 'slab')
-    const walls = children.filter((child) => child.type === 'wall')
-    for (const wall of walls) {
-      const electedBase = computeWallSlabSupport(
-        {
-          start: wall.start,
-          end: wall.end,
-          curveOffset: wall.curveOffset,
-          thickness: wall.thickness,
-        },
-        slabs,
-        walls,
-      ).elevation
-      const effectiveHeight = wall.height ?? DEFAULT_WALL_HEIGHT
-      const top = Math.max(0, electedBase) + effectiveHeight
-      if (Math.abs(plane - top) < PLANE_BOUND_EPSILON) {
-        if ('height' in wall) {
-          const { height: _height, ...planeBound } = wall
-          patchedNodes[wall.id] = planeBound
-        }
-      } else {
-        patchedNodes[wall.id] = { ...wall, height: effectiveHeight }
-      }
-    }
-  }
-
-  // 3d. Stair rise: on legacy scenes a totalRise of exactly 2.5 is the old
-  // schema default, not a user choice — drop it so the rise derives from the
-  // storey height. Gated on isLegacyScene because on a post-migration scene
-  // a stored 2.5 IS a deliberately typed value and must survive reloads.
-  if (isLegacyScene) {
-    for (const [id, node] of Object.entries(patchedNodes)) {
-      if (node?.type !== 'stair') continue
-      if (node.totalRise !== 2.5) continue
-      const { totalRise: _totalRise, ...derivedRise } = node
-      patchedNodes[id] = derivedRise
-    }
-  }
-
-  // 3e. Slab placement/thickness split. `elevation` stays the walking surface;
-  // the new `thickness` grows downward so the solid occupies
-  // [elevation − thickness, elevation]. Legacy solids extruded [0, elevation],
-  // so thickness = elevation EXACTLY (including degenerate 0 — MIN_SLAB_THICKNESS
-  // applies to edits only, never here) keeps the occupied interval identical.
-  // Legacy pools (elevation < 0) become explicit `recessed` intent with
-  // elevation unchanged. Gated per slab on a missing `thickness` — the
-  // migration output is cast, so schema defaults never materialize on load.
-  for (const [id, node] of Object.entries(patchedNodes)) {
-    if (node?.type !== 'slab' || 'thickness' in node) continue
-    const elevation = getFiniteNumber(node.elevation, 0.05)
-    patchedNodes[id] =
-      elevation < 0
-        ? { ...node, thickness: 0.05, recessed: true }
-        : { ...node, thickness: elevation }
-  }
-
-  // 3f. Ceiling follows-mode classification (the ceiling mirror of 3c; runs
-  // after 3b/3e so the clamp bound sees stored level heights and split slab
-  // thicknesses). A stored ceiling height within PLANE_BOUND_EPSILON of its
-  // clamp bound (min(storey plane, covering-slab underside) − margin, via
-  // getCeilingClampBound) is the legacy default tracking the level top, not
-  // a choice — drop it so the ceiling follows the level from now on.
-  // autoFromWalls ceilings always convert: their height was derived by the
-  // space-detection sync, never user intent. Gated on isLegacyScene, which
-  // is exact — nothing shipped between the level-height migration and this
-  // one — and makes the step idempotent. Known accepted edge: a
-  // post-migration user typing a custom height exactly equal to the bound
-  // keeps it (the gate prevents re-classification on later loads).
-  if (isLegacyScene) {
-    for (const [id, node] of Object.entries(patchedNodes)) {
-      if (node?.type !== 'ceiling' || !('height' in node)) continue
-      const dropHeight = () => {
-        const { height: _height, ...follows } = node
-        patchedNodes[id] = follows
-      }
-      if (node.autoFromWalls === true) {
-        dropHeight()
-        continue
-      }
-      if (typeof node.parentId !== 'string') continue
-      const bound = getCeilingClampBound(
-        node.parentId,
-        patchedNodes as Record<AnyNodeId, AnyNode>,
-        Array.isArray(node.polygon) ? node.polygon : [],
-      )
-      const stored = getFiniteNumber(node.height, Number.NaN)
-      if (Number.isFinite(bound) && Math.abs(stored - bound) < PLANE_BOUND_EPSILON) {
-        dropHeight()
-      }
-    }
-  }
-
-  return { nodes: patchedNodes as Record<string, AnyNode>, mintedMaterials }
+  const vertical = migrateVerticalSceneNodes(patchedNodes)
+  return { nodes: vertical.nodes as Record<string, AnyNode>, mintedMaterials }
 }
 
 function getNodeChildIds(node: AnyNode): AnyNodeId[] {

--- a/packages/core/src/utils/scene-migrations.ts
+++ b/packages/core/src/utils/scene-migrations.ts
@@ -7,3 +7,7 @@ export {
   type RetiredSceneNodeMigration,
   removeRetiredDrawingSheetNodes,
 } from './retired-scene-nodes'
+export {
+  migrateVerticalSceneNodes,
+  type VerticalSceneMigration,
+} from './vertical-scene-migration'

--- a/packages/core/src/utils/vertical-scene-migration.ts
+++ b/packages/core/src/utils/vertical-scene-migration.ts
@@ -1,0 +1,167 @@
+import type { AnyNode, AnyNodeId } from '../schema/types'
+import { deriveLegacyLevelHeight } from '../services/level-height'
+import { getCeilingClampBound } from '../services/storey'
+import { computeWallSlabSupport } from '../systems/slab/slab-support'
+import { DEFAULT_WALL_HEIGHT } from '../systems/wall/wall-footprint'
+
+export type VerticalSceneMigration = {
+  changed: boolean
+  nodes: Record<string, unknown>
+}
+
+function getFiniteNumber(value: unknown, fallback: number) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function getStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : []
+}
+
+// Walls whose top lands within this of the storey plane become plane-bound;
+// ceilings whose stored height lands within this of their clamp bound become
+// follows-mode. The strict comparison preserves intentional 0.20-short walls.
+const PLANE_BOUND_EPSILON = 0.2
+
+/**
+ * Applies the vertical-model load migration to serialized scene nodes.
+ *
+ * This must remain pure, idempotent, and server-safe: the editor loader and
+ * hosted scene authority both call it so they compare and persist the same
+ * canonical fields during collaboration.
+ */
+export function migrateVerticalSceneNodes(
+  sourceNodes: Record<string, unknown>,
+): VerticalSceneMigration {
+  const nodes: Record<string, any> = { ...sourceNodes }
+  let changed = false
+  const replaceNode = (id: string, node: Record<string, unknown>) => {
+    nodes[id] = node
+    changed = true
+  }
+
+  // A level without `height` marks a scene saved before the vertical model
+  // landed. Compute the gate before mutating anything so stair and ceiling
+  // intent on already-migrated scenes is never reclassified.
+  const isLegacyScene = Object.values(nodes).some(
+    (node) => node?.type === 'level' && !('height' in node),
+  )
+
+  // Ordinals are semantic and compact independently within each building.
+  const buildingNodes = Object.values(nodes).filter((node) => node?.type === 'building')
+  const levelsByBuilding = new Map<string | null, Array<{ id: string; ordinal: number }>>()
+  for (const [id, node] of Object.entries(nodes)) {
+    if (node?.type !== 'level') continue
+    const buildingId =
+      buildingNodes.find((building) => building.id === node.parentId)?.id ??
+      buildingNodes.find((building) => getStringArray(building.children).includes(id))?.id ??
+      null
+    const bucket = levelsByBuilding.get(buildingId) ?? []
+    bucket.push({ id, ordinal: getFiniteNumber(node.level, 0) })
+    levelsByBuilding.set(buildingId, bucket)
+  }
+  for (const bucket of levelsByBuilding.values()) {
+    const sorted = [...bucket].sort((a, b) => a.ordinal - b.ordinal)
+    const negativeCount = sorted.filter((entry) => entry.ordinal < 0).length
+    sorted.forEach((entry, index) => {
+      const nextOrdinal = index - negativeCount
+      const current = nodes[entry.id]
+      if (current.level !== nextOrdinal) {
+        replaceNode(entry.id, { ...current, level: nextOrdinal })
+      }
+    })
+  }
+
+  // Materialize exact legacy storey planes before classifying wall tops.
+  const legacyLevelIds = Object.entries(nodes)
+    .filter(([, node]) => node?.type === 'level' && !('height' in node))
+    .map(([id]) => id)
+  const derivedHeights = new Map<string, number>()
+  for (const levelId of legacyLevelIds) {
+    derivedHeights.set(
+      levelId,
+      deriveLegacyLevelHeight(levelId, nodes as Record<AnyNodeId, AnyNode>),
+    )
+  }
+
+  for (const levelId of legacyLevelIds) {
+    const plane = derivedHeights.get(levelId)!
+    const level = nodes[levelId]
+    replaceNode(levelId, { ...level, height: plane })
+
+    const children = getStringArray(level.children)
+      .map((childId) => nodes[childId])
+      .filter((child) => child !== undefined)
+    const slabs = children.filter((child) => child.type === 'slab')
+    const walls = children.filter((child) => child.type === 'wall')
+    for (const wall of walls) {
+      const electedBase = computeWallSlabSupport(
+        {
+          start: wall.start,
+          end: wall.end,
+          curveOffset: wall.curveOffset,
+          thickness: wall.thickness,
+        },
+        slabs,
+        walls,
+      ).elevation
+      const effectiveHeight = wall.height ?? DEFAULT_WALL_HEIGHT
+      const top = Math.max(0, electedBase) + effectiveHeight
+      if (Math.abs(plane - top) < PLANE_BOUND_EPSILON) {
+        if ('height' in wall) {
+          const { height: _height, ...planeBound } = wall
+          replaceNode(wall.id, planeBound)
+        }
+      } else if (wall.height !== effectiveHeight) {
+        replaceNode(wall.id, { ...wall, height: effectiveHeight })
+      }
+    }
+  }
+
+  if (isLegacyScene) {
+    for (const [id, node] of Object.entries(nodes)) {
+      if (node?.type !== 'stair' || node.totalRise !== 2.5) continue
+      const { totalRise: _totalRise, ...derivedRise } = node
+      replaceNode(id, derivedRise)
+    }
+  }
+
+  // Preserve the exact occupied interval of legacy slabs.
+  for (const [id, node] of Object.entries(nodes)) {
+    if (node?.type !== 'slab' || 'thickness' in node) continue
+    const elevation = getFiniteNumber(node.elevation, 0.05)
+    replaceNode(
+      id,
+      elevation < 0
+        ? { ...node, thickness: 0.05, recessed: true }
+        : { ...node, thickness: elevation },
+    )
+  }
+
+  if (isLegacyScene) {
+    for (const [id, node] of Object.entries(nodes)) {
+      if (node?.type !== 'ceiling' || !('height' in node)) continue
+      const dropHeight = () => {
+        const { height: _height, ...follows } = node
+        replaceNode(id, follows)
+      }
+      if (node.autoFromWalls === true) {
+        dropHeight()
+        continue
+      }
+      if (typeof node.parentId !== 'string') continue
+      const bound = getCeilingClampBound(
+        node.parentId,
+        nodes as Record<AnyNodeId, AnyNode>,
+        Array.isArray(node.polygon) ? node.polygon : [],
+      )
+      const stored = getFiniteNumber(node.height, Number.NaN)
+      if (Number.isFinite(bound) && Math.abs(stored - bound) < PLANE_BOUND_EPSILON) {
+        dropHeight()
+      }
+    }
+  }
+
+  return changed ? { changed, nodes } : { changed, nodes: sourceNodes }
+}

--- a/wiki/architecture/vertical-model.md
+++ b/wiki/architecture/vertical-model.md
@@ -11,7 +11,7 @@ The invariant, in one sentence:
 > that height and translating the wall from its elected base. Optional terrain infill
 > extends only the bottom; it never changes the authored wall height or top.
 
-**Sources**: `packages/core/src/services/storey.ts`, `packages/core/src/systems/wall/wall-top.ts`, `packages/core/src/systems/slab/slab-support.ts`, `packages/core/src/systems/stair/stair-rise.ts`, `packages/core/src/store/use-scene.ts` (migration Pass 3)
+**Sources**: `packages/core/src/services/storey.ts`, `packages/core/src/systems/wall/wall-top.ts`, `packages/core/src/systems/slab/slab-support.ts`, `packages/core/src/systems/stair/stair-rise.ts`, `packages/core/src/utils/vertical-scene-migration.ts`
 
 ## Stored truth
 
@@ -122,9 +122,9 @@ free: `FloorElevationSystem` writes to the node's registered object, which for t
 selection proxy, not the instance. Such renderers must resolve each instance's Y through
 `getFloorStackedPosition` themselves.
 
-## Load migration (lives in `migrateNodes` Pass 3, indefinitely)
+## Load migration (lives in `migrateVerticalSceneNodes`, indefinitely)
 
-Because community autosave only persists after the first post-load edit, the migration must remain in `migrateNodes`:
+Because community autosave only persists after the first post-load edit, the migration must remain on the load path. It is pure and server-safe so the editor loader and hosted scene authority canonicalize identical fields before collaboration compares or persists an operation:
 
 - Writes each legacy level's **exact** derived height (a default legacy storey stores 2.55 = 0.05 slab + 2.5 wall) — never snapped to presets.
 - Compacts `level` ordinals per building, anchored at zero (non-negatives → 0,1,2…; negatives → −1,−2… — basements stay basements). Runs every load; idempotent.


### PR DESCRIPTION
## Summary

- extract the complete vertical-model load migration into one pure, idempotent core utility
- run the same canonicalization from the editor loader and expose it to hosted scene authorities
- document the shared client/server invariant

## Why

A legacy organization scene could retain an explicit height on an auto-generated ceiling in server authority while the editor removed that field during load. Every recovery snapshot then recreated the representation split and caused subsequent create, delete, undo, and redo operations to conflict.

## Verification

- bun test packages/core/src: 950 passed
- bun run check-types: 10 tasks passed
- bun run build in packages/core: passed
- Biome check on touched TypeScript files: passed
- git diff --check: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Load-path migration logic affects every scene open and collaboration persistence; the refactor is intended to be behavior-preserving but any divergence in ceiling/wall canonicalization would cause ongoing sync conflicts.
> 
> **Overview**
> Moves the vertical-model **load migration** (level heights, ordinals, wall/ceiling plane binding, stair rise, slab thickness) out of `migrateNodes` in the scene store into a pure **`migrateVerticalSceneNodes`** utility, re-exported from **`scene-migrations`** for server-safe use.
> 
> The editor still runs it at the end of `migrateNodes`; hosted scene authorities can run the same path so client and server canonicalize identical node fields before collaboration compares or persists ops—addressing splits like an auto-ceiling keeping an explicit `height` on the server while the editor dropped it on load.
> 
> The utility adds a **`changed`** flag and returns the original nodes reference when nothing mutates; wall classification skips writes when the effective height already matches. **`vertical-model.md`** now points at the shared module and documents the client/server invariant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d77850972470403431926c123753ff11a57f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->