### PR TITLE
chore: bump plugin-bones to dc1daf3 — cladding both-modes fix + night-3 verify round

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#dc1daf3a0cf912e23c119c5741e3552ed5bc4d65",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#f308cf36042371fb03e8aef154ab4a1578d3f3a6",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#aa7c7b23f4db1cf2e492843f94dbf9447306baca",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#dc1daf3a0cf912e23c119c5741e3552ed5bc4d65",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#dc1daf3a0cf912e23c119c5741e3552ed5bc4d65",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#f308cf36042371fb03e8aef154ab4a1578d3f3a6",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#dc1daf3", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-dc1daf3"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#f308cf3", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-f308cf3"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#aa7c7b23f4db1cf2e492843f94dbf9447306baca",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#dc1daf3a0cf912e23c119c5741e3552ed5bc4d65",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#aa7c7b2", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-aa7c7b2"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#dc1daf3", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-dc1daf3"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Pin bump only. Plugin changes since aa7c7b2 (see plugin repo master):

- **Cladding choice reads in both render modes** — the Engineering panel's exterior finish now changes (a) X-ray member colors per family (brick veneer + EIFS previously emitted NO members at all — their layer roles were unmapped), and (b) the solid-mode host wall skin by writing `slots.exterior` (library textures for stucco/brick/EIFS, minted flat scene materials for vinyl/fiber-cement/wood), covering colinear duplicate twins.
- **Batt/layer interpenetration fix** — batts cap at the cavity the layer stacks leave (thickness − 1"), flagged when genuinely compressed; INTL jurisdictions now label batts with the same assumed-zone-4 R the panel hint prints.
- **Colinear dedupe merges duplicate openings** — studs no longer run through doorways carried only by the dropped twin.
- **Stud misfit warning** — explicit 2x6 on a too-thin wall warns on both Engineering surfaces (geometry stays honest).
- Plugin dev-dep types bumped to `@pascal-app/*@0.9.2` for the slots/scene-material API.

779 plugin tests + tsc green. Adversarial verify loop (skeptic + visual) re-running at this sha on localhost before the community bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> No local code changes, but the new plugin revision alters structural wall geometry, cladding, and warnings in the 3D editor—worth regression testing on Engineering panel flows.
> 
> **Overview**
> Pins **`@pascal-app/plugin-bones`** in the editor app from `aa7c7b2` to **`f308cf3`**, with the matching **`bun.lock`** resolution entry updated. There are **no in-repo source changes**—behavior updates come entirely from the new plugin revision.
> 
> That plugin release (per release notes) improves **exterior cladding** in X-ray and solid modes (including brick veneer/EIFS layer mapping and `slots.exterior` skins), fixes **batt/layer interpenetration** and **colinear wall dedupe** around openings, adds **stud misfit warnings**, and aligns plugin types with **`@pascal-app/*@0.9.2`** APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 370be3cbaa3f7b21781ecd89365fbd9b10c76acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->