### PR TITLE
chore: bump plugin-bones to ecd6270 (Save full plans export)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#39f1916213de6fa8e65388d771839c5f9834fea1",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#ecd62705b2689c84913220483b3bf85ec42d25f7",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#39f1916213de6fa8e65388d771839c5f9834fea1",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#ecd62705b2689c84913220483b3bf85ec42d25f7",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#39f1916", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-39f1916"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#ecd6270", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-ecd6270"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Follow-up to #653: bumps Bones to ecd6270.

- New **Save full plans** button at the bottom of the Bones sidebar — generates a print-ready LOD 400 plan set (foundation / floor / wall / roof framing plans, electrical rough-in with device tags, MEP, schedules + takeoff with engineering flags), paginated for Print → Save as PDF. Pure client-side SVG, dependency-free.
- Catalog description trimmed to stay high-level.

412 tests + typecheck green at the pinned sha; export verified E2E on the demo house (5 sheets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only a dependency pin and lockfile update; no in-repo logic changes, though Bones sidebar/export behavior will change with the new plugin version.
> 
> **Overview**
> **Dependency-only change:** updates the editor’s pinned `@pascal-app/plugin-bones` Git ref from `39f1916` to `ecd6270` in `apps/editor/package.json`, with the matching lockfile entry in `bun.lock`.
> 
> That newer Bones build is what adds the **Save full plans** flow in the Bones sidebar (client-side, print-ready plan set for Print → Save as PDF). No application code changes in this repo—behavior shifts come entirely from the upgraded plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c189b0f54e15c81386944f41b510742b7754680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->