### PR TITLE
chore: bump plugin-bones — day batch (exploded strata, attic HVAC, service UX)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#45d4ad446024c68c2c524fef8f308bffee86bbaf",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#eace4e80d7bb1d04ac7d9b082395d392387dbb21",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#45d4ad446024c68c2c524fef8f308bffee86bbaf",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#eace4e80d7bb1d04ac7d9b082395d392387dbb21",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#45d4ad4", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-45d4ad4"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#eace4e8", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-eace4e8"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Bumps `@pascal-app/plugin-bones` dccdac2^.. → eace4e8 (from 45d4ad4).

- Exploded view: floor / roof trusses / shingle shell as three strata (above-owner scoping gated)
- Gable walls on slab-less roof levels wear the full exterior stack (prod bug)
- HVAC to code: attic trunk + ceiling grilles, never through plate bands (M1 gate, IRC R602.6/M1601); interior storeys soffit with a printed note; thermostat + outdoor heat pump placed and movable
- Electric meter with street→meter→panel service cable riding the wall graph, RO-aware
- Door-style drag for service points (parentFrame) + per-wall engineering card in the panel
- Pairs with the merged hover re-subscription fix (#665) so plugin equipment outlines on hover like windows

Five adversarial verify rounds absorbed; 668 plugin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Monorepo change is dependency pin and lockfile only; risk is limited to editor behavior delivered by the external bones plugin at runtime.
> 
> **Overview**
> **Pins `@pascal-app/plugin-bones`** from `45d4ad4` → `eace4e8` in `apps/editor/package.json`, with the matching `bun.lock` resolution update. No application source changes in this repo—the editor picks up the new plugin build on install.
> 
> The bumped plugin release (per paired release notes) adds **exploded-view strata** (floor / roof trusses / shingle shell), fixes **gable exterior stacking** on slab-less roof levels, **code-oriented attic HVAC** (trunk, grilles, thermostat/heat pump placement), **electric meter + wall-routed service cable**, and **door-style drag / per-wall engineering UI** for service points. Intended to work with the hover outline fix in #665.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5597040a302aa233071eac032e2d1046781c4c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->