### PR TITLE
chore: bump plugin-bones — exploded strata, wall Engineering card, mixed CMU/framed walls

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#eace4e80d7bb1d04ac7d9b082395d392387dbb21",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#aa7c7b23f4db1cf2e492843f94dbf9447306baca",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#eace4e80d7bb1d04ac7d9b082395d392387dbb21",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#aa7c7b23f4db1cf2e492843f94dbf9447306baca",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#eace4e8", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-eace4e8"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#aa7c7b2", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-aa7c7b2"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Bumps `@pascal-app/plugin-bones` → aa7c7b2.

- Exploded view reads floor / attic carpentry / roof shell as three strata regardless of which storey hosts the X-ray (render-only mount tag; blueprint elevations unaffected)
- Wall card: bones icon opens a pure Engineering view (either/or with the regular menu — pairs with #667/#668), Framed/CMU/Skip + block-height slider
- Mixed CMU/framed walls: course-snapped seam, PT sill anchor-bolted per R403.1.6, zoned openings with seam flags, corner butt joints with width-aware acute retreats (SAT-gated incl. 45° thin-neighbor cases)

Six adversarial verify rounds across the batch; 721 plugin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only changes a GitHub dependency pin and lockfile; risk is limited to whatever behavioral changes ship in the external bones plugin at the new commit.
> 
> **Overview**
> Pins **`@pascal-app/plugin-bones`** in the editor app from `eace4e8` to **`aa7c7b2`**, with matching updates in **`bun.lock`**. There are no other monorepo code changes—the editor still loads the plugin via `bootstrap.ts` as before.
> 
> The new plugin revision is expected to deliver **exploded-view** behavior that always separates floor, attic carpentry, and roof shell into three strata (render-only; blueprint elevations unchanged), a **wall Engineering** card (bones icon, Framed/CMU/Skip and block-height controls, mutually exclusive with the regular menu), and **mixed CMU/framed walls** (course-snapped seam, PT sill/anchor-bolt detail, zoned openings, corner butt joints with width-aware retreats).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f9d798b16628c832db999aaff2253b0be6116b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->