### PR TITLE
fix: plugin node kinds miss hover/click subscriptions when they register after mount

### DIFF
--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -41,7 +41,6 @@ export {
   resolveFacingIndicator,
   setPluginDiscovery,
 } from './registry'
-export { useRegistryVersion } from './use-registry-version'
 export {
   type CascadeContext,
   type ChildQuery,
@@ -156,3 +155,4 @@ export type {
   ToolHintChip,
   Vec2,
 } from './types'
+export { useRegistryVersion } from './use-registry-version'

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -21,6 +21,7 @@ export {
   extendPluginDiscovery,
   getHostRefFields,
   getNodePluginId,
+  getRegistryVersion,
   getSelectableKinds,
   hasRegistry3DMoveTool,
   isDrawnViaTool,
@@ -34,11 +35,13 @@ export {
   kindsWithFloorplanScope,
   loadPlugin,
   nodeRegistry,
+  onRegistryChange,
   type PluginDiscovery,
   registerNode,
   resolveFacingIndicator,
   setPluginDiscovery,
 } from './registry'
+export { useRegistryVersion } from './use-registry-version'
 export {
   type CascadeContext,
   type ChildQuery,

--- a/packages/core/src/registry/registry.test.ts
+++ b/packages/core/src/registry/registry.test.ts
@@ -245,4 +245,42 @@ describe('loadPlugin', () => {
       ).rejects.toThrow(/duplicate node kind/)
     })
   })
+
+  // GATE (late-plugin subscriptions): plugins register via async dynamic
+  // imports AFTER consumers mount. The selection managers rebuild their
+  // `getSelectableKinds()` emitter subscriptions off this change signal —
+  // without it, a plugin kind selects but never hovers in prod (the outline
+  // subscription list froze pre-registration).
+  test('registerNode bumps the registry version and notifies subscribers', async () => {
+    const { getRegistryVersion, onRegistryChange } = await import('./registry')
+    const before = getRegistryVersion()
+    let notified = 0
+    const unsubscribe = onRegistryChange(() => {
+      notified += 1
+    })
+
+    registerNode(makeDefinition('late:kind', { capabilities: { selectable: {} } }))
+    expect(getRegistryVersion()).toBe(before + 1)
+    expect(notified).toBe(1)
+
+    // A consumer re-deriving on the notification now sees the new kind.
+    const { getSelectableKinds } = await import('./registry')
+    expect(getSelectableKinds()).toContain('late:kind')
+
+    unsubscribe()
+    registerNode(makeDefinition('late:kind-2'))
+    expect(getRegistryVersion()).toBe(before + 2)
+    expect(notified).toBe(1) // unsubscribed — no further calls
+  })
+
+  test('loadPlugin notifies once per registered kind', async () => {
+    const { getRegistryVersion } = await import('./registry')
+    const before = getRegistryVersion()
+    await loadPlugin({
+      id: 'pack',
+      apiVersion: 1,
+      nodes: [makeDefinition('pack:a'), makeDefinition('pack:b')],
+    })
+    expect(getRegistryVersion()).toBe(before + 2)
+  })
 })

--- a/packages/core/src/registry/registry.ts
+++ b/packages/core/src/registry/registry.ts
@@ -6,6 +6,43 @@ const BUILTIN_PLUGIN_ID = 'pascal:core'
 
 const pluginIdsByKind = new Map<string, string>()
 
