### PR TITLE
feat(viewer): make the render-loop frame cap configurable via `maxFps`

### DIFF
--- a/packages/viewer/src/components/viewer/frame-limiter.test.ts
+++ b/packages/viewer/src/components/viewer/frame-limiter.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+import { createFrameClock } from './frame-limiter'
+
+describe('createFrameClock', () => {
+  test('uses the first rAF sample only as a wall-time baseline', () => {
+    const clock = createFrameClock(12)
+
+    expect(clock.sample(60_000, 20)).toBeNull()
+    expect(clock.sample(60_020, 20)).toBeCloseTo(12.02)
+  })
+
+  test('preserves the synthetic time across limiter restarts', () => {
+    const firstLimiter = createFrameClock(0)
+    firstLimiter.sample(1_000, 20)
+    const priorTime = firstLimiter.sample(2_000, 20)
+    if (priorTime === null) throw new Error('frame expected')
+
+    const restartedLimiter = createFrameClock(priorTime)
+    expect(restartedLimiter.sample(75_000, 1000 / 30)).toBeNull()
+    expect(restartedLimiter.sample(75_034, 1000 / 30)).toBeCloseTo(priorTime + 1 / 30)
+  })
+
+  test('carries sub-frame remainder into the next sample', () => {
+    const clock = createFrameClock()
+    clock.sample(100, 20)
+
+    expect(clock.sample(145, 20)).toBeCloseTo(0.04)
+    expect(clock.sample(160, 20)).toBeCloseTo(0.06)
+  })
+
+  test('supports monotonic timer and resume kicks', () => {
+    const clock = createFrameClock(2)
+
+    expect(clock.step(0.02)).toBeCloseTo(2.02)
+    expect(clock.step(0.001)).toBeCloseTo(2.021)
+  })
+})

--- a/packages/viewer/src/components/viewer/frame-limiter.tsx
+++ b/packages/viewer/src/components/viewer/frame-limiter.tsx
@@ -6,6 +6,42 @@ type FrameLimiterProps = {
   fps?: number
 }
 
+export type FrameClock = {
+  sample: (wallTimeMs: number, intervalMs: number) => number | null
+  step: (seconds: number) => number
+}
+
+/**
+ * Keeps R3F's manual clock monotonic while each limiter effect owns a fresh
+ * wall-time baseline. The first rAF sample establishes that baseline instead
+ * of treating the browser's process uptime as elapsed frame time.
+ */
+export function createFrameClock(initialTime = 0): FrameClock {
+  let frameTime = initialTime
+  let previousWallTime: number | null = null
+
+  return {
+    sample(wallTimeMs, intervalMs) {
+      if (previousWallTime === null) {
+        previousWallTime = wallTimeMs
+        return null
+      }
+
+      const elapsedMs = wallTimeMs - previousWallTime
+      if (elapsedMs < intervalMs) return null
+
+      const remainderMs = elapsedMs % intervalMs
+      frameTime += (elapsedMs - remainderMs) / 1000
+      previousWallTime = wallTimeMs - remainderMs
+      return frameTime
+    },
+    step(seconds) {
+      frameTime += seconds
+      return frameTime
+    },
+  }
+}
+
 // `?disable=draw` (see post-processing.tsx): the page renders no real frames,
 // and Chromium's no-damage scheduler then throttles requestAnimationFrame to
 // 1Hz on Linux (measured in the headless bake worker — every useFrame system
