### PR TITLE
chore: bump plugin-bones to 39f1916 (camera-proof X-ray + engine fixes)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#a480fd81052e6fc26e389114dd0ddd01df969f46",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#39f1916213de6fa8e65388d771839c5f9834fea1",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#a480fd81052e6fc26e389114dd0ddd01df969f46",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#39f1916213de6fa8e65388d771839c5f9834fea1",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#a480fd8", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-a480fd8"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#39f1916", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-39f1916"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Bumps the Bones pin from a480fd8 to 39f1916.

**Rendering** — the X-ray is now a solid scene-layer pass + a ghost overlay pass:
- survives orbit/zoom (the previous depth-wipe never actually took effect in the TSL RenderPipeline; walls "closed off" over the framing after any camera move)
- foreground objects (e.g. nature-plugin trees) correctly occlude and cast shadows on the skeleton instead of being painted over

**Engines** — round-10/11 exactness batch: repo-wide OBB interpenetration gate plus the geometry it caught (ridge-face rafter bearing with inscribed plumb cuts, fascia outside tail cuts, dropped gable ends, sistered ceiling joists/collar ties, wall corner/tee run insets, oblique foundation corners, per-bay floor blocking, live girder end-bearing validation, R802.7.1 birdsmouth cap, purchasable 1x8 fascia, CMU grout field + numeric pins, HVAC square-trunk takeoff, LA-1/GA-1 circuit pins).

408 tests + typecheck green at the pinned sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 61633216678f4e7e1acaa60ace3bf053625f3a60. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->