+// ---------------------------------------------------------------------------
+// Registry change notification. Plugin kinds register ASYNCHRONOUSLY (app
+// bootstraps discover them via dynamic imports — see `discoverPlugins`), so
+// any consumer that snapshots the registry at mount (the selection managers'
+// `getSelectableKinds()` subscription lists) goes stale the moment a plugin
+// loads after it. `_register` / `_reset` bump a monotonic version and notify
+// listeners; `useRegistryVersion()` (registry/use-registry-version.ts) turns
+// that into a React re-render so effects can re-derive their kind lists.
+// ---------------------------------------------------------------------------
+
+let registryVersion = 0
+const registryListeners = new Set<() => void>()
+
+function notifyRegistryChanged(): void {
+  registryVersion += 1
+  // Copy before iterating — a listener may unsubscribe (or subscribe) as a
+  // consequence of the notification.
+  for (const listener of [...registryListeners]) listener()
+}
+
+/** Monotonic counter, bumped on every kind registration (and test reset). */
+export function getRegistryVersion(): number {
+  return registryVersion
+}
+
+/**
+ * Subscribe to registry changes (a kind registered via {@link registerNode}
+ * / {@link loadPlugin}, or a test reset). Returns the unsubscribe function.
+ * `useSyncExternalStore`-compatible.
+ */
+export function onRegistryChange(listener: () => void): () => void {
+  registryListeners.add(listener)
+  return () => {
+    registryListeners.delete(listener)
+  }
+}
+
 // True in dev / test builds, false in production. Tries Vite's
 // `import.meta.env.DEV` first (the editor app's bundler) and falls back
 // to `process.env.NODE_ENV !== 'production'` for Node test runners.
@@ -72,12 +109,14 @@ class NodeRegistryImpl implements NodeRegistry {
       }
     }
     this.defs.set(def.kind, def)
+    notifyRegistryChanged()
   }
 
   // Test-only — clears the registry. Not exported from the package barrel.
   _reset(): void {
     this.defs.clear()
     pluginIdsByKind.clear()
+    notifyRegistryChanged()
   }
 }
 

--- a/packages/core/src/registry/use-registry-version.ts
+++ b/packages/core/src/registry/use-registry-version.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { getRegistryVersion, onRegistryChange } from './registry'
+
+/**
+ * React binding for the node registry's change counter. Re-renders the
+ * consumer whenever a kind registers (plugin kinds arrive asynchronously via
+ * dynamic-import discovery, AFTER the first mount). Effects that snapshot
+ * registry-derived lists — `getSelectableKinds()` subscription lists in the
+ * selection managers — add the returned version to their dependency array so
+ * a late plugin load rebuilds the subscriptions instead of leaving the
+ * plugin's kinds without hover / click handlers.
+ */
+export function useRegistryVersion(): number {
+  return useSyncExternalStore(onRegistryChange, getRegistryVersion, getRegistryVersion)
+}

--- a/packages/editor/src/components/editor/selection-manager.tsx
+++ b/packages/editor/src/components/editor/selection-manager.tsx
@@ -23,6 +23,7 @@ import {
   type StairSurfaceMaterialRole,
   sceneRegistry,
   useLiveNodeOverrides,
+  useRegistryVersion,
   useScene,
 } from '@pascal-app/core'
 
@@ -782,6 +783,12 @@ export const SelectionManager = () => {
 
   const movingNode = useMovingNode()
   const isCurveReshape = useIsCurveReshape()
+  // Plugin kinds register AFTER mount (async dynamic-import discovery), so
+  // every effect below that snapshots `getSelectableKinds()` into an emitter
+  // subscription list depends on this version — a late plugin load re-runs
+  // them and picks up the new kinds (hover / click / double-click / paint /
+  // pointerdown). Without it, plugin nodes select-but-never-hover in prod.
+  const registryVersion = useRegistryVersion()
 
   useEffect(() => {
     const nextHoverMode: HoverHighlightMode = mode === 'delete' ? 'delete' : 'default'
@@ -1188,7 +1195,7 @@ export const SelectionManager = () => {
       setHoverHighlightMode('default')
       useEditor.getState().setPaintHover(null)
     }
-  }, [isCurveReshape, mode, movingNode, setHoverHighlightMode])
+  }, [isCurveReshape, mode, movingNode, setHoverHighlightMode, registryVersion])
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -1363,7 +1370,7 @@ export const SelectionManager = () => {
         emitter.off(`${type}:pointerdown` as any, onPointerDown as any)
       }
     }
