### PR TITLE
fix(editor): inspector extension mode is either/or with the regular controls

### DIFF
--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -881,10 +881,13 @@ export type FloorplanMoveTarget<N> = (args: {
 /**
  * A plugin-contributed section for the floating node inspector card.
  * When a node whose `type` is in `kinds` is selected, the inspector header
- * shows the extension's `icon` as a button while the card is folded
- * (click → expand straight to the section), and the expanded card renders
- * `component` inside a collapsible section titled `title`, after the
- * kind's own controls.
+ * shows the extension's `icon` as a button. Clicking it swaps the card
+ * body to ONLY this extension's `component` (inside a section titled
+ * `title`) — extension mode and the kind's own controls are EITHER/OR,
+ * never appended together. Clicking the (highlighted) icon again, or the
+ * chevron, returns to the regular controls. The mobile sheet has no
+ * header icons, so it appends the section after the kind's controls
+ * instead.
  *
  * `component` is lazy-loaded on first expand and receives the selected
  * node as a `node` prop (`ComponentType<{ node: AnyNode }>` — typed as

--- a/packages/editor/src/components/ui/panels/panel-wrapper.tsx
+++ b/packages/editor/src/components/ui/panels/panel-wrapper.tsx
@@ -27,6 +27,11 @@ import {
   useState,
 } from 'react'
 import { useIsMobile } from '../../../hooks/use-mobile'
+import {
+  resolveActiveExtension,
+  toggleCard,
+  toggleExtension,
+} from '../../../lib/inspector-card-mode'
 import { cn } from '../../../lib/utils'
 import { PanelSection } from '../controls/panel-section'
 import { ErrorBoundary } from '../primitives/error-boundary'
@@ -132,10 +137,13 @@ export function PanelWrapper({
     )
   }, [selectedType, installedPlugins, registryVersion])
 
-  // The extension whose folded-header icon was clicked — its section mounts
-  // expanded when the card opens. Cleared whenever the card folds so a plain
-  // chevron expand shows extension sections collapsed again.
-  const [focusedExtensionId, setFocusedExtensionId] = useState<string | null>(null)
+  // Which extension's content fills the card body (extension mode). The two
+  // expanded modes are EITHER/OR: extension mode replaces the regular
+  // controls; null shows the regular controls with no extension sections.
+  // See `lib/inspector-card-mode.ts` for the transition table.
+  const [activeExtensionId, setActiveExtensionId] = useState<string | null>(null)
+  // Stale ids (kind changed, plugin gated off) fall back to regular mode.
+  const activeExtension = resolveActiveExtension(activeExtensionId, extensions)
 
   // The whole panel is collapsed to just its header by default; the chevron
   // expands it to reveal the inspector body. Keep the desktop value shared
@@ -154,10 +162,24 @@ export function PanelWrapper({
     [],
   )
 
-  // Folding the card forgets the focused extension — the focus jump is a
+  const applyMode = useCallback(
+    (next: { collapsed: boolean; activeExtensionId: string | null }) => {
+      setCollapsed(next.collapsed)
+      setActiveExtensionId(next.activeExtensionId)
+    },
+    [setCollapsed],
+  )
+
+  // Chevron / header press — collapsed → regular, regular → collapsed,
+  // extension mode → regular (exit the extension first, stay expanded).
+  const handleCardToggle = useCallback(() => {
+    applyMode(toggleCard({ collapsed, activeExtensionId }))
+  }, [applyMode, collapsed, activeExtensionId])
+
+  // Folding the card forgets the active extension — extension mode is a
   // one-shot affordance of the header icon, not sticky panel state.
   useEffect(() => {
-    if (collapsed) setFocusedExtensionId(null)
+    if (collapsed) setActiveExtensionId(null)
   }, [collapsed])
 
   // Drag-to-reposition from the header. `offset` is a translation applied on
@@ -224,15 +246,19 @@ export function PanelWrapper({
     setOffset({ x: drag.baseX + (left - drag.rectLeft), y: drag.baseY + (top - drag.rectTop) })
   }, [])
 
-  const handleHeaderPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    const drag = dragRef.current
-    if (!drag) return
-    dragRef.current = null
-    setIsDragging(false)
-    e.currentTarget.releasePointerCapture(e.pointerId)
-    // A press that never turned into a drag is a click → toggle collapse.
-    if (!drag.moved) setCollapsed((c) => !c)
-  }, [])
+  const handleHeaderPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current
+      if (!drag) return
+      dragRef.current = null
+      setIsDragging(false)
+      e.currentTarget.releasePointerCapture(e.pointerId)
+      // A press that never turned into a drag is a click → same mode toggle
+      // as the chevron.
+      if (!drag.moved) handleCardToggle()
+    },
+    [handleCardToggle],
+  )
 
   // Expanding can grow the panel past an edge if it was dragged there while
   // collapsed — nudge it back inside the viewer bounds.
@@ -329,30 +355,39 @@ export function PanelWrapper({
                 <RotateCcw className="h-4 w-4" />
               </button>
             )}
-            {/* Extension jump buttons — folded card only: one icon per
-                registered inspector extension, left of the chevron. Click
-                expands the card straight to that section. */}
-            {collapsed &&
-              extensions.map((extension) => (
+            {/* Extension mode buttons — one icon per registered inspector
+                extension, left of the chevron. Click swaps the card body to
+                ONLY that extension's content (either/or with the regular
+                controls); the active icon (highlighted) or the chevron
+                returns to the regular controls. */}
+            {extensions.map((extension) => {
+              const isActive = !collapsed && activeExtensionId === extension.id
+              return (
                 <button
-                  aria-label={`Open ${extension.title}`}
-                  className="flex h-7 w-7 items-center justify-center rounded-md bg-[#2C2C2E] text-muted-foreground transition-colors hover:bg-[#3e3e3e] hover:text-foreground"
+                  aria-label={isActive ? `Close ${extension.title}` : `Open ${extension.title}`}
+                  aria-pressed={isActive}
+                  className={cn(
+                    'flex h-7 w-7 items-center justify-center rounded-md transition-colors',
+                    isActive
+                      ? 'bg-cyan-500/20 text-cyan-400 hover:bg-cyan-500/30'
+                      : 'bg-[#2C2C2E] text-muted-foreground hover:bg-[#3e3e3e] hover:text-foreground',
+                  )}
                   key={extension.id}
-                  onClick={() => {
-                    setFocusedExtensionId(extension.id)
-                    setCollapsed(false)
-                  }}
+                  onClick={() =>
+                    applyMode(toggleExtension({ collapsed, activeExtensionId }, extension.id))
+                  }
                   title={extension.title}
                   type="button"
                 >
                   {renderExtensionIcon(extension.icon)}
                 </button>
-              ))}
+              )
+            })}
             <button
               aria-expanded={!collapsed}
               aria-label={collapsed ? 'Expand panel' : 'Collapse panel'}
               className="flex h-7 w-7 items-center justify-center rounded-md bg-[#2C2C2E] text-muted-foreground transition-colors hover:bg-[#3e3e3e] hover:text-foreground"
-              onClick={() => setCollapsed((c) => !c)}
+              onClick={handleCardToggle}
               type="button"
             >
               <ChevronDown
@@ -372,20 +407,36 @@ export function PanelWrapper({
         </div>
       )}
 
-      {/* Content — hidden while the panel is collapsed (desktop). */}
+      {/* Content — hidden while the panel is collapsed (desktop). The two
+          expanded modes are EITHER/OR: extension mode renders ONLY that
+          extension's content; regular mode renders ONLY the kind's own
+          controls (`children`). A stale extension id falls back to regular
+          via `resolveActiveExtension`. */}
       {!(collapsed && !isMobile) && (
         <div className="no-scrollbar flex min-h-0 flex-1 flex-col overflow-y-auto">
-          {children}
-          {/* Plugin-contributed sections, after the kind's own controls. */}
-          {selectedId &&
-            extensions.map((extension) => (
-              <InspectorExtensionSection
-                defaultExpanded={extension.id === focusedExtensionId}
-                extension={extension}
-                key={extension.id}
-                nodeId={selectedId}
-              />
-            ))}
+          {!isMobile && selectedId && activeExtension ? (
+            <InspectorExtensionSection
+              extension={activeExtension}
+              key={activeExtension.id}
+              nodeId={selectedId}
+            />
+          ) : (
+            <>
+              {children}
+              {/* Mobile sheet has no header icons to swap modes — keep the
+                  plugin sections appended after the kind's controls there. */}
+              {isMobile &&
+                selectedId &&
+                extensions.map((extension) => (
+                  <InspectorExtensionSection
+                    defaultExpanded={false}
+                    extension={extension}
+                    key={extension.id}
+                    nodeId={selectedId}
+                  />
+                ))}
+            </>
+          )}
         </div>
       )}
 
@@ -446,14 +497,16 @@ function resolveExtensionComponent(
  * One plugin-contributed inspector section. Subscribes to the full node —
  * the section body reflects any edit — and hands it to the extension's
  * lazy component inside its own error boundary so a crashing plugin
- * section can't take down the inspector card.
+ * section can't take down the inspector card. On desktop this is the
+ * card's SOLE body while its extension is active (either/or with the
+ * regular controls); the mobile sheet appends it after them instead.
  */
 function InspectorExtensionSection({
-  defaultExpanded,
+  defaultExpanded = true,
   extension,
   nodeId,
 }: {
-  defaultExpanded: boolean
+  defaultExpanded?: boolean
   extension: InspectorExtension
   nodeId: AnyNodeId
 }) {

--- a/packages/editor/src/lib/inspector-card-mode.test.ts
+++ b/packages/editor/src/lib/inspector-card-mode.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  type InspectorCardMode,
+  resolveActiveExtension,
+  toggleCard,
+  toggleExtension,
+} from './inspector-card-mode'
+
+const collapsed: InspectorCardMode = { collapsed: true, activeExtensionId: null }
+const regular: InspectorCardMode = { collapsed: false, activeExtensionId: null }
+const engineering: InspectorCardMode = { collapsed: false, activeExtensionId: 'bones:eng' }
+
+// EITHER/OR contract (replaces #667's appended-section behavior): the
+// expanded card shows the regular controls OR one extension's content,
+// never both. These gates encode every transition of the mode machine.
+
+describe('toggleCard (chevron / header press)', () => {
+  test('folded card expands to the REGULAR controls — no extension', () => {
+    expect(toggleCard(collapsed)).toEqual(regular)
+  })
+
+  test('regular expanded card folds', () => {
+    expect(toggleCard(regular)).toEqual(collapsed)
+  })
+
+  test('extension mode returns to the regular controls, staying expanded', () => {
+    // The chevron exits extension mode first; it does NOT fold from there.
+    expect(toggleCard(engineering)).toEqual(regular)
+  })
+})
+
+describe('toggleExtension (header icon press)', () => {
+  test('folded card opens straight into extension-only mode', () => {
+    expect(toggleExtension(collapsed, 'bones:eng')).toEqual(engineering)
+  })
+
+  test('regular expanded card swaps to extension-only mode', () => {
+    expect(toggleExtension(regular, 'bones:eng')).toEqual(engineering)
+  })
+
+  test('pressing the ACTIVE extension icon again returns to regular mode', () => {
+    expect(toggleExtension(engineering, 'bones:eng')).toEqual(regular)
+  })
+
+  test('pressing another extension icon switches extension modes directly', () => {
+    expect(toggleExtension(engineering, 'other:ext')).toEqual({
+      collapsed: false,
+      activeExtensionId: 'other:ext',
+    })
+  })
+})
+
+describe('resolveActiveExtension', () => {
+  const bones = { id: 'bones:eng' }
+  const other = { id: 'other:ext' }
+  const extensions = [bones, other]
+
+  test('null id → regular mode (no extension)', () => {
+    expect(resolveActiveExtension(null, extensions)).toBeNull()
+  })
+
+  test('matching id → that extension fills the body', () => {
+    expect(resolveActiveExtension('bones:eng', extensions)).toBe(bones)
+    expect(resolveActiveExtension('other:ext', extensions)).toBe(other)
+  })
+
+  test('stale id (kind changed / plugin gated off) falls back to regular', () => {
+    expect(resolveActiveExtension('bones:eng', [])).toBeNull()
+    expect(resolveActiveExtension('gone:ext', extensions)).toBeNull()
+  })
+})
+
+describe('full user flows (QA script)', () => {
+  test('chevron → regular only; fold; icon → extension only; icon again → regular', () => {
+    let mode = collapsed
+    mode = toggleCard(mode) // chevron
+    expect(mode).toEqual(regular)
+    mode = toggleCard(mode) // fold
+    expect(mode).toEqual(collapsed)
+    mode = toggleExtension(mode, 'bones:eng') // bones icon
+    expect(mode).toEqual(engineering)
+    mode = toggleExtension(mode, 'bones:eng') // bones icon again
+    expect(mode).toEqual(regular)
+  })
+
+  test('extension mode exits via the chevron too', () => {
+    let mode = toggleExtension(collapsed, 'bones:eng')
+    expect(mode).toEqual(engineering)
+    mode = toggleCard(mode) // chevron
+    expect(mode).toEqual(regular)
+  })
+})

--- a/packages/editor/src/lib/inspector-card-mode.ts
+++ b/packages/editor/src/lib/inspector-card-mode.ts
@@ -1,0 +1,60 @@
+/**
+ * Mode machine for the floating inspector card (`PanelWrapper`).
+ *
+ * The card is in exactly one of three modes — the two expanded modes are
+ * EITHER/OR, never combined:
+ *
+ * - collapsed: header only;
+ * - regular: the node kind's own controls (`children`) — no plugin
+ *   inspector-extension sections appended;
+ * - extension: ONE plugin inspector-extension's content fills the body
+ *   (its own section chrome), the regular controls are hidden.
+ *
+ * Transitions:
+ * - chevron / header press ({@link toggleCard}): collapsed → regular,
+ *   regular → collapsed, extension → regular (exit extension mode first,
+ *   stay expanded);
+ * - extension icon press ({@link toggleExtension}): enters that
+ *   extension's mode from anywhere (expanding a folded card); pressing
+ *   the ACTIVE extension's icon again returns to regular.
+ */
+
+export interface InspectorCardMode {
+  /** Card folded to its header. */
+  collapsed: boolean
+  /** Extension whose content fills the body; null = regular controls. */
+  activeExtensionId: string | null
+}
+
+/** Chevron / header press. */
+export function toggleCard(mode: InspectorCardMode): InspectorCardMode {
+  // Folded → expand to the regular controls.
+  if (mode.collapsed) return { collapsed: false, activeExtensionId: null }
+  // Extension mode → back to the regular controls (stay expanded).
+  if (mode.activeExtensionId !== null) return { collapsed: false, activeExtensionId: null }
+  // Regular expanded → fold.
+  return { collapsed: true, activeExtensionId: null }
+}
+
+/** Header extension-icon press. */
+export function toggleExtension(mode: InspectorCardMode, extensionId: string): InspectorCardMode {
+  // The active extension's icon pressed again → back to the regular controls.
+  if (!mode.collapsed && mode.activeExtensionId === extensionId) {
+    return { collapsed: false, activeExtensionId: null }
+  }
+  // Anywhere else (folded, regular, another extension) → this extension only.
+  return { collapsed: false, activeExtensionId: extensionId }
+}
+
+/**
+ * The extension whose content should fill the card body, or null for the
+ * regular controls. A stale `activeExtensionId` (selection changed kind,
+ * plugin uninstalled, registry reset) safely falls back to regular mode.
+ */
+export function resolveActiveExtension<E extends { id: string }>(
+  activeExtensionId: string | null,
+  extensions: readonly E[],
+): E | null {
+  if (activeExtensionId === null) return null
+  return extensions.find((extension) => extension.id === activeExtensionId) ?? null
+}


### PR DESCRIPTION
## Summary

UX correction to #667 after user review on localhost. The extension header icon used to uncollapse the card and **append** the extension as a `PanelSection` after the kind's own controls. The floating inspector card now has two **mutually exclusive** expanded modes:

- **Chevron (or header press)** → ONLY the kind's regular controls (today's Pascal wall menu) — no extension sections appended. Pressing again folds the card, as before.
- **Extension icon (e.g. Bones)** → ONLY that extension's content fills the card body (its own section title/chrome), regular controls hidden. The icon shows an active (cyan) state while its mode is on; pressing it again — or the chevron — returns to the regular controls without folding.

