### PR TITLE
chore: bump plugin-bones to 55a0623 — multi-storey elevations

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#92e1f12a7303f00acb8612f9603079f9d365163b",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#55a06231786485043c47e75547f803a7f3d7fb1e",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#92e1f12a7303f00acb8612f9603079f9d365163b",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#55a06231786485043c47e75547f803a7f3d7fb1e",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#92e1f12", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-92e1f12"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#55a0623", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-55a0623"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
## What

Bumps `@pascal-app/plugin-bones` 92e1f12 → 55a0623.

## Why

Prod report: on a two-storey house, Bones rendered the roof trusses at ground-floor height and X-ray per level misbehaved.

- Cross-level roofs now carry the exact storey delta (mirrors core `getLevelElevations`: per-building ordinal stacking, baseElevation, default height 2.5).
- One X-ray per building frames ALL roof-bearing levels (porch + main roof), each at its own delta; other nodes point to the owner.
- Ground detection / storey-below datum / roof search are building-scoped; per-config compute memo.
- Verified: two adversarial code-review rounds (all findings fixed + gated, 12 new gates) and in-browser measurement — bones deck aligns with the host-drawn roof shell to the pixel (live scene-graph cross-check).

457 plugin tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it alters 3D structural visualization and level-scoped behavior in the editor viewer—worth a quick smoke test on multi-storey scenes.
> 
> **Overview**
> Updates the editor’s **`@pascal-app/plugin-bones`** Git dependency from commit `92e1f12` to **`55a0623`**, with matching **`bun.lock`** resolution.
> 
> This pulls in the plugin fix for **multi-storey elevations**: roof trusses and per-level X-ray should follow correct storey stacking (aligned with core level elevation logic) instead of rendering roofs at ground-floor height on two-storey buildings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23881d15f6bf5e4ba78f5d9bbdc5d3170a14e2c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->