-  }, [isCurveReshape, mode, movingNode, camera, raycaster, glDomElement])
+  }, [isCurveReshape, mode, movingNode, camera, raycaster, glDomElement, registryVersion])
 
   // Move cursor over the selected movable node: the visual cue that clicking it
   // picks it up (replaces the removed move-cross gizmo). Reacts only when the
@@ -1781,7 +1788,7 @@ export const SelectionManager = () => {
       })
       emitter.off('grid:click', onGridClick)
     }
-  }, [isCurveReshape, mode, movingNode])
+  }, [isCurveReshape, mode, movingNode, registryVersion])
 
   // Global double-click handler for auto-switching phases and cross-phase hover
   useEffect(() => {
@@ -1936,7 +1943,7 @@ export const SelectionManager = () => {
         emitter.off(`${type}:double-click` as any, onDoubleClick as any)
       })
     }
-  }, [isCurveReshape, mode, movingNode])
+  }, [isCurveReshape, mode, movingNode, registryVersion])
 
   // Delete mode: click-to-delete (sledgehammer tool)
   useEffect(() => {
@@ -2012,7 +2019,7 @@ export const SelectionManager = () => {
       }
       useViewer.setState({ hoveredId: null })
     }
-  }, [mode])
+  }, [mode, registryVersion])
 
   return (
     <>

--- a/packages/editor/src/components/editor/selection-manager.tsx
+++ b/packages/editor/src/components/editor/selection-manager.tsx
@@ -800,6 +800,8 @@ export const SelectionManager = () => {
   }, [mode, setHoverHighlightMode])
 
   useEffect(() => {
+    // re-subscribe when plugin kinds register after mount (async plugin load)
+    void registryVersion
     if (mode !== 'material-paint') return
     if (movingNode || isCurveReshape) return
 
@@ -1231,6 +1233,8 @@ export const SelectionManager = () => {
   }, [])
 
   useEffect(() => {
+    // re-subscribe when plugin kinds register after mount (async plugin load)
+    void registryVersion
     if (mode !== 'select') return
     if (movingNode || isCurveReshape) return
 
@@ -1536,6 +1540,8 @@ export const SelectionManager = () => {
   }, [isCurveReshape, mode, movingNode])
 
   useEffect(() => {
+    // re-subscribe when plugin kinds register after mount (async plugin load)
+    void registryVersion
     if (mode !== 'select') return
     if (movingNode || isCurveReshape) return
 
@@ -1792,6 +1798,8 @@ export const SelectionManager = () => {
 
   // Global double-click handler for auto-switching phases and cross-phase hover
   useEffect(() => {
+    // re-subscribe when plugin kinds register after mount (async plugin load)
+    void registryVersion
     if (mode !== 'select') return
     if (movingNode || isCurveReshape) return
 
@@ -1947,6 +1955,8 @@ export const SelectionManager = () => {
 
   // Delete mode: click-to-delete (sledgehammer tool)
   useEffect(() => {
+    // re-subscribe when plugin kinds register after mount (async plugin load)
+    void registryVersion
     if (mode !== 'delete') return
 
     const onClick = (event: NodeEvent) => {

--- a/packages/viewer/src/components/viewer/selection-manager.tsx
+++ b/packages/viewer/src/components/viewer/selection-manager.tsx
@@ -312,6 +312,8 @@ export const SelectionManager = () => {
   const registryVersion = useRegistryVersion()
 
   useEffect(() => {
+    // re-subscribe when plugin kinds register after mount (async plugin load)
+    void registryVersion
     const onEnter = (event: NodeEvent) => {
       const strategy = getStrategy()
       if (!strategy) return

--- a/packages/viewer/src/components/viewer/selection-manager.tsx
+++ b/packages/viewer/src/components/viewer/selection-manager.tsx
@@ -13,6 +13,7 @@ import {
   pointInPolygon,
   resolveSelectionProxyId,
   sceneRegistry,
+  useRegistryVersion,
   useScene,
   type WallNode,
   type ZoneNode,
@@ -306,6 +307,9 @@ const getStrategy = (): SelectionStrategy | null => {
 export const SelectionManager = () => {
   const selection = useViewer((s) => s.selection)
   const clickHandledRef = useRef(false)
+  // Plugin kinds register AFTER mount (async dynamic-import discovery) —
+  // re-derive the `getSelectableKinds()` subscription list when they land.
+  const registryVersion = useRegistryVersion()
 
   useEffect(() => {
     const onEnter = (event: NodeEvent) => {
@@ -396,7 +400,7 @@ export const SelectionManager = () => {
         emitter.off(`${type}:click` as any, onClick as any)
       }
     }
-  }, [])
+  }, [registryVersion])
 
   return (
     <>


### PR DESCRIPTION
## Problem (user-reported on prod)

Hovering a window outlines it; hovering a Bones service box (electric panel / water heater) does nothing. Selection works.

## Root cause

The editor + viewer `SelectionManager`s build their emitter subscription lists from `getSelectableKinds()` **inside effects**, snapshotted at mount. Built-in kinds register synchronously at bootstrap, but plugin kinds arrive through **async dynamic-import discovery** (`extendPluginDiscovery(async () => (await import('@pascal-app/plugin-bones')).bonesPlugin)` in the community bootstrap) — i.e. after mount. The registry had no change notification, so the subscription lists stayed frozen on the pre-plugin kind set: plugin nodes never got `:enter`/`:leave`/`:click`/`:double-click` handlers unless an unrelated effect dep (`mode`, `movingNode`, `isCurveReshape`) happened to change first. Hover is the visible casualty; click/paint/pointerdown lists had the same latent staleness.

Dev is unaffected (apps/editor bootstrap uses static imports → registration completes in microtasks before any effect runs), which is why QA on localhost never reproduced it.

## Fix (minimal)

- `packages/core/src/registry/registry.ts`: `_register`/`_reset` bump a monotonic version and notify listeners (`getRegistryVersion` / `onRegistryChange`).
- `packages/core/src/registry/use-registry-version.ts`: `useRegistryVersion()` — `useSyncExternalStore` binding.
- `packages/editor` SelectionManager: `registryVersion` added to the dep arrays of the 5 effects that snapshot `getSelectableKinds()` (paint, pointerdown, click, hover/double-click, delete-mode).
- `packages/viewer` SelectionManager: same for its single subscription effect (deps were `[]`).

A late plugin load now rebuilds the subscriptions; re-running the effects is idempotent (they unsubscribe in cleanup).

## Tests

- New gates in `packages/core/src/registry/registry.test.ts`: version bump + listener notify + unsubscribe; `loadPlugin` notifies per kind.
- `packages/core` 1007 pass, `packages/editor` 604 pass, `packages/viewer` 101 pass; `tsc --noEmit` clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core input/selection wiring for all selectable kinds; behavior change is limited to fixing stale subscriptions after late plugin load, with targeted tests on the registry notification API.
> 
> **Overview**
> Fixes **plugin nodes that could be selected but not hovered** in production when kinds register after the selection managers mount.
> 
> The node registry now **bumps a monotonic version and notifies subscribers** on each `registerNode` / `loadPlugin` kind and on test `_reset`, via **`getRegistryVersion`**, **`onRegistryChange`**, and **`useRegistryVersion()`** (`useSyncExternalStore`). Editor and viewer **`SelectionManager`** effects that snapshot **`getSelectableKinds()`** into emitter subscriptions now depend on that version so a late async plugin load **re-subscribes** for hover, click, double-click, paint, pointerdown, and delete handlers.
> 
> Tests cover version bumps, listener notify/unsubscribe, and per-kind notifications from **`loadPlugin`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ffc5ddd90ef6472599e1809f05492fa6f386e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->