### PR TITLE
chore: bump plugin-bones — blueprint round-3 polish + braided connectors

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#e8d15ea46971c1eb05661ac4f2339827877bbc42",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#45d4ad446024c68c2c524fef8f308bffee86bbaf",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#e8d15ea46971c1eb05661ac4f2339827877bbc42",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#45d4ad446024c68c2c524fef8f308bffee86bbaf",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#e8d15ea", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-e8d15ea"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#45d4ad4", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-45d4ad4"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Bumps `@pascal-app/plugin-bones` e8d15ea → 45d4ad4.

Blueprint examiner round-3 closure: filled-rect section poché (cut plane auto-slides off wall axes), width-aware electrical label de-collision, grid-based roof-coverage flag, every engine flag printed (no truncation), butt-cap linework, 'n/a' instead of 0.0 on slab-less characteristics. Plus braided supply connectors for fixtures off the wall (rough-opening flagged, counted as parts not phantom copper). Verified: connector skeptic PASS, examiner fix-check with all acceptance criteria gated. 585 plugin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: version pin and lockfile only; behavior changes live in the external plugin, with no local code edits.
> 
> **Overview**
> **Dependency-only change:** pins `@pascal-app/plugin-bones` from `e8d15ea` to `45d4ad4` in `apps/editor/package.json` and refreshes `bun.lock`. No in-repo application code changes.
> 
> The new plugin revision (per release notes) delivers blueprint examiner round-3 polish—filled-rect section poché with cut-plane behavior on wall axes, width-aware electrical label de-collision, grid-based roof-coverage flag, full engine-flag output, butt-cap linework, and `n/a` instead of `0.0` on slab-less characteristics—and **braided supply connectors** for off-wall fixtures (rough-opening flagged, counted as parts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805687b5f41ab5cd182429d3c72751d9047f0670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->