### PR TITLE
fix(editor): harden history command ownership

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -260,6 +260,7 @@ export * from './schema'
 export * from './services'
 export { isMovable, movePlanToward, moveToward, resolveMovable } from './services/movement'
 export {
+  acquireSceneHistoryPause,
   getSceneHistoryPauseDepth,
   pauseSceneHistory,
   resetSceneHistoryPauseDepth,

--- a/packages/core/src/store/history-control.test.ts
+++ b/packages/core/src/store/history-control.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import {
+  acquireSceneHistoryPause,
+  getSceneHistoryPauseDepth,
+  pauseSceneHistory,
+  resetSceneHistoryPauseDepth,
+  resumeSceneHistory,
+} from './history-control'
+
+function temporalStore() {
+  const pause = mock(() => {})
+  const resume = mock(() => {})
+  return {
+    pause,
+    resume,
+    store: { temporal: { getState: () => ({ pause, resume }) } },
+  }
+}
+
+describe('scene history pause ownership', () => {
+  beforeEach(() => resetSceneHistoryPauseDepth())
+
+  test('releases each ownership lease exactly once', () => {
+    const { pause, resume, store } = temporalStore()
+    const releaseFirst = acquireSceneHistoryPause(store)
+    const releaseSecond = acquireSceneHistoryPause(store)
+
+    expect(getSceneHistoryPauseDepth()).toBe(2)
+    expect(pause).toHaveBeenCalledTimes(1)
+    releaseFirst()
+    releaseFirst()
+    expect(getSceneHistoryPauseDepth()).toBe(1)
+    expect(resume).toHaveBeenCalledTimes(0)
+    releaseSecond()
+    expect(getSceneHistoryPauseDepth()).toBe(0)
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not let a lease release consume an anonymous pause owner', () => {
+    const { pause, resume, store } = temporalStore()
+    pauseSceneHistory(store)
+    const release = acquireSceneHistoryPause(store)
+
+    release()
+    release()
+    expect(getSceneHistoryPauseDepth()).toBe(1)
+    expect(resume).toHaveBeenCalledTimes(0)
+    resumeSceneHistory(store)
+    expect(getSceneHistoryPauseDepth()).toBe(0)
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(pause).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/store/history-control.ts
+++ b/packages/core/src/store/history-control.ts
@@ -3,6 +3,7 @@ import type { SceneMaterial, SceneMaterialId } from '../schema/scene-material'
 import type { AnyNode, AnyNodeId } from '../schema/types'
 
 let sceneHistoryPauseDepth = 0
+const sceneHistoryPauseLeases = new Set<symbol>()
 
 export type SceneSnapshot = {
   nodes: Record<AnyNodeId, AnyNode>
@@ -139,7 +140,7 @@ function endSceneCommitTransaction(): void {
 }
 
 export function pauseSceneHistory(sceneStore: TemporalStoreLike): void {
-  if (sceneHistoryPauseDepth === 0) {
+  if (getSceneHistoryPauseDepth() === 0) {
     sceneStore.temporal.getState().pause()
   }
   sceneHistoryPauseDepth += 1
@@ -151,17 +152,35 @@ export function resumeSceneHistory(sceneStore: TemporalStoreLike): void {
   }
 
   sceneHistoryPauseDepth -= 1
-  if (sceneHistoryPauseDepth === 0) {
+  if (getSceneHistoryPauseDepth() === 0) {
     sceneStore.temporal.getState().resume()
   }
 }
 
+export function acquireSceneHistoryPause(sceneStore: TemporalStoreLike): () => void {
+  if (getSceneHistoryPauseDepth() === 0) {
+    sceneStore.temporal.getState().pause()
+  }
+  const lease = Symbol('scene-history-pause')
+  sceneHistoryPauseLeases.add(lease)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    sceneHistoryPauseLeases.delete(lease)
+    if (getSceneHistoryPauseDepth() === 0) {
+      sceneStore.temporal.getState().resume()
+    }
+  }
+}
+
 export function getSceneHistoryPauseDepth(): number {
-  return sceneHistoryPauseDepth
+  return sceneHistoryPauseDepth + sceneHistoryPauseLeases.size
 }
 
 export function resetSceneHistoryPauseDepth(): void {
   sceneHistoryPauseDepth = 0
+  sceneHistoryPauseLeases.clear()
 }
 
 function retainedPastStateCount<TPastState>(before: TPastState[], after: TPastState[]): number {

--- a/packages/editor/src/components/ui/command-palette/editor-commands.tsx
+++ b/packages/editor/src/components/ui/command-palette/editor-commands.tsx
@@ -37,7 +37,7 @@ import {
   Video,
 } from 'lucide-react'
 import { useEffect } from 'react'
-import { runRedo, runUndo } from '../../../lib/history'
+import { getHistoryCommandState, runRedo, runUndo } from '../../../lib/history'
 import { deleteLevelWithFallbackSelection } from '../../../lib/level-selection'
 import { useCommandRegistry } from '../../../store/use-command-registry'
 import type { StructureTool } from '../../../store/use-editor'
@@ -351,6 +351,7 @@ export function EditorCommands() {
         group: 'History',
         icon: <Undo2 className="h-4 w-4" />,
         keywords: ['undo', 'revert', 'back'],
+        when: () => getHistoryCommandState().canUndo,
         execute: () => run(() => runUndo()),
       },
       {
@@ -359,6 +360,7 @@ export function EditorCommands() {
         group: 'History',
         icon: <Redo2 className="h-4 w-4" />,
         keywords: ['redo', 'forward', 'repeat'],
+        when: () => getHistoryCommandState().canRedo,
         execute: () => run(() => runRedo()),
       },
 

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -387,10 +387,14 @@ export {
 export { commitFreshPlacementSubtree } from './lib/fresh-planar-placement'
 export { exportSceneToGlb } from './lib/glb-export'
 export {
+  getHistoryCommandState,
   type HistoryCommandDelegate,
+  type HistoryCommandResult,
+  type HistoryCommandState,
   installHistoryCommandDelegate,
   runRedo,
   runUndo,
+  subscribeHistoryCommandState,
 } from './lib/history'
 export {
   boundaryReshapeScope,

--- a/packages/editor/src/lib/history.test.ts
+++ b/packages/editor/src/lib/history.test.ts
@@ -7,7 +7,13 @@ import {
   LevelNode,
   useScene,
 } from '@pascal-app/core'
-import { installHistoryCommandDelegate, runRedo, runUndo } from './history'
+import {
+  getHistoryCommandState,
+  installHistoryCommandDelegate,
+  runRedo,
+  runUndo,
+  subscribeHistoryCommandState,
+} from './history'
 
 type RafFn = (cb: (time: number) => void) => number
 ;(globalThis as unknown as { requestAnimationFrame?: RafFn }).requestAnimationFrame ??= (cb) => {
@@ -58,12 +64,28 @@ describe('editor history controller', () => {
   })
 
   test('delegates undo and redo while a host delegate is installed', () => {
-    const undo = mock(() => {})
-    const redo = mock(() => {})
-    disposeController = installHistoryCommandDelegate({ undo, redo })
+    const undo = mock(() => ({ kind: 'applied', persistence: 'queued' }) as const)
+    const redo = mock(() => ({ kind: 'empty' }) as const)
+    disposeController = installHistoryCommandDelegate({
+      getState: () => ({
+        canRedo: false,
+        canUndo: true,
+        mode: 'collaborative',
+        status: 'syncing',
+      }),
+      redo,
+      subscribe: () => () => {},
+      undo,
+    })
 
-    runUndo()
-    runRedo()
+    expect(runUndo()).toEqual({ kind: 'applied', persistence: 'queued' })
+    expect(runRedo()).toEqual({ kind: 'empty' })
+    expect(getHistoryCommandState()).toEqual({
+      canRedo: false,
+      canUndo: true,
+      mode: 'collaborative',
+      status: 'syncing',
+    })
 
     expect(undo).toHaveBeenCalledTimes(1)
     expect(redo).toHaveBeenCalledTimes(1)
@@ -72,25 +94,68 @@ describe('editor history controller', () => {
   })
 
   test('falls back to standalone Zundo undo and redo when no controller is installed', () => {
-    runUndo()
+    expect(runUndo()).toEqual({ kind: 'applied', persistence: 'local' })
     expect(levelNumber()).toBe(0)
     expect(useScene.temporal.getState().futureStates).toHaveLength(1)
 
-    runRedo()
+    expect(runRedo()).toEqual({ kind: 'applied', persistence: 'local' })
     expect(levelNumber()).toBe(1)
     expect(useScene.temporal.getState().pastStates).toHaveLength(1)
   })
 
   test('an older cleanup cannot uninstall a newer controller', () => {
     const firstUndo = mock(() => {})
-    const stopFirst = installHistoryCommandDelegate({ undo: firstUndo, redo: () => {} })
+    const delegate = (undo: () => void) => ({
+      getState: () => ({
+        canRedo: false,
+        canUndo: true,
+        mode: 'collaborative' as const,
+        status: 'ready' as const,
+      }),
+      redo: () => ({ kind: 'empty' as const }),
+      subscribe: () => () => {},
+      undo: () => {
+        undo()
+        return { kind: 'applied' as const, persistence: 'queued' as const }
+      },
+    })
+    const stopFirst = installHistoryCommandDelegate(delegate(firstUndo))
     const secondUndo = mock(() => {})
-    disposeController = installHistoryCommandDelegate({ undo: secondUndo, redo: () => {} })
+    disposeController = installHistoryCommandDelegate(delegate(secondUndo))
 
     stopFirst()
     runUndo()
 
     expect(firstUndo).toHaveBeenCalledTimes(0)
     expect(secondUndo).toHaveBeenCalledTimes(1)
+  })
+
+  test('publishes delegate state changes and restores standalone availability on teardown', () => {
+    const listeners = new Set<() => void>()
+    const observed: string[] = []
+    const unsubscribe = subscribeHistoryCommandState(() => {
+      observed.push(getHistoryCommandState().mode)
+    })
+    disposeController = installHistoryCommandDelegate({
+      getState: () => ({
+        canRedo: false,
+        canUndo: true,
+        mode: 'collaborative',
+        status: 'offline',
+      }),
+      redo: () => ({ kind: 'empty' }),
+      subscribe: (listener) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
+      undo: () => ({ kind: 'applied', persistence: 'queued' }),
+    })
+
+    for (const listener of listeners) listener()
+    disposeController()
+    disposeController = () => {}
+    unsubscribe()
+
+    expect(observed).toEqual(['collaborative', 'collaborative', 'standalone'])
   })
 })

--- a/packages/editor/src/lib/history.ts
+++ b/packages/editor/src/lib/history.ts
@@ -1,17 +1,64 @@
 import { useLiveNodeOverrides, useLiveTransforms, useScene } from '@pascal-app/core'
 
+export type HistoryCommandState = {
+  canRedo: boolean
+  canUndo: boolean
+  mode: 'collaborative' | 'standalone'
+  status: 'offline' | 'ready' | 'syncing' | 'unavailable'
+}
+
+export type HistoryCommandResult =
+  | { kind: 'applied'; persistence: 'local' | 'queued' }
+  | { kind: 'empty' }
+  | { kind: 'unavailable' }
+
 export type HistoryCommandDelegate = {
-  undo: () => void
-  redo: () => void
+  getState: () => HistoryCommandState
+  redo: () => HistoryCommandResult
+  subscribe: (listener: () => void) => () => void
+  undo: () => HistoryCommandResult
 }
 
 let historyCommandDelegate: HistoryCommandDelegate | null = null
+let historyCommandDelegateSubscription: (() => void) | null = null
+const historyCommandListeners = new Set<() => void>()
 
 export function installHistoryCommandDelegate(delegate: HistoryCommandDelegate): () => void {
+  historyCommandDelegateSubscription?.()
   historyCommandDelegate = delegate
+  historyCommandDelegateSubscription = delegate.subscribe(notifyHistoryCommandListeners)
+  notifyHistoryCommandListeners()
   return () => {
-    if (historyCommandDelegate === delegate) historyCommandDelegate = null
+    if (historyCommandDelegate !== delegate) return
+    historyCommandDelegateSubscription?.()
+    historyCommandDelegateSubscription = null
+    historyCommandDelegate = null
+    notifyHistoryCommandListeners()
   }
+}
+
+export function getHistoryCommandState(): HistoryCommandState {
+  if (historyCommandDelegate) return historyCommandDelegate.getState()
+  const temporal = useScene.temporal.getState()
+  return {
+    canRedo: temporal.futureStates.length > 0,
+    canUndo: temporal.pastStates.length > 0,
+    mode: 'standalone',
+    status: 'ready',
+  }
+}
+
+export function subscribeHistoryCommandState(listener: () => void): () => void {
+  historyCommandListeners.add(listener)
+  const unsubscribeTemporal = useScene.temporal.subscribe(listener)
+  return () => {
+    historyCommandListeners.delete(listener)
+    unsubscribeTemporal()
+  }
+}
+
+function notifyHistoryCommandListeners() {
+  for (const listener of [...historyCommandListeners]) listener()
 }
 
 function refreshSceneAfterHistoryJump() {
@@ -24,22 +71,20 @@ function refreshSceneAfterHistoryJump() {
   }
 }
 
-export function runUndo() {
-  if (historyCommandDelegate) {
-    historyCommandDelegate.undo()
-    return
-  }
+export function runUndo(): HistoryCommandResult {
+  if (historyCommandDelegate) return historyCommandDelegate.undo()
+  if (useScene.temporal.getState().pastStates.length === 0) return { kind: 'empty' }
   useScene.temporal.getState().undo()
   refreshSceneAfterHistoryJump()
+  return { kind: 'applied', persistence: 'local' }
 }
 
-export function runRedo() {
-  if (historyCommandDelegate) {
-    historyCommandDelegate.redo()
-    return
-  }
+export function runRedo(): HistoryCommandResult {
+  if (historyCommandDelegate) return historyCommandDelegate.redo()
+  if (useScene.temporal.getState().futureStates.length === 0) return { kind: 'empty' }
   useScene.temporal.getState().redo()
   refreshSceneAfterHistoryJump()
+  return { kind: 'applied', persistence: 'local' }
 }
 
 /**

--- a/packages/nodes/src/fence/curve-tool.tsx
+++ b/packages/nodes/src/fence/curve-tool.tsx
@@ -2,6 +2,7 @@
 
 import {
   type AnyNodeId,
+  acquireSceneHistoryPause,
   emitter,
   type FenceNode,
   type GridEvent,
@@ -10,8 +11,6 @@ import {
   getWallChordFrame,
   getWallMidpointHandlePoint,
   normalizeWallCurveOffset,
-  pauseSceneHistory,
-  resumeSceneHistory,
   useScene,
 } from '@pascal-app/core'
 import {
@@ -61,8 +60,8 @@ export const CurveFenceTool: React.FC<{ node: FenceNode }> = ({ node }) => {
     const chord = getWallChordFrame(node)
     const maxCurveOffset = getMaxWallCurveOffset(node)
 
-    pauseSceneHistory(useScene)
-    let wasCommitted = false
+    let releaseHistory = acquireSceneHistoryPause(useScene)
+    let wasFinalized = false
 
     const applyPreview = (curveOffset: number) => {
       if (previewOffsetRef.current === curveOffset) {
@@ -116,13 +115,14 @@ export const CurveFenceTool: React.FC<{ node: FenceNode }> = ({ node }) => {
     }
 
     const onGridClick = (event: GridEvent) => {
+      if (wasFinalized) return
       if (Date.now() - activatedAtRef.current < 150) {
         event.nativeEvent?.stopPropagation?.()
         return
       }
 
       const curveOffset = previewOffsetRef.current
-      wasCommitted = true
+      wasFinalized = true
 
       if (curveOffset !== originalCurveOffset) {
         // Restore original baseline while paused so the next resume+update
@@ -130,10 +130,10 @@ export const CurveFenceTool: React.FC<{ node: FenceNode }> = ({ node }) => {
         useScene.getState().updateNode(nodeId, { curveOffset: originalCurveOffset })
         useScene.getState().markDirty(nodeId as AnyNodeId)
 
-        resumeSceneHistory(useScene)
+        releaseHistory()
         useScene.getState().updateNode(nodeId, { curveOffset })
         useScene.getState().markDirty(nodeId as AnyNodeId)
-        pauseSceneHistory(useScene)
+        releaseHistory = acquireSceneHistoryPause(useScene)
       }
 
       triggerSFX('sfx:item-place')
@@ -143,9 +143,11 @@ export const CurveFenceTool: React.FC<{ node: FenceNode }> = ({ node }) => {
     }
 
     const onCancel = () => {
+      if (wasFinalized) return
       restoreOriginal()
+      wasFinalized = true
       useViewer.getState().setSelection({ selectedIds: [nodeId] })
-      resumeSceneHistory(useScene)
+      releaseHistory()
       markToolCancelConsumed()
       exitCurveMode()
     }
@@ -155,10 +157,10 @@ export const CurveFenceTool: React.FC<{ node: FenceNode }> = ({ node }) => {
     emitter.on('tool:cancel', onCancel)
 
     return () => {
-      if (!wasCommitted) {
+      if (!wasFinalized) {
         restoreOriginal()
       }
-      resumeSceneHistory(useScene)
+      releaseHistory()
       emitter.off('grid:move', onGridMove)
       emitter.off('grid:click', onGridClick)
       emitter.off('tool:cancel', onCancel)

--- a/packages/nodes/src/fence/move-control-point-tool.tsx
+++ b/packages/nodes/src/fence/move-control-point-tool.tsx
@@ -2,11 +2,10 @@
 
 import {
   type AnyNodeId,
+  acquireSceneHistoryPause,
   emitter,
   type FenceNode,
   type GridEvent,
-  pauseSceneHistory,
-  resumeSceneHistory,
   useLiveNodeOverrides,
   useScene,
 } from '@pascal-app/core'
@@ -37,8 +36,8 @@ export const MoveFenceControlPointTool: React.FC<{
   ])
 
   useEffect(() => {
-    pauseSceneHistory(useScene)
-    let committed = false
+    const releaseHistory = acquireSceneHistoryPause(useScene)
+    let finalized = false
     let lastPoint: [number, number] = [originalPoint[0], originalPoint[1]]
 
     const buildPatch = (point: [number, number]): Partial<FenceNode> => {
@@ -88,8 +87,9 @@ export const MoveFenceControlPointTool: React.FC<{
     }
 
     const onGridClick = (event: GridEvent) => {
-      committed = true
-      resumeSceneHistory(useScene)
+      if (finalized) return
+      finalized = true
+      releaseHistory()
       useScene.getState().updateNode(fenceId, buildPatch(lastPoint))
       useLiveNodeOverrides.getState().clear(fenceId)
       useScene.getState().markDirty(fenceId)
@@ -98,8 +98,10 @@ export const MoveFenceControlPointTool: React.FC<{
     }
 
     const onCancel = () => {
+      if (finalized) return
       restore()
-      resumeSceneHistory(useScene)
+      finalized = true
+      releaseHistory()
       markToolCancelConsumed()
       exit(false)
     }
@@ -109,9 +111,9 @@ export const MoveFenceControlPointTool: React.FC<{
     emitter.on('tool:cancel', onCancel)
 
     return () => {
-      if (!committed) {
+      if (!finalized) {
         restore()
-        resumeSceneHistory(useScene)
+        releaseHistory()
       }
       emitter.off('grid:move', onGridMove)
       emitter.off('grid:click', onGridClick)

--- a/packages/nodes/src/fence/move-tangent-tool.tsx
+++ b/packages/nodes/src/fence/move-tangent-tool.tsx
@@ -2,11 +2,10 @@
 
 import {
   type AnyNodeId,
+  acquireSceneHistoryPause,
   emitter,
   type FenceNode,
   type GridEvent,
-  pauseSceneHistory,
-  resumeSceneHistory,
   useLiveNodeOverrides,
   useScene,
 } from '@pascal-app/core'
@@ -34,8 +33,8 @@ export const MoveFenceTangentTool: React.FC<{
   const [cursor, setCursor] = useState<[number, number, number]>([anchor[0], 0, anchor[1]])
 
   useEffect(() => {
-    pauseSceneHistory(useScene)
-    let committed = false
+    const releaseHistory = acquireSceneHistoryPause(useScene)
+    let finalized = false
     const originalTangents: Array<[number, number] | null> = (target.fence.tangents ?? []).map(
       (t) => (t ? [t[0], t[1]] : null),
     )
@@ -89,9 +88,10 @@ export const MoveFenceTangentTool: React.FC<{
     }
 
     const onGridClick = (event: GridEvent) => {
-      committed = true
+      if (finalized) return
+      finalized = true
       const finalTangents = lastTangents
-      resumeSceneHistory(useScene)
+      releaseHistory()
       useScene.getState().updateNode(fenceId, { tangents: finalTangents })
       useLiveNodeOverrides.getState().clear(fenceId)
       useScene.getState().markDirty(fenceId)
@@ -101,8 +101,10 @@ export const MoveFenceTangentTool: React.FC<{
     }
 
     const onCancel = () => {
+      if (finalized) return
       restore()
-      resumeSceneHistory(useScene)
+      finalized = true
+      releaseHistory()
       markToolCancelConsumed()
       exit(false)
     }
@@ -112,9 +114,9 @@ export const MoveFenceTangentTool: React.FC<{
     emitter.on('tool:cancel', onCancel)
 
     return () => {
-      if (!committed) {
+      if (!finalized) {
         restore()
-        resumeSceneHistory(useScene)
+        releaseHistory()
       }
       emitter.off('grid:move', onGridMove)
       emitter.off('grid:click', onGridClick)

--- a/packages/nodes/src/wall/curve-tool.tsx
+++ b/packages/nodes/src/wall/curve-tool.tsx
@@ -2,6 +2,7 @@
 
 import {
   type AnyNodeId,
+  acquireSceneHistoryPause,
   emitter,
   type GridEvent,
   getClampedWallCurveOffset,
@@ -27,10 +28,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 /**
  * Phase 5 Stage D — wall curve tool (kind-owned).
  *
- * 1:1 port of the legacy `CurveWallTool`. Same snap pipeline,
- * history dance, activation grace. The wall variant uses
- * `useScene.temporal.getState().pause()` / `.resume()` directly rather
- * than the depth-counted `pauseSceneHistory` helpers — matches legacy.
+ * 1:1 port of the legacy `CurveWallTool`. Same snap pipeline and
+ * activation grace. History uses an idempotent lease because cancel and
+ * effect cleanup can both release the active interaction.
  */
 export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
   const activatedAtRef = useRef<number>(Date.now())
@@ -57,8 +57,8 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
     const chord = getWallChordFrame(node)
     const maxCurveOffset = getMaxWallCurveOffset(node)
 
-    useScene.temporal.getState().pause()
-    let wasCommitted = false
+    let releaseHistory = acquireSceneHistoryPause(useScene)
+    let wasFinalized = false
 
     const applyPreview = (curveOffset: number) => {
       if (previewOffsetRef.current === curveOffset) {
@@ -119,13 +119,14 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
     }
 
     const onGridClick = (event: GridEvent) => {
+      if (wasFinalized) return
       if (Date.now() - activatedAtRef.current < 150) {
         event.nativeEvent?.stopPropagation?.()
         return
       }
 
       const curveOffset = previewOffsetRef.current
-      wasCommitted = true
+      wasFinalized = true
 
       if (curveOffset !== originalCurveOffset) {
         // Restore original baseline while paused so the next resume+update
@@ -133,10 +134,10 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
         useScene.getState().updateNode(nodeId, { curveOffset: originalCurveOffset })
         useScene.getState().markDirty(nodeId as AnyNodeId)
 
-        useScene.temporal.getState().resume()
+        releaseHistory()
         useScene.getState().updateNode(nodeId, { curveOffset })
         useScene.getState().markDirty(nodeId as AnyNodeId)
-        useScene.temporal.getState().pause()
+        releaseHistory = acquireSceneHistoryPause(useScene)
       }
 
       triggerSFX('sfx:item-place')
@@ -146,9 +147,11 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
     }
 
     const onCancel = () => {
+      if (wasFinalized) return
       restoreOriginal()
+      wasFinalized = true
       useViewer.getState().setSelection({ selectedIds: [nodeId] })
-      useScene.temporal.getState().resume()
+      releaseHistory()
       markToolCancelConsumed()
       exitCurveMode()
     }
@@ -158,10 +161,10 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
     emitter.on('tool:cancel', onCancel)
 
     return () => {
-      if (!wasCommitted) {
+      if (!wasFinalized) {
         restoreOriginal()
       }
-      useScene.temporal.getState().resume()
+      releaseHistory()
       emitter.off('grid:move', onGridMove)
       emitter.off('grid:click', onGridClick)
       emitter.off('tool:cancel', onCancel)


### PR DESCRIPTION
## What does this PR do?

Adds an explicit host history Interface so the hosted collaborative editor can expose immediate undo/redo state and results without changing standalone Zundo behavior.

It also adds idempotent scene-history pause leases and migrates the fence/wall curve interactions that could release history twice during cancel plus effect cleanup. Command-palette history actions now follow the active history availability.

This is the public editor half of the hosted collaboration journal fix.

## How to test

1. Run `bun run check && bun run check-types && bun run build`.
2. Run `bun test packages/core/src packages/editor/src packages/nodes/src`.
3. In standalone editor mode, verify undo/redo still use the local Zundo stacks; with a host delegate installed, verify commands and availability come from the host.

## Screenshots / screen recording

Not applicable; this changes history behavior and ownership without a visual redesign.

## Checklist

- [ ] Tested locally with `bun dev`
- [x] Code style verified with `bun check`
- [x] Relevant documentation updated where applicable
- [x] This PR targets the `main` branch
