### PR TITLE
editor: noPanel sidebar tabs for stage-driving rail entries

### DIFF
--- a/packages/editor/src/components/editor/editor-layout-v2.tsx
+++ b/packages/editor/src/components/editor/editor-layout-v2.tsx
@@ -77,6 +77,11 @@ function LeftColumn({
   // up to the minimum so the panel always returns to a usable size.
   const handleRailClick = useCallback(
     (id: string) => {
+      // noPanel tabs drive the stage, not the panel — leave collapse state alone.
+      if (tabs.find((t) => t.id === id)?.noPanel) {
+        setActivePanel(id)
+        return
+      }
       if (isCollapsed) {
         setIsCollapsed(false)
         if (width < SIDEBAR_MIN_WIDTH) setWidth(SIDEBAR_MIN_WIDTH)
@@ -89,7 +94,7 @@ function LeftColumn({
       }
       setActivePanel(id)
     },
-    [isCollapsed, width, activePanel, setIsCollapsed, setWidth, setActivePanel],
+    [tabs, isCollapsed, width, activePanel, setIsCollapsed, setWidth, setActivePanel],
   )
 
   useEffect(() => {
@@ -126,7 +131,7 @@ function LeftColumn({
         onIconClick={handleRailClick}
         tabs={tabs}
       />
-      {!isCollapsed && (
+      {!isCollapsed && !tabs.find((t) => t.id === activePanel)?.noPanel && (
         <div
           className="relative flex h-full flex-col"
           style={{
@@ -239,7 +244,7 @@ export function EditorLayoutV2({
         overlays={overlays}
         renderTabContent={renderTabContent}
         sidebarOverlay={sidebarOverlay}
-        sidebarTabs={sidebarTabs}
+        sidebarTabs={sidebarTabs.filter((t) => !t.noPanel)}
         viewerContent={viewerContent}
         viewerToolbarLeft={viewerToolbarLeft}
         viewerToolbarRight={viewerToolbarRight}

--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -1393,12 +1393,13 @@ export default function Editor({
     }
 
     const tabBarTabs = [
-      ...(sidebarTabs?.map(({ id, label, mobileDefaultSnap, mobileIcon, icon }) => ({
+      ...(sidebarTabs?.map(({ id, label, mobileDefaultSnap, mobileIcon, icon, noPanel }) => ({
         id,
         label,
         mobileDefaultSnap,
         mobileIcon,
         icon,
+        noPanel,
       })) ?? []),
       // Host panels appear after the explicit tabs in the rail. The icon
       // doubles as the mobile icon; a half-height sheet is a sensible default.

--- a/packages/editor/src/components/ui/sidebar/tab-bar.tsx
+++ b/packages/editor/src/components/ui/sidebar/tab-bar.tsx
@@ -13,6 +13,12 @@ export type SidebarTab = {
   mobileIcon?: ReactNode
   /** Desktop icon shown in the vertical rail (v2 layout). */
   icon?: ReactNode
+  /**
+   * Rail entry that drives the stage instead of opening a sidebar panel:
+   * activating it hides the panel column (preserving its collapse state) and
+   * keeps the icon highlighted regardless of collapse.
+   */
+  noPanel?: boolean
 }
 
 interface TabBarProps {
@@ -75,7 +81,7 @@ export function IconRail({ tabs, activeTab, collapsed, onIconClick }: IconRailPr
   const pluginTabs = tabs.filter((tab) => pluginPanelIds.has(tab.id) || tab.id === 'plugins')
 
   const renderTab = (tab: SidebarTab) => {
-    const showActive = activeTab === tab.id && !collapsed
+    const showActive = activeTab === tab.id && (!collapsed || tab.noPanel === true)
     return (
       <Tooltip key={tab.id}>
         <TooltipTrigger asChild>


### PR DESCRIPTION
## What does this PR do?

Adds an optional `noPanel` flag to `SidebarTab` (v2 layout): a rail entry that activates without opening the left panel column — the icon stays highlighted regardless of the panel's collapse state, clicking it never expands/collapses the panel, and the panel column hides while such a tab is active (its collapse state is preserved for the normal tabs). The mobile layout skips `noPanel` tabs entirely.

This backs host surfaces that swap the stage instead of showing a sidebar panel — first consumer is the hosted editor's studio item builder, whose rail entry drives a full-stage `stageOverlay` (listing ⇄ item editor) rather than a panel.

## How to test

1. In a host embedding `<Editor layoutVersion="v2">`, add a tab with `noPanel: true` to `sidebarTabs` (any `component` — it never renders).
2. Click the entry: it highlights, no panel column opens, and the host can key a `stageOverlay` off `activeSidebarPanel`.
3. Click a normal tab: the panel column returns with its previous width/collapse state.
4. Re-click the noPanel entry while another tab's panel is open: panel hides, no collapse-state churn.
5. Mobile viewport: the noPanel entry does not appear in the bottom tab bar.

End-to-end consumer: pascalorg/private-editor branch `feat/studio-item-builder` (studio > Item builder).

## Screenshots / screen recording

N/A here — the visible behavior ships with the private-editor item-builder PR, which includes the full flow.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive UI layout change scoped to v2 sidebar rail behavior. No auth, data, or persistence logic is modified.
> 
> **Overview**
> Adds an optional **`noPanel`** flag on `SidebarTab` so v2 rail entries can activate a stage-driving mode instead of opening the left panel.
> 
> When such a tab is active, the panel column stays hidden (collapse/width state preserved), the rail icon remains highlighted even while collapsed, and clicks only switch `activeSidebarPanel` without expand/collapse. Mobile filters these tabs out of the bottom bar entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f3857ffa51414bcd52250c94be7f2a19043ffde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->