### PR TITLE
Add Streetscape plugin to Pascal

### DIFF
--- a/apps/editor/app/globals.css
+++ b/apps/editor/app/globals.css
@@ -5,6 +5,7 @@
 @source "../../../packages/nodes/src";
 @source "../../../node_modules/@pascal-app/plugin-trees/src";
 @source "../../../node_modules/@mint/pascal-plugin/src";
+@source "../../../node_modules/@pascal-app/plugin-streetscape/src";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/editor/lib/bootstrap.ts
+++ b/apps/editor/lib/bootstrap.ts
@@ -90,12 +90,10 @@ registerEditorHostPanel(treesHostPanel)
 extendPluginDiscovery(async () => [mintPlugin])
 registerEditorHostPanel(mintHostPanel)
 extendPluginDiscovery(async () => [streetscapePlugin])
-// The upstream manifest points creator/pluginUrl at a pascalorg repo that
-// doesn't exist; credit the actual author until the package fixes it.
+// The upstream manifest still names 'Pascal' as creator; credit the author.
 registerEditorHostPanel({
   ...streetscapeHostPanel,
   creator: { name: 'Sudhir Yadav', url: 'https://github.com/sudhir9297' },
-  pluginUrl: 'https://github.com/sudhir9297/streetscape-pascal-plugin',
 })
 
 loadBuiltinsSync()

--- a/apps/editor/lib/bootstrap.ts
+++ b/apps/editor/lib/bootstrap.ts
@@ -9,6 +9,10 @@ import {
 } from '@pascal-app/core'
 import { registerEditorHostPanel } from '@pascal-app/editor'
 import { builtinPlugin } from '@pascal-app/nodes'
+import {
+  streetscapeHostPanel,
+  streetscapePlugin,
+} from '@pascal-app/plugin-streetscape'
 import { treesHostPanel, treesPlugin } from '@pascal-app/plugin-trees'
 
 // Idempotency guards: HMR can reload this module, but `registerNode`
@@ -88,6 +92,8 @@ extendPluginDiscovery(async () => [treesPlugin])
 registerEditorHostPanel(treesHostPanel)
 extendPluginDiscovery(async () => [mintPlugin])
 registerEditorHostPanel(mintHostPanel)
+extendPluginDiscovery(async () => [streetscapePlugin])
+registerEditorHostPanel(streetscapeHostPanel)
 
 loadBuiltinsSync()
 void loadExternalPlugins()

--- a/apps/editor/lib/bootstrap.ts
+++ b/apps/editor/lib/bootstrap.ts
@@ -9,10 +9,7 @@ import {
 } from '@pascal-app/core'
 import { registerEditorHostPanel } from '@pascal-app/editor'
 import { builtinPlugin } from '@pascal-app/nodes'
-import {
-  streetscapeHostPanel,
-  streetscapePlugin,
-} from '@pascal-app/plugin-streetscape'
+import { streetscapeHostPanel, streetscapePlugin } from '@pascal-app/plugin-streetscape'
 import { treesHostPanel, treesPlugin } from '@pascal-app/plugin-trees'
 
 // Idempotency guards: HMR can reload this module, but `registerNode`
@@ -93,7 +90,13 @@ registerEditorHostPanel(treesHostPanel)
 extendPluginDiscovery(async () => [mintPlugin])
 registerEditorHostPanel(mintHostPanel)
 extendPluginDiscovery(async () => [streetscapePlugin])
-registerEditorHostPanel(streetscapeHostPanel)
+// The upstream manifest points creator/pluginUrl at a pascalorg repo that
+// doesn't exist; credit the actual author until the package fixes it.
+registerEditorHostPanel({
+  ...streetscapeHostPanel,
+  creator: { name: 'Sudhir Yadav', url: 'https://github.com/sudhir9297' },
+  pluginUrl: 'https://github.com/sudhir9297/streetscape-pascal-plugin',
+})
 
 loadBuiltinsSync()
 void loadExternalPlugins()

