### PR TITLE
chore: bump plugin-bones to a4baf65 (dollhouse X-ray + blueprint quality batch)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#ecd62705b2689c84913220483b3bf85ec42d25f7",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#a4baf65104d0bb4982dfad44cef49d0f98a9186a",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#ecd62705b2689c84913220483b3bf85ec42d25f7",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#a4baf65104d0bb4982dfad44cef49d0f98a9186a",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#ecd6270", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-ecd6270"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#a4baf65", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-a4baf65"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Bumps Bones ecd6270 → a4baf65 — the reviewed output of a three-agent loop (LOD architect round 14, quality reviewer rounds 1–3, blueprint examiner).

**X-ray / rendering**
- Dollhouse semantics: near wall faces open, far drywall is the backdrop; host wall mode auto-switches while X-ray is on and restores after
- Exterior walls detected geometrically when the scene marks both faces interior — unlocks sheathing/WRB/cladding stacks, correct device faces
- Wall assembly layers render only in X-ray (no z-fight with the host skin); duplicate colinear walls dedupe before framing (~20% phantom lumber gone)

**Blueprints**
- 'Blueprints' CTA; mitered foundation runs at any corner angle; per-circuit distinct colors + de-collided tags; wrapped title blocks with resolved jurisdiction + effective date; legend gutters; MEP context + legend; paginated schedules; ICC code links that resolve

**Engines (architect round 14, all verified)**
- Every roof family inscribes cleanly (flat/gambrel/mansard/dutch/steep hips/low pitches); rotated slabs; floor sisters; foundation splice/tee precedence; oblique multipliers on plates + CMU; electrical connectivity harness + per-circuit drill planes

434 tests + typecheck green at the pinned sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes come entirely from the pinned Git dependency (3D rendering, blueprints, structural engines), not from in-repo code edits—regression risk is in viewer/editor runtime when Bones loads.
> 
> **Overview**
> **Pins `@pascal-app/plugin-bones`** in the editor app from commit `ecd6270` to **`a4baf65`**, with the matching **`bun.lock`** entry updated.
> 
> This pulls in the external plugin release described in the PR (dollhouse X-ray wall semantics, blueprint/MEP improvements, and architect-round-14 geometry/engine fixes); **this repo diff is dependency-only**—no local source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e228d3c45efc39811f2d780fab979f79c6102345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->