### PR TITLE
chore: bump plugin-bones to 9f5a43f — plumbing rebuild + architectural set + characteristics

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#4cd28a0347c2038bd96eb34d2b39377e585fda84",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#9f5a43f4b003ac8134ed54cac4e000e2992f57cc",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#4cd28a0347c2038bd96eb34d2b39377e585fda84",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#9f5a43f4b003ac8134ed54cac4e000e2992f57cc",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#4cd28a0", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-4cd28a0"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#9f5a43f", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-9f5a43f"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
## What

Bumps `@pascal-app/plugin-bones` 4cd28a0 → 9f5a43f.

## Highlights

- **Placed-fixture plumbing**: toilets/sinks/showers the user drops are the demand points — water-service meter + shut-off, panel-style water heater (garage tank / exterior tankless), hot+cold homeruns along the wall graph, DFU-sized sloped DWV tree with traps/vents to a sewer-exit cleanout. Six adversarial verify rounds: 14 defect classes fixed and gated (cross-trade separation ≥2cm, rough-opening avoidance with never-silent flags, no-size-reduction drain sizing, NEC 110.26 tank/panel separation).
- **Standard architectural set**: cover sheet (iso hero + sheet index), four framing elevations, transverse section — with examiner round-2 fixes (E/W orientation, section extent membership, one family scale, hidden-work linework).
- **Building characteristics**: floor area / volume / envelope / windows / climate-zone insulation R / UA / heat-loss + cooling estimates in a collapsible panel drawer with CSV, and printed on the blueprints.
- Under-slab DWV ghosts through the floor in X-ray (crawl-space view).

513 plugin tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes come entirely from the external plugin pin (plumbing, drawings, and building metrics), so regressions depend on that package rather than local code review here.
> 
> **Overview**
> **Dependency-only change:** updates `@pascal-app/plugin-bones` from `4cd28a0` to `9f5a43f` in `apps/editor/package.json` and the matching lockfile entry in `bun.lock`. No application source in this repo is modified.
> 
> The new plugin revision (per PR notes) brings **placed-fixture plumbing** (meter/shut-off, water heater, homeruns, DWV with verification gates), a **standard architectural drawing set** (cover, elevations, section), **building characteristics** UI/export on blueprints, and **under-slab DWV** visibility in X-ray crawl-space view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 618dc0e767bb49d1db44956cd0f24768e82f91fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->