### PR TITLE
chore: bump plugin-bones to 92e1f12 — electrical avoids window/door rough openings

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#a4baf65104d0bb4982dfad44cef49d0f98a9186a",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#92e1f12a7303f00acb8612f9603079f9d365163b",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#a4baf65104d0bb4982dfad44cef49d0f98a9186a",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#92e1f12a7303f00acb8612f9603079f9d365163b",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#a4baf65", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-a4baf65"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#92e1f12", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-92e1f12"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
## What

Bumps `@pascal-app/plugin-bones` a4baf65 → 92e1f12.

## Why

Prod-reported bug: place a low window or door and wires route straight through the rough opening; boxes could land on doors.

- Wire runs now detour around **any** opening whose RO crosses the drill plane (over header / under sill, transom-aware); full-height glazing gets a visible ⚠ flag.
- Boxes, switches, panel, junctions all snap out of ROs.
- New permanent gate `electrical.openings.test.ts` + adversarial visual QA (PASS — low window dropped on a live run reroutes in <0.5s).
- Blueprint follow-ups: one shared transform per sheet set, circuit-ID labels on runs, distinct GEN colors, anchor-bolt/o.c. callouts, engine warnings printed on schedules, even pagination, interior link-wall footings.

445 plugin tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change lives entirely in the bones plugin (electrical + blueprint output); risk is moderate because it affects generated building geometry/schedules, not local app code.
> 
> **Overview**
> Pins **`@pascal-app/plugin-bones`** in the editor app from `a4baf65` to **`92e1f12`**, with matching **`bun.lock`** resolution—no in-repo source changes.
> 
> That plugin revision fixes prod electrical routing through door/window rough openings: wire runs detour when an RO crosses the drill plane, and boxes, switches, panels, and junctions snap out of ROs (full-height glazing can surface a warning). Blueprint-related improvements in the same release are bundled with the bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95870618afe83e6b3688b129719ffd7a0a294266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->