### PR TITLE
chore: bump plugin-bones to e8d15ea — movable service points

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#9f5a43f4b003ac8134ed54cac4e000e2992f57cc",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#e8d15ea46971c1eb05661ac4f2339827877bbc42",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#9f5a43f4b003ac8134ed54cac4e000e2992f57cc",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#e8d15ea46971c1eb05661ac4f2339827877bbc42",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#9f5a43f", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-9f5a43f"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#e8d15ea", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-e8d15ea"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
## What

Bumps `@pascal-app/plugin-bones` 9f5a43f → e8d15ea.

## Why

Service points: a 'Place service points' panel action creates five labeled, selectable, movable `bones:service` nodes — electrical panel (bolt sign), water heater, water entry valve, sewer exit, power entry. Node positions are authoritative: wiring and piping re-derive around wherever the user moves them (inspector wall-slider or gizmo drag), with NEC 110.26 / rough-opening warnings on non-compliant spots. Two adversarial verify rounds: 8 defects fixed and gated (override compliance warnings, gizmo precedence, NaN guards, duplicate determinism, texture lifecycle, mirrored signs). Visual QA PASS: blueprint tags track moved equipment at exact scale.

559 plugin tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no local logic changes; risk is limited to behavior introduced in the new plugin commit.
> 
> **Overview**
> Updates the editor’s pinned **`@pascal-app/plugin-bones`** Git dependency from `9f5a43f` to **`e8d15ea`**, with the matching **`bun.lock`** entry.
> 
> This pulls in the external plugin release described as **movable service points** (panel action, `bones:service` nodes, wiring/piping that follows moves, compliance warnings)—no in-repo application code changes beyond the version pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8b305b808f217a68cda2fc26d41ab5c1f8a05f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->