### PR TITLE
feat(editor): add undo/redo buttons to viewer toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Undo/Redo buttons in the viewer toolbar (top-left, alongside the collapse and view-mode controls). The buttons subscribe to the history store via `subscribeHistoryCommandState`, dispatch through `runUndo`/`runRedo` (respecting the collaborative history delegate), and disable when nothing can be undone/redone. Keyboard shortcuts were already wired: Ctrl/Cmd+Z undo, Ctrl/Cmd+Shift+Z redo.
+
 ### Fixes
 
 - Preserve custom scene materials across save, load, clone, fork, and live sync. Materials were dropped at every persistence boundary, so a scene reopened with default surfaces. Collections were dropped on MCP import for the same reason ([#597](https://github.com/pascalorg/editor/pull/597)) by [@ShiroKSH](https://github.com/ShiroKSH)

--- a/apps/editor/components/viewer-toolbar.tsx
+++ b/apps/editor/components/viewer-toolbar.tsx
@@ -10,6 +10,10 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  getHistoryCommandState,
+  runRedo,
+  runUndo,
+  subscribeHistoryCommandState,
   useEditor,
   useFloorplanAnnotationVisibility,
   useFloorplanMode,
@@ -37,6 +41,7 @@ import {
   Layers3,
   Magnet,
   PenLine,
+  Redo2,
   Ruler,
   ScanLine,
   SlidersHorizontal,
@@ -44,9 +49,10 @@ import {
   SquareUserRound,
   SwatchBook,
   Tag,
+  Undo2,
 } from 'lucide-react'
 import Image from 'next/image'
-import { type ReactNode, useCallback } from 'react'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from './toolbar-tooltip'
@@ -686,10 +692,69 @@ function PreviewButton() {
   )
 }
 
+// Undo/Redo toolbar controls. They subscribe to the shared history state
+// (`history.ts`) so buttons enable/disable as the scene history grows, and
+// route through `runUndo`/`runRedo` so they honor a collaborative host
+// delegate when one is installed. Keyboard shortcuts (Ctrl/Cmd+Z and
+// Ctrl/Cmd+Shift+Z) are wired separately in `use-keyboard.ts` and land here
+// via the same state subscription.
+function HistoryControls() {
+  const [state, setState] = useState(() => getHistoryCommandState())
+
+  useEffect(() => {
+    return subscribeHistoryCommandState(() => setState(getHistoryCommandState()))
+  }, [])
+
+  const undo = () => {
+    if (!getHistoryCommandState().canUndo) return
+    runUndo()
+  }
+
+  const redo = () => {
+    if (!getHistoryCommandState().canRedo) return
+    runRedo()
+  }
+
+  return (
+    <div className={TOOLBAR_CONTAINER}>
+      <ToolbarTooltip label="Undo (Ctrl+Z)">
+        <button
+          aria-label="Undo"
+          aria-disabled={!state.canUndo}
+          className={cn(
+            TOOLBAR_BTN,
+            !state.canUndo && 'cursor-default opacity-40 hover:bg-transparent hover:text-inherit',
+          )}
+          onClick={undo}
+          type="button"
+        >
+          <Undo2 className="h-4 w-4" />
+        </button>
+      </ToolbarTooltip>
+      <div className="my-1.5 w-px bg-border/50" />
+      <ToolbarTooltip label="Redo (Ctrl+Shift+Z)">
+        <button
+          aria-label="Redo"
+          aria-disabled={!state.canRedo}
+          className={cn(
+            TOOLBAR_BTN,
+            !state.canRedo && 'cursor-default opacity-40 hover:bg-transparent hover:text-inherit',
+          )}
+          onClick={redo}
+          type="button"
+        >
+          <Redo2 className="h-4 w-4" />
+        </button>
+      </ToolbarTooltip>
+    </div>
+  )
+}
+
 export function CommunityViewerToolbarLeft() {
   return (
     <>
       <CollapseSidebarButton />
+      <HistoryControls />
       <ViewModeControl />
     </>
   )


### PR DESCRIPTION
## What does this PR do?

Adds Undo/Redo buttons to the viewer toolbar (top-left, next to the collapse and view-mode controls). The buttons subscribe to the history store via `subscribeHistoryCommandState` and dispatch through `runUndo`/`runRedo`, which respect the collaborative history delegate and fall back to standalone Zundo when no controller is installed. Buttons disable when nothing can be undone/redone.

Keyboard shortcuts were already wired (Ctrl/Cmd+Z undo, Ctrl/Cmd+Shift+Z redo) and command palette entries already existed; this PR adds the visible toolbar affordance and the CHANGELOG entry.

## How to test

1. Run `bun dev` and open the editor at http://localhost:3002
2. Create or move a node in the 3D view
3. Click the Undo button — the action is reverted; click Redo — it is reapplied
4. With an empty history, both buttons are disabled
5. Press Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z to confirm the keyboard shortcuts still work alongside the buttons

## Screenshots / screen recording

N/A — visual change; a screen recording will be added if requested.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only addition that reuses existing history APIs; no changes to undo/redo or scene mutation logic.
> 
> **Overview**
> Adds **Undo** and **Redo** controls to the top-left community viewer toolbar (between sidebar collapse and 3D/2D/split view mode).
> 
> A new `HistoryControls` block subscribes to `subscribeHistoryCommandState`, reads `canUndo` / `canRedo` via `getHistoryCommandState`, and invokes `runUndo` / `runRedo` so behavior matches the command palette and keyboard shortcuts (including collaborative history when a delegate is set). Buttons use the same toolbar styling as other controls and are visually disabled when history is empty. **CHANGELOG** documents the feature under Unreleased → Features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a63b694287ce10e8b46f95d5ed000bc821ccb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->