@@ -31,13 +67,12 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
 
   useLayoutEffect(() => {
     if (renderPaused) return
-    let elapsed = 0
-    let then = 0
-    let i = nextFrameTimeRef.current
+    const clock = createFrameClock(nextFrameTimeRef.current)
     let raf: number | null = null
     let timer: ReturnType<typeof setInterval> | null = null
     let sizeSynced = false
-    const interval = 1000 / fps
+    const effectiveFps = Number.isFinite(fps) && fps > 0 ? fps : 50
+    const interval = 1000 / effectiveFps
     function syncSize() {
       if (sizeSynced) return
       renderer.setPixelRatio(dpr)
@@ -47,19 +82,16 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     function tick(t: DOMHighResTimeStamp) {
       raf = requestAnimationFrame(tick)
       syncSize()
-      elapsed = t - then
-      if (elapsed > interval) {
-        advance(i)
-        i += elapsed / 1000 - (elapsed % interval) / 1000
-        nextFrameTimeRef.current = i
-        then = t - (elapsed % interval)
-      }
+      const frameTime = clock.sample(t, interval)
+      if (frameTime === null) return
+      nextFrameTimeRef.current = frameTime
+      advance(frameTime)
     }
     function kick() {
       syncSize()
-      i += 1 / 1000
-      nextFrameTimeRef.current = i
-      advance(i)
+      const frameTime = clock.step(1 / 1000)
+      nextFrameTimeRef.current = frameTime
+      advance(frameTime)
     }
     function onVisibilityChange() {
       if (document.visibilityState === 'visible') kick()
@@ -68,9 +100,9 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     set({ frameloop: 'never' })
     if (DRAW_DISABLED) {
       timer = setInterval(() => {
-        i += interval / 1000
-        nextFrameTimeRef.current = i
-        advance(i)
+        const frameTime = clock.step(interval / 1000)
+        nextFrameTimeRef.current = frameTime
+        advance(frameTime)
       }, interval)
     } else {
       // Kick off custom render loop

--- a/packages/viewer/src/components/viewer/frame-limiter.tsx
+++ b/packages/viewer/src/components/viewer/frame-limiter.tsx
@@ -1,5 +1,5 @@
 import { useThree } from '@react-three/fiber'
-import { useLayoutEffect } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import useViewer from '../../store/use-viewer'
 
 type FrameLimiterProps = {
@@ -22,6 +22,7 @@ const DRAW_DISABLED =
 
 const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
   const { advance, set, frameloop: initFrameloop } = useThree()
+  const nextFrameTimeRef = useRef(0)
   const renderer = useThree((state) => state.gl)
   const size = useThree((state) => state.size)
   const dpr = useThree((state) => state.viewport.dpr)
@@ -32,7 +33,7 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     if (renderPaused) return
     let elapsed = 0
     let then = 0
-    let i = 0
+    let i = nextFrameTimeRef.current
     let raf: number | null = null
     let timer: ReturnType<typeof setInterval> | null = null
     let sizeSynced = false
@@ -50,12 +51,14 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
       if (elapsed > interval) {
         advance(i)
         i += elapsed / 1000 - (elapsed % interval) / 1000
+        nextFrameTimeRef.current = i
         then = t - (elapsed % interval)
       }
     }
     function kick() {
       syncSize()
       i += 1 / 1000
+      nextFrameTimeRef.current = i
       advance(i)
     }
     function onVisibilityChange() {
@@ -66,6 +69,7 @@ const FrameLimiter: React.FC<FrameLimiterProps> = ({ fps = 50 }) => {
     if (DRAW_DISABLED) {
       timer = setInterval(() => {
         i += interval / 1000
+        nextFrameTimeRef.current = i
         advance(i)
       }, interval)
     } else {

--- a/packages/viewer/src/components/viewer/index.tsx
+++ b/packages/viewer/src/components/viewer/index.tsx
@@ -355,6 +355,19 @@ interface ViewerProps {
    */
   sceneReadyMaxWaitMs?: number
   /**
+   * Frame cap for the render loop, in frames per second. Defaults to 50, the
+   * value the viewer has always used.
+   *
+   * The viewer runs `frameloop="never"` and advances frames itself through
+   * `<FrameLimiter>`, so this cap is the only thing setting the cadence and a
+   * host cannot raise it from the outside. Hosts that animate the scene on
+   * their own clock — a timeline scrubbing node transforms, a walkthrough
+   * camera — are pinned to it and cannot reach display refresh, which reads as
+   * judder against a 60Hz+ monitor. Raise it for those; lower it to spare the
+   * GPU on a passive or background canvas.
+   */
+  maxFps?: number
+  /**
    * Skip the TSL post-processing pipeline (SSGI/denoise/ink/outline) and render
    * the scene directly. For headless/capture surfaces (the bake page) where
    * frame quality is irrelevant: on a software-rasterised worker the pipeline
@@ -389,6 +402,7 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
     sceneReadyKey,
     onSceneReadyChange,
     sceneReadyMaxWaitMs,
+    maxFps = 50,
     disablePostFx = false,
   },
   ref,
@@ -555,7 +569,7 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
         enabled: shadowsEnabled,
       }}
     >
-      <FrameLimiter fps={50} />
+      <FrameLimiter fps={maxFps} />
       <ViewerCamera />
       <GPUDeviceWatcher />
       <ToneMappingExposure />


### PR DESCRIPTION
## What does this PR do?

Adds an optional `maxFps` prop to `<Viewer>` and threads it to the existing `<FrameLimiter>`. The default remains 50, preserving current behavior.

Maintainer follow-up (August 17, 2026): the limiter now preserves its synthetic frame timestamp across runtime `maxFps` changes while each effect restart establishes a fresh browser wall-time baseline. Runtime FPS changes, resize, DPR changes, and pause/resume therefore avoid both negative deltas and process-uptime-sized positive jumps.

## How to test

1. Run `bun run check`.
2. Run `bun run check-types`.
3. Run `bun run --cwd packages/viewer test`; expect 105 passing tests.
4. In a host, change `maxFps` while animation is running (for example 20 → 60 → 30) and verify motion remains continuous with no negative clock delta or jump.
5. Omit `maxFps` and verify the existing 50 FPS default remains in effect.

## Screenshots / screen recording

N/A — frame-pacing API and clock-continuity change; no UI change.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core render loop and R3F `advance` timing; behavior is well covered by new unit tests but any pacing bug would affect all viewer animation.
> 
> **Overview**
> Adds optional **`maxFps`** on `<Viewer>` (default **50**) and wires it to `<FrameLimiter>` so hosts can raise cadence for timeline/walkthrough animation or lower it for passive canvases.
> 
> Refactors frame pacing around exported **`createFrameClock`**: the first rAF timestamp is only a wall-time baseline, sub-frame remainder is kept, and **`nextFrameTimeRef`** seeds a new clock when the limiter effect restarts (e.g. **`maxFps`** changes) so R3F’s manual clock stays continuous instead of jumping or going negative. Timer/`kick` paths use the same clock via **`step`**. Invalid **`fps`** falls back to 50.
> 
> Unit tests cover baseline sampling, restart continuity, remainder carry, and **`step`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996f7fd0964ce3b78a661f6fded9e6e2063297d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->