### PR TITLE
editor: drop the stale 6 m caps and surface the ceiling's level bound

### DIFF
--- a/packages/nodes/src/ceiling/panel.tsx
+++ b/packages/nodes/src/ceiling/panel.tsx
@@ -271,16 +271,34 @@ export function CeilingPanel() {
         )}
 
         {/* Presets write an explicit height (clamped to the bound), so
-            clicking one on a follows-mode ceiling switches it to custom. */}
+            clicking one on a follows-mode ceiling switches it to custom.
+            A preset taller than the storey would clamp silently and look
+            like a dead button — disable it and name the real gate instead. */}
         <div className="mt-2 grid grid-cols-3 gap-1.5 px-1 pb-1">
-          {heightPresets.map((preset) => (
-            <ActionButton
-              key={preset.label}
-              label={preset.label}
-              onClick={() => handleHeightChange(preset.height)}
-            />
-          ))}
+          {heightPresets.map((preset) => {
+            const fits = preset.height <= maxHeight
+            return (
+              <ActionButton
+                className={fits ? undefined : 'cursor-not-allowed opacity-40'}
+                disabled={!fits}
+                key={preset.label}
+                label={preset.label}
+                onClick={() => handleHeightChange(preset.height)}
+                title={
+                  fits
+                    ? undefined
+                    : `Taller than this level (${formatLinearMeasurement(maxHeight, unit, metricNotation)} available). Raise the level height first.`
+                }
+              />
+            )
+          })}
         </div>
+        {Number.isFinite(maxHeight) && (
+          <div className="px-1 pb-1 text-[11px] text-muted-foreground">
+            Limited by the level to {formatLinearMeasurement(maxHeight, unit, metricNotation)} —
+            raise the level height for a taller ceiling.
+          </div>
+        )}
       </PanelSection>
 
       <PanelSection title="Info">

--- a/packages/nodes/src/ceiling/panel.tsx
+++ b/packages/nodes/src/ceiling/panel.tsx
@@ -55,7 +55,7 @@ export function CeilingPanel() {
     const parent = node?.parentId ? s.nodes[node.parentId as AnyNode['id']] : undefined
     return parent?.type === 'level'
       ? getCeilingClampBound(parent.id, s.nodes, node?.polygon ?? [])
-      : 6
+      : Number.POSITIVE_INFINITY
   })
 
   // Effective height: the stored custom height, or — for follows-mode

--- a/packages/nodes/src/slab/panel.tsx
+++ b/packages/nodes/src/slab/panel.tsx
@@ -279,9 +279,11 @@ export function SlabPanel() {
       width={320}
     >
       <PanelSection title="Elevation">
+        {/* Range mirrors the 20 m storey cap; `clampSlabElevation` in the
+            write path stays the real bound against the level. */}
         <SliderControl
           label={node.recessed ? 'Floor' : 'Surface'}
-          max={6}
+          max={20}
           min={-3}
           onChange={handleElevationChange}
           precision={3}
@@ -292,7 +294,7 @@ export function SlabPanel() {
 
         <SliderControl
           label={node.recessed ? 'Rim' : 'Base'}
-          max={6}
+          max={20}
           min={-3}
           onChange={handleAnchorChange}
           precision={3}


### PR DESCRIPTION
## What does this PR do?

Follow-up to #642, which raised the room-envelope height caps from 6 m to 20 m but left two sliders behind, so a tall storey still wasn't usable in practice.

- **`ceiling/panel.tsx`** — the non-level-parent fallback stayed at `6` while `definition.ts` uses `Number.POSITIVE_INFINITY` for the same case, so the panel and the 3D drag handle disagreed on the same bound. They now agree.
- **`slab/panel.tsx`** — the elevation sliders (Surface/Floor and Base/Rim) stayed at `max={6}`, so a slab could not be raised past 6 m inside a 20 m level. `clampSlabElevation` in the write path is the real bound; the slider was only a UI ceiling.

It also fixes a usability trap found while verifying the above. A ceiling's cap is the storey plane (`getCeilingClampBound`), which on a stock 2.5 m level is 2.49 m — so the **"Standard (2.5m)"** and **"High (3.0m)"** presets clamped silently and read as dead buttons, with nothing pointing at the level height as the actual gate. Presets taller than the level are now disabled with the available height in their tooltip, and the Height section names the bound.

The clamp itself is unchanged: a ceiling still never pokes through its own storey.

## How to test

1. `bun dev`, draw a room with walls and a ceiling.
2. Select the ceiling → **Height** → switch to **Custom height**. On a default 2.5 m level, confirm the *Standard (2.5m)* and *High (3.0m)* presets are disabled, and hovering one explains that it's taller than the level.
3. Confirm the section now reads "Limited by the level to 2.49 m — raise the level height for a taller ceiling."
4. Raise the level height (level badge → **Level height**) to e.g. 6 m. The presets re-enable and the ceiling slider now goes up to 5.99 m.
5. Select a slab → **Elevation**. Confirm the Surface/Floor and Base/Rim sliders now travel to 20 m instead of stopping at 6 m, and that `clampSlabElevation` still holds them under the storey.

I verified the clamp empirically rather than by reading: `getCeilingClampBound` returns **19.99** on a 20 m level in every configuration tested — single level, level above, and level above with a covering floor slab.

## Screenshots / screen recording

N/A — will add a short clip if the reviewer wants one; the visible change is two disabled preset buttons and one line of helper text in the ceiling panel.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only panel bounds and preset UX; geometry clamp logic is unchanged.
> 
> **Overview**
> Removes leftover **6 m** UI limits on ceiling and slab inspectors so tall storeys (up to **20 m**) are editable in the panel, matching the write-path clamps and `definition.ts`.
> 
> In **`ceiling/panel.tsx`**, the non-level-parent `maxHeight` fallback changes from **6** to **`Number.POSITIVE_INFINITY`** (same as the 3D/registry bound). Height presets that exceed the storey clamp are **disabled** with a tooltip, and when the cap is finite the panel shows **“Limited by the level to …”** so silent clamping no longer looks like broken buttons.
> 
> In **`slab/panel.tsx`**, Surface/Floor and Base/Rim sliders **`max`** rise from **6** to **20**; **`clampSlabElevation`** remains the real limit on save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fae36af78337454f9016c261b7c4fc86a7dfab60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->