### PR TITLE
fix(core): keep placement drafts out of undo history

### DIFF
--- a/packages/core/src/store/use-scene-commits.test.ts
+++ b/packages/core/src/store/use-scene-commits.test.ts
@@ -170,6 +170,52 @@ describe('scene commit boundary', () => {
     expect(useScene.temporal.getState().pastStates).toHaveLength(1)
   })
 
+  test('excludes fresh placement subtrees until they become a committed undo step', () => {
+    const draftLevel = LevelNode.parse({
+      id: 'level_fresh_placement',
+      parentId: BUILDING_ID,
+      children: [],
+      level: 1,
+      metadata: { isNew: true },
+    })
+    const draftWall = WallNode.parse({
+      id: 'wall_fresh_placement',
+      parentId: draftLevel.id,
+      start: [0, 0],
+      end: [4, 0],
+    })
+    const commits: SceneCommit[] = []
+    unsubscribe = subscribeSceneCommits((commit) => commits.push(commit))
+
+    useScene.getState().createNodes([
+      { node: draftLevel, parentId: BUILDING_ID },
+      { node: draftWall, parentId: draftLevel.id },
+    ])
+    useScene.getState().updateNode(draftWall.id, { end: [5, 0] })
+
+    expect(useScene.getState().nodes[draftLevel.id]).toBeDefined()
+    expect(useScene.getState().nodes[draftWall.id]).toBeDefined()
+    expect(commits).toHaveLength(0)
+    expect(useScene.temporal.getState().pastStates).toHaveLength(0)
+
+    useScene.getState().updateNode(draftLevel.id, { metadata: {} })
+
+    expect(commits).toHaveLength(1)
+    expect(commits[0]?.before.nodes[draftLevel.id]).toBeUndefined()
+    expect(commits[0]?.before.nodes[draftWall.id]).toBeUndefined()
+    expect(commits[0]?.current.nodes[draftLevel.id]).toBeDefined()
+    expect(commits[0]?.current.nodes[draftWall.id]).toBeDefined()
+    expect(useScene.temporal.getState().pastStates).toHaveLength(1)
+
+    useScene.temporal.getState().undo()
+    expect(useScene.getState().nodes[draftLevel.id]).toBeUndefined()
+    expect(useScene.getState().nodes[draftWall.id]).toBeUndefined()
+
+    useScene.temporal.getState().redo()
+    expect(useScene.getState().nodes[draftLevel.id]).toBeDefined()
+    expect(useScene.getState().nodes[draftWall.id]).toBeDefined()
+  })
+
   test('coalesces a compound transaction into one commit and one undo step', () => {
     const commits: SceneCommit[] = []
     unsubscribe = subscribeSceneCommits((commit) => commits.push(commit))

--- a/packages/core/src/store/use-scene.ts
+++ b/packages/core/src/store/use-scene.ts
@@ -1088,7 +1088,80 @@ function sceneHistorySnapshotFromState(
   >,
 ): SceneSnapshot {
   const { nodes, rootNodeIds, collections, materials, installedPlugins } = state
-  return { nodes, rootNodeIds, collections, materials, installedPlugins }
+  // Fresh placement nodes are renderable drafts, not document history. Excluding their
+  // entire subtree here protects both local undo and external commit subscribers.
+  const transientNodeIds = new Set<AnyNodeId>()
+  for (const node of Object.values(nodes)) {
+    const metadata = node.metadata
+    if (
+      metadata &&
+      typeof metadata === 'object' &&
+      !Array.isArray(metadata) &&
+      (metadata as Record<string, unknown>).isNew === true
+    ) {
+      transientNodeIds.add(node.id)
+    }
+  }
+
+  if (transientNodeIds.size === 0) {
+    return { nodes, rootNodeIds, collections, materials, installedPlugins }
+  }
+
+  const childIdsByParentId = new Map<AnyNodeId, Set<AnyNodeId>>()
+  const addChild = (parentId: AnyNodeId, childId: AnyNodeId) => {
+    const childIds = childIdsByParentId.get(parentId) ?? new Set<AnyNodeId>()
+    childIds.add(childId)
+    childIdsByParentId.set(parentId, childIds)
+  }
+  for (const node of Object.values(nodes)) {
+    if (node.parentId) addChild(node.parentId as AnyNodeId, node.id)
+    for (const childId of getNodeChildIds(node)) addChild(node.id, childId)
+  }
+
+  const pendingIds = [...transientNodeIds]
+  while (pendingIds.length > 0) {
+    const parentId = pendingIds.pop()
+    if (!parentId) continue
+    for (const childId of childIdsByParentId.get(parentId) ?? []) {
+      if (transientNodeIds.has(childId)) continue
+      transientNodeIds.add(childId)
+      pendingIds.push(childId)
+    }
+  }
+
+  const historyNodes = {} as Record<AnyNodeId, AnyNode>
+  for (const [id, node] of Object.entries(nodes) as [AnyNodeId, AnyNode][]) {
+    if (transientNodeIds.has(id)) continue
+    if (!('children' in node && Array.isArray(node.children))) {
+      historyNodes[id] = node
+      continue
+    }
+    const children = (node.children as AnyNodeId[]).filter(
+      (childId) => !transientNodeIds.has(childId),
+    )
+    historyNodes[id] =
+      children.length === node.children.length ? node : ({ ...node, children } as AnyNode)
+  }
+
+  const historyCollections = {} as Record<CollectionId, Collection>
+  for (const [id, collection] of Object.entries(collections) as [CollectionId, Collection][]) {
+    const nodeIds = collection.nodeIds.filter((nodeId) => !transientNodeIds.has(nodeId))
+    if (collection.controlNodeId && transientNodeIds.has(collection.controlNodeId)) {
+      const { controlNodeId: _controlNodeId, ...rest } = collection
+      historyCollections[id] = { ...rest, nodeIds }
+    } else {
+      historyCollections[id] =
+        nodeIds.length === collection.nodeIds.length ? collection : { ...collection, nodeIds }
+    }
+  }
+
+  return {
+    nodes: historyNodes,
+    rootNodeIds: rootNodeIds.filter((id) => !transientNodeIds.has(id)),
+    collections: historyCollections,
+    materials,
+    installedPlugins,
+  }
 }
 
 const useScene: UseSceneStore = create<SceneState>()(


### PR DESCRIPTION
## Summary
- exclude fresh placement roots and their descendants from scene history snapshots until finalization
- remove transient references from parents, roots, and collections so both Zundo and external commit subscribers see a valid document snapshot
- add a regression proving draft motion emits no history and finalization produces one undoable, redoable step

## Test plan
- [x] bun run check
- [x] bun run check-types
- [x] bun run test
- [x] bun run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core scene history and commit boundaries used by undo and sync; behavior change is scoped to `isNew` placement flows but incorrect subtree/collection filtering could affect undo or host patches.
> 
> **Overview**
> **Placement drafts** (`metadata.isNew`) no longer enter undo stacks or scene commit snapshots until the user finalizes placement.
> 
> `sceneHistorySnapshotFromState` now strips every `isNew` root and its full descendant subtree from history snapshots, and cleans parent `children`, `rootNodeIds`, and collections so Zundo and `subscribeSceneCommits` see a consistent document without transient nodes. Edits while still in draft mode produce **no** commits or undo steps; clearing `isNew` records **one** step whose `before` omits the subtree and whose `current` includes the finalized placement (undo/redo removes or restores the whole subtree).
> 
> A regression test covers create → draft motion → finalize → undo/redo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71147a318dc1a416d603eea8f9a5f452e80a2ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->