### PR TITLE
viewer: expose depth snapshot channel

### DIFF
--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -141,6 +141,7 @@ export {
   SNAPSHOT_MAX_EDGE,
   SNAPSHOT_MIME,
   SNAPSHOT_QUALITY,
+  type SnapshotCaptureChannel,
   type SnapshotCaptureMode,
   type SnapshotCaptureResult,
   type SnapshotCropRegion,

--- a/packages/viewer/src/lib/snapshot-pipeline.test.ts
+++ b/packages/viewer/src/lib/snapshot-pipeline.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test'
+import { OrthographicCamera, PerspectiveCamera } from 'three'
+import { snapshotCameraDepthNode } from './snapshot-pipeline'
+
+test('keeps orthographic depth linear without perspective conversion', () => {
+  const rawDepth = {}
+  const linearDepth = {}
+  const scenePass = {
+    getLinearDepthNode: () => linearDepth,
+    getTextureNode: () => ({ r: rawDepth }),
+  }
+
+  expect(snapshotCameraDepthNode(scenePass as never, new OrthographicCamera())).toBe(rawDepth)
+  expect(snapshotCameraDepthNode(scenePass as never, new PerspectiveCamera())).toBe(linearDepth)
+})

--- a/packages/viewer/src/lib/snapshot-pipeline.ts
+++ b/packages/viewer/src/lib/snapshot-pipeline.ts
@@ -50,6 +50,8 @@ function clampSnapshotSize(width: number, height: number): { w: number; h: numbe
 }
 
 export type SnapshotCaptureMode = 'standard' | 'viewport' | 'area'
+/** Depth captures encode near as white and far or background as black. */
+export type SnapshotCaptureChannel = 'rgb' | 'depth'
 
 export type SnapshotCropRegion = {
   x: number
@@ -84,10 +86,12 @@ export type SnapshotPipeline = {
     camera: Camera
   }) => void
   capture: ({
+    channel,
     captureMode,
     cropRegion,
     standardSize,
   }: {
+    channel?: SnapshotCaptureChannel
     captureMode?: SnapshotCaptureMode
     cropRegion?: SnapshotCropRegion
     standardSize?: SnapshotSize
@@ -215,8 +219,12 @@ export async function createSnapshotPipeline({
     // into an intermediate RT so FXAA can sample it with neighbour UV offsets.
     const aaOutput = fxaa(convertToTexture(finalOutput))
 
-    const pipeline = new RenderPipeline(renderer)
-    pipeline.outputNode = aaOutput
+    const colorPipeline = new RenderPipeline(renderer)
+    colorPipeline.outputNode = aaOutput
+    const depth = snapshotCameraDepthNode(scenePass, camera).oneMinus()
+    const depthPipeline = new RenderPipeline(renderer)
+    depthPipeline.outputNode = vec4(vec3(depth), float(1))
+    depthPipeline.outputColorTransform = false
 
     // Dedicated render target — pipeline outputs here instead of the canvas,
     // so R3F's main render loop can never overwrite our capture.
@@ -249,7 +257,7 @@ export async function createSnapshotPipeline({
         bgProjInvUniform.value.copy(captureCamera.projectionMatrixInverse)
         bgCamWorldUniform.value.copy(captureCamera.matrixWorld)
       },
-      capture: async ({ captureMode, cropRegion, standardSize }) => {
+      capture: async ({ channel = 'rgb', captureMode, cropRegion, standardSize }) => {
         const standardW = standardSize?.w ?? THUMBNAIL_WIDTH
         const standardH = standardSize?.h ?? THUMBNAIL_HEIGHT
         const { width: captureWidth, height: captureHeight } = renderer.domElement
@@ -262,7 +270,7 @@ export async function createSnapshotPipeline({
         try {
           ;(renderer as any).setClearAlpha(0)
           renderer.setRenderTarget(renderTarget)
-          pipeline.render()
+          ;(channel === 'depth' ? depthPipeline : colorPipeline).render()
         } finally {
           renderer.setRenderTarget(null)
         }
@@ -388,7 +396,8 @@ export async function createSnapshotPipeline({
         return { blob, outW, outH }
       },
       dispose: () => {
-        pipeline.dispose()
+        colorPipeline.dispose()
+        depthPipeline.dispose()
         renderTarget.dispose()
       },
     }
@@ -399,4 +408,10 @@ export async function createSnapshotPipeline({
     )
     return null
   }
+}
+
+export function snapshotCameraDepthNode(scenePass: ReturnType<typeof pass>, camera: Camera) {
+  return camera.type === 'OrthographicCamera'
+    ? scenePass.getTextureNode('depth').r
+    : scenePass.getLinearDepthNode()
 }


### PR DESCRIPTION
## What does this PR do?

Adds an optional `channel: 'rgb' | 'depth'` to `SnapshotPipeline.capture`, defaulting to the existing RGB behavior.

The depth channel reuses the snapshot pipeline's existing scene pass, render target, crop, GPU readback, and encoder. It emits near geometry as white and far/background pixels as black. Orthographic cameras use the hardware depth attachment directly because Three's current `getLinearDepthNode()` always applies perspective conversion.

This makes aligned RGB/depth evidence available to viewer consumers without maintaining a second capture implementation.

## How to test

1. From `packages/viewer`, run `bun run build`.
2. From `packages/viewer`, run `bun run test` and confirm all 102 tests pass.
3. Run `bunx biome check packages/viewer/src/lib/snapshot-pipeline.ts packages/viewer/src/lib/snapshot-pipeline.test.ts packages/viewer/src/index.ts` from the repository root.

## Screenshots / screen recording

Not applicable: this adds a capture API channel and does not change the live viewer UI.

## Checklist

- [x] I've tested this locally with the viewer build and full viewer test suite
- [x] My code follows the existing code style
- [x] I've documented the depth encoding on the public capture-channel type
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API with default RGB behavior unchanged; depth path is isolated but touches the shared snapshot render/dispose flow.
> 
> **Overview**
> Adds an optional **`channel: 'rgb' | 'depth'`** argument to `SnapshotPipeline.capture` (default **`'rgb'`**), so consumers can request **aligned depth evidence** through the same render target, crop modes, and WebP readback path as existing snapshots.
> 
> For **`'depth'`**, a dedicated TSL pipeline outputs **inverted depth** (near white, far/background black) with color transforms disabled. **`snapshotCameraDepthNode`** picks **raw depth** for orthographic cameras and **linear depth** for perspective, avoiding Three’s perspective-only `getLinearDepthNode()` on ortho shots. The public **`SnapshotCaptureChannel`** type documents the encoding; **`snapshotCameraDepthNode`** is covered by a small unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3671362cd30e822b94acf25b37a0e537a6fd9b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->