--- a/apps/editor/next.config.ts
+++ b/apps/editor/next.config.ts
@@ -32,6 +32,7 @@ const nextConfig: NextConfig = {
     '@pascal-app/core',
     '@pascal-app/editor',
     '@pascal-app/mcp',
+    '@pascal-app/plugin-streetscape',
     '@pascal-app/plugin-trees',
     '@mint/pascal-plugin',
     '@dgreenheck/ez-tree',

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -19,7 +19,7 @@
     "@pascal-app/editor": "*",
     "@pascal-app/mcp": "*",
     "@pascal-app/nodes": "*",
-    "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#3c885bfe112e87c7e0e9e38c0c6bc36e6dc692c7",
+    "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
     "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
     "@pascal-app/viewer": "*",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -19,6 +19,7 @@
     "@pascal-app/editor": "*",
     "@pascal-app/mcp": "*",
     "@pascal-app/nodes": "*",
+    "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#3c885bfe112e87c7e0e9e38c0c6bc36e6dc692c7",
     "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
     "@pascal-app/viewer": "*",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
+        "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#3c885bfe112e87c7e0e9e38c0c6bc36e6dc692c7",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -99,7 +100,7 @@
     },
     "packages/cli": {
       "name": "@pascal-app/cli",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "bin": {
         "pascal": "dist/bin/pascal.js",
       },
@@ -233,7 +234,7 @@
     },
     "packages/mcp": {
       "name": "@pascal-app/mcp",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "bin": {
         "pascal-mcp": "./dist/bin/pascal-mcp.js",
       },
@@ -722,6 +723,8 @@
     "@pascal-app/mcp": ["@pascal-app/mcp@workspace:packages/mcp"],
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
+
+    "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#3c885bf", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-3c885bf", "sha512-/O+vZjgpmc4bv5crJvU9OZmBIqM/i0ptyu2+t6zAS5QBkwontnnsGNNRobkTLNzMVUDW2vMS6JRuOxfxGnWW4Q=="],
 
     "@pascal-app/plugin-trees": ["@pascal-app/plugin-trees@github:pascalorg/plugin-trees#56d978c", { "dependencies": { "@dgreenheck/ez-tree": "^1.1.0" }, "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-trees-56d978c", "sha512-16VzWot1oadvxCPqsRwMJbaP0a3u5FESFy7F7++pY5wAAFq9JTFwzHvKAsllrY5TZ5TJ7Y5vSqvbmQk8sy8HaA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#3c885bfe112e87c7e0e9e38c0c6bc36e6dc692c7",
+        "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -724,7 +724,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#3c885bf", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-3c885bf", "sha512-/O+vZjgpmc4bv5crJvU9OZmBIqM/i0ptyu2+t6zAS5QBkwontnnsGNNRobkTLNzMVUDW2vMS6JRuOxfxGnWW4Q=="],
+    "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9", "sha512-X7Zg7wi0ghZRcTtbH5LF6xye493uSZ2ft3AmAQBtguBCU6VCwCexA7pdKDr5AnVxX/JRj2s6JSd/OX4aIZ9Y6Q=="],
 
     "@pascal-app/plugin-trees": ["@pascal-app/plugin-trees@github:pascalorg/plugin-trees#56d978c", { "dependencies": { "@dgreenheck/ez-tree": "^1.1.0" }, "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-trees-56d978c", "sha512-16VzWot1oadvxCPqsRwMJbaP0a3u5FESFy7F7++pY5wAAFq9JTFwzHvKAsllrY5TZ5TJ7Y5vSqvbmQk8sy8HaA=="],
 


### PR DESCRIPTION
## Summary

- Add and register the Streetscape plugin ([sudhir9297/streetscape-pascal-plugin](https://github.com/sudhir9297/streetscape-pascal-plugin)) and its editor panel, following the mint/trees pattern.
- Pin `@pascal-app/plugin-streetscape` by immutable commit (`3c885bf`).
- Register `streetscapePlugin` via plugin discovery and `streetscapeHostPanel` at bootstrap, add the package to Next transpilation and Tailwind `@source`.

The plugin is self-contained — ~38 procedural node kinds (road networks, street/area/pedestrian lighting, utility poles + wire spans, traffic signals, signs, and roadside infrastructure) plus one left-rail panel. No API proxy route, env vars, or backend needed (unlike mint).

## Tested

- `bun run check-types` — 10/10 tasks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only plugin wiring with no auth, API, or data-path changes; main risk is bundle size and any runtime issues inside the external package.
> 
> **Overview**
> Wires the **Streetscape** third-party node pack into the editor app the same way as trees and mint.
> 
> Adds `@pascal-app/plugin-streetscape` (GitHub pin) and registers `streetscapePlugin` via `extendPluginDiscovery` plus `streetscapeHostPanel` at bootstrap, overriding the panel **creator** metadata to credit Sudhir Yadav. Next is configured to **transpile** the package, and Tailwind **`@source`** includes the plugin so its UI classes are picked up. Lockfile also records the new dependency (and unrelated workspace version bumps for CLI/MCP).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19cfb1dd10139d7841118426e8194299576c5c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->