### PR TITLE
Raise room-envelope height caps from 6m to 20m

### DIFF
--- a/packages/editor/src/components/ui/floating-level-selector.tsx
+++ b/packages/editor/src/components/ui/floating-level-selector.tsx
@@ -235,7 +235,7 @@ function LevelRow({
             >
               <SliderControl
                 label="Level height"
-                max={6}
+                max={20}
                 min={1}
                 onChange={(v) => updateNode(level.id, { height: v })}
                 precision={3}

--- a/packages/nodes/src/ceiling/panel.tsx
+++ b/packages/nodes/src/ceiling/panel.tsx
@@ -260,7 +260,7 @@ export function CeilingPanel() {
         ) : (
           <SliderControl
             label="Height"
-            max={Math.min(6, maxHeight)}
+            max={Math.min(20, maxHeight)}
             min={0}
             onChange={handleHeightChange}
             precision={3}

--- a/packages/nodes/src/ceiling/parametrics.ts
+++ b/packages/nodes/src/ceiling/parametrics.ts
@@ -12,7 +12,7 @@ export const ceilingParametrics: ParametricDescriptor<CeilingNode> = {
   groups: [
     {
       label: 'Dimensions',
-      fields: [{ key: 'height', kind: 'number', unit: 'm', min: 1.5, max: 6, step: 0.05 }],
+      fields: [{ key: 'height', kind: 'number', unit: 'm', min: 1.5, max: 20, step: 0.05 }],
     },
   ],
   customPanel: () => import('./panel'),

--- a/packages/nodes/src/column/panel.tsx
+++ b/packages/nodes/src/column/panel.tsx
@@ -546,7 +546,7 @@ export default function ColumnPanel() {
         )}
         <SliderControl
           label="Height"
-          max={6}
+          max={20}
           min={0.8}
           onChange={(value) => handleUpdate({ height: value })}
           precision={2}

--- a/packages/nodes/src/column/parametrics.ts
+++ b/packages/nodes/src/column/parametrics.ts
@@ -14,7 +14,7 @@ export const columnParametrics: ParametricDescriptor<ColumnNode> = {
     {
       label: 'Dimensions',
       fields: [
-        { key: 'height', kind: 'number', unit: 'm', min: 0.5, max: 6, step: 0.05 },
+        { key: 'height', kind: 'number', unit: 'm', min: 0.5, max: 20, step: 0.05 },
         { key: 'width', kind: 'number', unit: 'm', min: 0.1, max: 2, step: 0.01 },
         { key: 'depth', kind: 'number', unit: 'm', min: 0.1, max: 2, step: 0.01 },
       ],

--- a/packages/nodes/src/wall/panel.tsx
+++ b/packages/nodes/src/wall/panel.tsx
@@ -287,11 +287,11 @@ export default function WallPanel() {
         ) : (
           <SliderControl
             label="Height"
-            max={metersToLinearUnit(6, unit)}
+            max={metersToLinearUnit(20, unit)}
             min={metersToLinearUnit(0.1, unit)}
             onChange={(v) =>
               handleUpdate({
-                height: linearControlValueToMeters(v, unit, { maxMeters: 6, minMeters: 0.1 }),
+                height: linearControlValueToMeters(v, unit, { maxMeters: 20, minMeters: 0.1 }),
               })
             }
             precision={2}

--- a/packages/nodes/src/wall/parametrics.ts
+++ b/packages/nodes/src/wall/parametrics.ts
@@ -21,7 +21,7 @@ export const wallParametrics: ParametricDescriptor<WallNode> = {
         { key: 'thickness', kind: 'number', unit: 'm', min: 0.05, max: 0.6, step: 0.01 },
         // `height` may be absent (plane-bound top); the custom panel owns the
         // Follows storey / Custom height mode switch, so this is metadata only.
-        { key: 'height', kind: 'number', unit: 'm', min: 1.5, max: 6, step: 0.05 },
+        { key: 'height', kind: 'number', unit: 'm', min: 1.5, max: 20, step: 0.05 },
         { key: 'curveOffset', kind: 'number', unit: 'm', min: -3, max: 3, step: 0.05 },
       ],
     },


### PR DESCRIPTION
Level height, wall custom height, ceiling custom height, and column height were all UI-capped at 6m, which rules out tall single-space builds (climbing gyms, warehouses, halls).

## Changes

- Level height slider (level selector popover): max 6 → 20
- Wall "Custom height" (panel slider + clamp, parametric descriptor): max 6 → 20
- Ceiling custom height (panel, still clamped to the level-top bound; descriptor): max 6 → 20
- Column height (panel + descriptor): max 6 → 20

20m covers the tallest realistic single-storey uses — lead-climbing walls top out around 15–18m — while keeping the sliders usable in the common 2–4m band. The caps were never enforced in core schemas; only the controls change. Slab elevation, doors, and dormer fields are deliberately untouched.

Walls/ceilings in "Follows level" mode already track the level top, so raising the level height is all a plain tall room needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only slider/descriptor max changes; schemas and core clamping behavior are unchanged, so risk is limited to allowing taller geometry via existing controls.
> 
> **Overview**
> Raises the **UI height caps** for tall single-space builds (warehouses, halls, climbing gyms) from **6m → 20m**.
> 
> Updates the level-height slider in the floating level selector, plus custom-height controls and parametric descriptors for **walls**, **ceilings**, and **columns**. Ceiling custom height remains clamped to the level-top bound. Core schemas were never enforcing the old 6m limit—only the controls change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8b40229609b8104e2b3f8097af89c823476c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->