## Implementation

- The transition table is a pure module, `packages/editor/src/lib/inspector-card-mode.ts` (`toggleCard`, `toggleExtension`, `resolveActiveExtension`), used by `PanelWrapper`. A stale active-extension id (selection kind changed, plugin gated off) safely falls back to regular mode.
- Header extension icons now render on the expanded card too (needed for the active-state toggle); folded-card behavior jumps straight into extension mode as before.
- Preserved: collapse semantics + the shared `desktopInspectorCollapsed` reset machinery, header drag, `installedPlugins` + `registryVersion` gating, lazy/Suspense/ErrorBoundary section loading.
- Mobile sheet has no header icons, so it keeps #667's appended sections.
- Core `InspectorExtension` JSDoc updated to the either/or contract (doc-only core change).

## Tests

- New `inspector-card-mode.test.ts`: 12 mode-toggle tests encoding the either/or contract, including the full QA flows (chevron → regular only; icon → extension only; icon again / chevron → back to regular) and the stale-id fallback.
- `bun test`: editor 616 pass / 0 fail, core 1013 pass / 0 fail; root `check-types` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only inspector UI and a small pure state module with tests; no auth, data, or scene mutation changes.
> 
> **Overview**
> **UX fix** after #667: the floating inspector no longer **appends** plugin extension sections under the kind’s controls on desktop. Expanded state is **either** regular kind controls **or** a single extension’s body—never both.
> 
> **Desktop `PanelWrapper`:** A pure `inspector-card-mode` module (`toggleCard`, `toggleExtension`, `resolveActiveExtension`) drives transitions. Chevron/header expands to regular only; extension header icons show on the expanded card with cyan active state; tapping the active icon or chevron exits extension mode without folding. Stale extension ids fall back to regular when the kind or plugin gate changes. Collapsing still clears extension mode.
> 
> **Mobile** keeps appended extension sections (no header mode swap). **`InspectorExtension` JSDoc** in core documents the either/or contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db998adeeb0aaf34fd1dd6fdb90bf2f4b1b0e49d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->