### PR TITLE
feat(editor): add synchronized 2D viewer modes

### DIFF
--- a/apps/editor/components/scene-loader.tsx
+++ b/apps/editor/components/scene-loader.tsx
@@ -225,7 +225,7 @@ export function SceneLoader({ initialScene, meta }: SceneLoaderProps) {
           <p className="font-medium text-destructive text-xs">{saveError}</p>
         </div>
       )}
-      <div className="pointer-events-none absolute top-4 right-4 z-40 flex items-center gap-2">
+      <div className="pointer-events-none absolute top-4 right-4 z-40 flex flex-col items-end gap-1 md:top-14 md:flex-row md:items-center md:gap-2">
         <button
           aria-pressed={lightPreview}
           className={cn(

--- a/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
+++ b/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.tsx
@@ -67,6 +67,10 @@ import {
   resolveFloorplanAnnotationVisibility,
   resolveFloorplanWallDimensionReference,
 } from '../../../lib/floorplan/floorplan-mode'
+import {
+  buildFloorplanContext,
+  floorplanLayerRank,
+} from '../../../lib/floorplan/floorplan-readonly'
 import { clientToPlan } from '../../../lib/floorplan/plan-coords'
 import {
   type ActiveInteractionScope,
@@ -3158,73 +3162,7 @@ function isFloorplanHierarchyVisible(
   return true
 }
 
-export function buildContext(
-  node: AnyNode,
-  nodes: Record<string, AnyNode>,
-  viewState: {
-    automaticDimensions?: boolean
-    selected: boolean
-    unit: 'metric' | 'imperial'
-    metricNotation?: 'meters' | 'millimeters'
-    purpose?: 'edit' | 'document'
-    wallDimensionReference?: FloorplanWallDimensionReference
-    highlighted: boolean
-    hovered: boolean
-    moving: boolean
-    palette: FloorplanPalette | undefined
-  },
-  levelData?: unknown,
-): GeometryContext {
-  const resolve = <N = AnyNode>(id: AnyNodeId): N | undefined => nodes[id] as N | undefined
-
-  const childIds = (node as unknown as { children?: AnyNodeId[] }).children
-  const children: AnyNode[] = Array.isArray(childIds)
-    ? childIds.map((cid) => nodes[cid]).filter((n): n is AnyNode => n !== undefined)
-    : []
-
-  const parentId = node.parentId as AnyNodeId | null
-  const parent: AnyNode | null = parentId ? (nodes[parentId] ?? null) : null
-
-  let siblings: AnyNode[] = []
-  if (parent) {
-    const parentChildIds = (parent as unknown as { children?: AnyNodeId[] }).children
-    if (Array.isArray(parentChildIds)) {
-      for (const sid of parentChildIds) {
-        if (sid === node.id) continue
-        const s = nodes[sid]
-        if (s && s.type === node.type) siblings.push(s)
-      }
-    } else {
-      siblings = Object.values(nodes).filter(
-        (n) => n !== node && n.type === node.type && n.parentId === parentId,
-      )
-    }
-  }
-
-  return {
-    resolve,
-    children,
-    siblings,
-    parent,
-    levelData,
-    extensions: createFloorplanContextExtensions({
-      automaticDimensions: viewState.automaticDimensions,
-      metricNotation: viewState.metricNotation ?? 'meters',
-      purpose: viewState.purpose ?? 'edit',
-      wallDimensionReference: viewState.wallDimensionReference,
-    }),
-    viewState: viewState.palette
-      ? {
-          selected: viewState.selected,
-          unit: viewState.unit,
-          highlighted: viewState.highlighted,
-          hovered: viewState.hovered,
-          moving: viewState.moving,
-          palette: viewState.palette,
-        }
-      : undefined,
-  }
-}
+export const buildContext = buildFloorplanContext
 
 export function collectFloorplanLinkedLevelNodes(
   nodes: Record<string, AnyNode>,
@@ -3526,17 +3464,7 @@ function depsValueEqual(a: unknown, b: unknown): boolean {
  * Sort is stable in modern JS engines, so siblings within the same
  * bucket keep their DFS order (= scene tree order).
  */
-export function floorplanLayerRank(type: string): number {
-  switch (type) {
-    case 'zone':
-      return 0
-    case 'slab':
-    case 'ceiling':
-      return 1
-    default:
-      return 2
-  }
-}
+export { floorplanLayerRank }
 
 function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true

--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -194,7 +194,7 @@ import {
 } from '../tools/wall/wall-drafting'
 
 import { PALETTE_COLORS } from '../ui/primitives/color-dot'
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/primitives/tooltip'
+import { FloorplanCompassButton } from '../viewer/floorplan-compass-button'
 import { resolveFloorplanBackgroundSelection } from './floorplan-background-selection'
 import {
   subscribeFloorplanCameraNavigation,
@@ -504,50 +504,6 @@ type GuideHandleHintAnchor = {
   y: number
   directionX: number
   directionY: number
-}
-
-function FloorplanCompassButton({
-  northRotationDeg,
-  onAlignNorth,
-  needleRef,
-}: {
-  northRotationDeg: number
-  onAlignNorth: () => void
-  needleRef?: React.RefObject<SVGSVGElement | null>
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          aria-label="Align view to north"
-          className="group absolute bottom-3 left-3 z-30 flex h-8 w-8 items-center justify-center rounded-full border border-black/10 bg-white/85 shadow-sm backdrop-blur-md transition hover:bg-white hover:shadow-md dark:border-white/10 dark:bg-neutral-900/85 dark:hover:bg-neutral-900"
-          onClick={(event) => {
-            event.preventDefault()
-            event.stopPropagation()
-            onAlignNorth()
-          }}
-          onPointerDown={(event) => {
-            event.stopPropagation()
-          }}
-          type="button"
-        >
-          <span className="relative flex h-6 w-6 items-center justify-center rounded-full bg-[#b8b8b8] shadow-inner dark:bg-neutral-700">
-            <svg
-              aria-hidden="true"
-              className="h-6 w-6"
-              ref={needleRef}
-              style={{ transform: `rotate(${northRotationDeg}deg)` }}
-              viewBox="0 0 48 48"
-            >
-              <path d="M24 4.5 31.5 25 24 21.5 16.5 25Z" fill="#f15b5b" />
-              <path d="M24 43.5 16.5 23 24 26.5 31.5 23Z" fill="#ffffff" />
-            </svg>
-          </span>
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="right">Align view to north</TooltipContent>
-    </Tooltip>
-  )
 }
 
 type GuideInteractionState = {

--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -59,6 +59,8 @@ import { SettingsPanel, type SettingsPanelProps } from '../ui/sidebar/panels/set
 import { SitePanel, type SitePanelProps } from '../ui/sidebar/panels/site-panel'
 import type { SidebarTab } from '../ui/sidebar/tab-bar'
 import { useHostPanels } from '../ui/sidebar/use-plugin-panels'
+import { ViewerStage } from '../viewer/viewer-stage'
+import type { ViewerStageMode } from '../viewer/viewer-stage-modes'
 import { CustomCameraControls } from './custom-camera-controls'
 import { DeleteConfirmationDialog } from './delete-confirmation-dialog'
 import { EditorLayoutV2 } from './editor-layout-v2'
@@ -86,6 +88,8 @@ import { WallMoveSideHandles } from './wall-move-side-handles'
 import { WallOpeningHighlights } from './wall-opening-highlights'
 
 const CAMERA_CONTROLS_HINT_DISMISSED_STORAGE_KEY = 'editor-camera-controls-hint-dismissed:v1'
+const PREVIEW_STAGE_SWITCHER_POSITION =
+  'top-28 right-4 left-auto translate-x-0 md:top-4 md:right-auto md:left-1/2 md:-translate-x-1/2'
 const DELETE_CURSOR_BADGE_COLOR = '#ef4444'
 const DELETE_CURSOR_BADGE_OFFSET_X = 14
 const DELETE_CURSOR_BADGE_OFFSET_Y = 14
@@ -1119,6 +1123,60 @@ const ViewerCanvas = memo(function ViewerCanvas({
   )
 })
 
+function PreviewStage({
+  isFirstPersonMode,
+  mode,
+  onModeChange,
+  showLoader,
+  viewerContent,
+}: {
+  isFirstPersonMode: boolean
+  mode: ViewerStageMode
+  onModeChange: (mode: ViewerStageMode) => void
+  showLoader: boolean
+  viewerContent: ReactNode
+}) {
+  const hasFloorplan = useScene((state) =>
+    Object.values(state.nodes).some((node) => node.type === 'level'),
+  )
+
+  const handleModeChange = useCallback(
+    (nextMode: ViewerStageMode) => {
+      if (nextMode !== '3d') useEditor.getState().setFirstPersonMode(false)
+      onModeChange(nextMode)
+    },
+    [onModeChange],
+  )
+
+  const stageMode = isFirstPersonMode || !hasFloorplan ? '3d' : mode
+  const stageModes = hasFloorplan && !isFirstPersonMode ? undefined : (['3d'] as const)
+
+  return (
+    <div className="dark relative h-full w-full overflow-hidden bg-neutral-100 text-foreground">
+      {isFirstPersonMode ? (
+        <FirstPersonOverlay onExit={() => useEditor.getState().setFirstPersonMode(false)} />
+      ) : (
+        <ViewerOverlay
+          hideBottomBar={stageMode !== '3d'}
+          onBack={() => useEditor.getState().setPreviewMode(false)}
+        />
+      )}
+
+      <ViewerStage
+        className="absolute inset-0"
+        mode={stageMode}
+        modes={stageModes}
+        onModeChange={handleModeChange}
+        showCompass={hasFloorplan && !isFirstPersonMode}
+        showSwitcher={hasFloorplan && !isFirstPersonMode}
+        switcherClassName={`${PREVIEW_STAGE_SWITCHER_POSITION} ${showLoader ? 'z-[70]' : ''}`}
+      >
+        {viewerContent}
+      </ViewerStage>
+    </div>
+  )
+}
+
 export default function Editor({
   layoutVersion = 'v1',
   appMenuButton,
@@ -1166,6 +1224,7 @@ export default function Editor({
   const [hasLoadedInitialScene, setHasLoadedInitialScene] = useState(false)
   const [sceneReadyKey, setSceneReadyKey] = useState(0)
   const [isViewerSceneReady, setIsViewerSceneReady] = useState(false)
+  const [previewStageMode, setPreviewStageMode] = useState<ViewerStageMode>('3d')
   const isPreviewMode = useEditor((s) => s.isPreviewMode)
   const isCaptureMode = useEditor((s) => s.isCaptureMode)
 
@@ -1262,6 +1321,10 @@ export default function Editor({
   }, [isVersionPreviewMode])
 
   useEffect(() => {
+    if (!isPreviewMode) setPreviewStageMode('3d')
+  }, [isPreviewMode])
+
+  useEffect(() => {
     document.body.classList.add('dark')
     return () => {
       document.body.classList.remove('dark')
@@ -1286,10 +1349,19 @@ export default function Editor({
   }, [hasLoadedInitialScene, isLoading, isSceneLoading, isViewerSceneReady, sceneReadyKey])
 
   const showLoader = isLoading || isSceneLoading || !hasLoadedInitialScene || !isViewerSceneReady
+  const visibleLoader =
+    showLoader &&
+    !(
+      isPreviewMode &&
+      previewStageMode === '2d' &&
+      !isLoading &&
+      !isSceneLoading &&
+      hasLoadedInitialScene
+    )
 
   useEffect(() => {
-    onLoaderChange?.(showLoader)
-  }, [showLoader, onLoaderChange])
+    onLoaderChange?.(visibleLoader)
+  }, [visibleLoader, onLoaderChange])
 
   const firstPersonPreviousLevelRef = useRef(useViewer.getState().selection.levelId)
   const wasFirstPersonModeRef = useRef(isFirstPersonMode)
@@ -1415,23 +1487,20 @@ export default function Editor({
     return (
       <>
         <FloorplanModeCoordinator />
-        {showLoader && (
+        {visibleLoader && (
           <div className="fixed inset-0 z-60">
             <SceneLoader className="bg-background" />
           </div>
         )}
 
         {!isLoading && isPreviewMode ? (
-          <div className="dark flex h-full w-full flex-col bg-neutral-100 text-foreground">
-            {isFirstPersonMode ? (
-              <FirstPersonOverlay onExit={() => useEditor.getState().setFirstPersonMode(false)} />
-            ) : (
-              <ViewerOverlay onBack={() => useEditor.getState().setPreviewMode(false)} />
-            )}
-            <div className="h-full w-full" data-pascal-viewer-3d>
-              {previewViewerContent}
-            </div>
-          </div>
+          <PreviewStage
+            isFirstPersonMode={isFirstPersonMode}
+            mode={previewStageMode}
+            onModeChange={setPreviewStageMode}
+            showLoader={visibleLoader}
+            viewerContent={previewViewerContent}
+          />
         ) : (
           <>
             <EditorLayoutV2
@@ -1491,23 +1560,20 @@ export default function Editor({
   return (
     <div className="dark flex h-full w-full gap-3 bg-neutral-100 p-3 text-foreground">
       <FloorplanModeCoordinator />
-      {showLoader && (
+      {visibleLoader && (
         <div className="fixed inset-0 z-60">
           <SceneLoader className="bg-background" />
         </div>
       )}
 
       {!isLoading && isPreviewMode ? (
-        <>
-          {isFirstPersonMode ? (
-            <FirstPersonOverlay onExit={() => useEditor.getState().setFirstPersonMode(false)} />
-          ) : (
-            <ViewerOverlay onBack={() => useEditor.getState().setPreviewMode(false)} />
-          )}
-          <div className="h-full w-full" data-pascal-viewer-3d>
-            {previewViewerContent}
-          </div>
-        </>
+        <PreviewStage
+          isFirstPersonMode={isFirstPersonMode}
+          mode={previewStageMode}
+          onModeChange={setPreviewStageMode}
+          showLoader={visibleLoader}
+          viewerContent={previewViewerContent}
+        />
       ) : (
         <>
           {/* Sidebar */}

--- a/packages/editor/src/components/viewer-overlay.tsx
+++ b/packages/editor/src/components/viewer-overlay.tsx
@@ -39,6 +39,7 @@ interface ViewerOverlayProps {
   owner?: ProjectOwner | null
   canShowScans?: boolean
   canShowGuides?: boolean
+  hideBottomBar?: boolean
   onBack?: () => void
 }
 
@@ -47,17 +48,20 @@ export const ViewerOverlay = ({
   owner,
   canShowScans = true,
   canShowGuides = true,
+  hideBottomBar = false,
   onBack,
 }: ViewerOverlayProps) => (
   <>
     <ViewerSceneHeader onBack={onBack} owner={owner} projectName={projectName} />
-    <ViewerControlsBar
-      canShowGuides={canShowGuides}
-      canShowScans={canShowScans}
-      onWalkthroughToggle={() => {
-        flushSync(() => useEditor.getState().setFirstPersonMode(true))
-        requestWalkthroughPointerLock()
-      }}
-    />
+    {!hideBottomBar ? (
+      <ViewerControlsBar
+        canShowGuides={canShowGuides}
+        canShowScans={canShowScans}
+        onWalkthroughToggle={() => {
+          flushSync(() => useEditor.getState().setFirstPersonMode(true))
+          requestWalkthroughPointerLock()
+        }}
+      />
+    ) : null}
   </>
 )

--- a/packages/editor/src/components/viewer/floorplan-compass-button.tsx
+++ b/packages/editor/src/components/viewer/floorplan-compass-button.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import type React from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/primitives/tooltip'
+
+export type FloorplanCompassButtonProps = {
+  northRotationDeg: number
+  onAlignNorth: () => void
+  needleRef?: React.RefObject<SVGSVGElement | null>
+}
+
+export function FloorplanCompassButton({
+  northRotationDeg,
+  onAlignNorth,
+  needleRef,
+}: FloorplanCompassButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          aria-label="Align view to north"
+          className="group pointer-events-auto absolute bottom-3 left-3 z-30 flex h-8 w-8 items-center justify-center rounded-full border border-black/10 bg-white/85 shadow-sm backdrop-blur-md transition hover:bg-white hover:shadow-md dark:border-white/10 dark:bg-neutral-900/85 dark:hover:bg-neutral-900"
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onAlignNorth()
+          }}
+          onPointerDown={(event) => {
+            event.stopPropagation()
+          }}
+          type="button"
+        >
+          <span className="relative flex h-6 w-6 items-center justify-center rounded-full bg-[#b8b8b8] shadow-inner dark:bg-neutral-700">
+            <svg
+              aria-hidden="true"
+              className="h-6 w-6"
+              ref={needleRef}
+              style={{ transform: `rotate(${northRotationDeg}deg)` }}
+              viewBox="0 0 48 48"
+            >
+              <path d="M24 4.5 31.5 25 24 21.5 16.5 25Z" fill="#f15b5b" />
+              <path d="M24 43.5 16.5 23 24 26.5 31.5 23Z" fill="#ffffff" />
+            </svg>
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">Align view to north</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/editor/src/components/viewer/floorplan-preview-geometry.test.ts
+++ b/packages/editor/src/components/viewer/floorplan-preview-geometry.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test'
+import type { FloorplanGeometry } from '@pascal-app/core'
+import {
+  clientToFloorplanPoint,
+  getFloorplanBounds,
+  padFloorplanBounds,
+  panFloorplanViewBox,
+  scaleFloorplanViewBox,
+  scaleFloorplanViewBoxBetweenClients,
+} from './floorplan-preview-geometry'
+
+describe('floorplan preview bounds', () => {
+  test('composes nested translation and rotation', () => {
+    const geometry: FloorplanGeometry = {
+      kind: 'group',
+      transform: { translate: [10, 5], rotate: Math.PI / 2 },
+      children: [
+        {
+          kind: 'rect',
+          x: 0,
+          y: 0,
+          width: 4,
+          height: 2,
+        },
+      ],
+    }
+
+    expect(getFloorplanBounds([geometry])).toEqual({
+      minX: 8,
+      minY: 5,
+      maxX: 10,
+      maxY: 9,
+    })
+  })
+
+  test('includes image rotation and dimension baselines', () => {
+    const geometries: FloorplanGeometry[] = [
+      {
+        kind: 'image',
+        url: '/symbol.png',
+        center: [2, 3],
+        width: 4,
+        height: 2,
+        rotation: Math.PI / 2,
+      },
+      {
+        kind: 'dimension',
+        start: [-3, -2],
+        end: [3, -2],
+        dimensionStart: [-4, -1],
+        dimensionEnd: [4, -1],
+        offsetNormal: [0, -1],
+        offsetDistance: 1,
+        extensionOvershoot: 0.2,
+        text: '8 m',
+      },
+    ]
+
+    expect(getFloorplanBounds(geometries)).toEqual({
+      minX: -4,
+      minY: -2,
+      maxX: 4,
+      maxY: 5,
+    })
+  })
+
+  test('pads narrow plans by a usable minimum', () => {
+    expect(padFloorplanBounds({ minX: 0, minY: 0, maxX: 0, maxY: 0 })).toEqual({
+      minX: -0.75,
+      minY: -0.75,
+      maxX: 0.75,
+      maxY: 0.75,
+    })
+  })
+
+  test('maps clients through letterboxed SVG content', () => {
+    const viewBox = { x: 0, y: 0, width: 10, height: 10 }
+    const viewport = { left: 0, top: 0, width: 1000, height: 500 }
+
+    expect(clientToFloorplanPoint(viewBox, viewport, 250, 0)).toEqual([0, 0])
+    expect(clientToFloorplanPoint(viewBox, viewport, 750, 500)).toEqual([10, 10])
+    expect(panFloorplanViewBox(viewBox, viewport, [500, 250], [550, 250])).toEqual({
+      x: -1,
+      y: 0,
+      width: 10,
+      height: 10,
+    })
+  })
+
+  test('keeps the plan point beneath a moving pinch midpoint', () => {
+    const viewBox = { x: 0, y: 0, width: 10, height: 10 }
+    const viewport = { left: 0, top: 0, width: 1000, height: 500 }
+    const next = scaleFloorplanViewBoxBetweenClients(viewBox, 0.5, viewport, [500, 250], [600, 250])
+
+    expect(next).toEqual({ x: 1.5, y: 2.5, width: 5, height: 5 })
+    expect(clientToFloorplanPoint(next, viewport, 600, 250)).toEqual([5, 5])
+  })
+
+  test('clamps zoom without changing the view box aspect ratio', () => {
+    expect(scaleFloorplanViewBox({ x: 0, y: 0, width: 100, height: 1 }, 0.01)).toEqual({
+      x: 37.5,
+      y: 0.375,
+      width: 25,
+      height: 0.25,
+    })
+  })
+})

--- a/packages/editor/src/components/viewer/floorplan-preview-geometry.ts
+++ b/packages/editor/src/components/viewer/floorplan-preview-geometry.ts
@@ -1,0 +1,281 @@
+import type { FloorplanGeometry, FloorplanPoint } from '@pascal-app/core'
+
+export type FloorplanBounds = {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+export type FloorplanViewBox = { x: number; y: number; width: number; height: number }
+
+export type FloorplanViewport = {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+type PlanTransform = { tx: number; ty: number; rotation: number }
+
+const IDENTITY: PlanTransform = { tx: 0, ty: 0, rotation: 0 }
+const MIN_VIEWBOX_SIZE = 0.25
+const MAX_VIEWBOX_SIZE = 500
+
+function clientToViewBoxFraction(
+  viewBox: FloorplanViewBox,
+  viewport: FloorplanViewport,
+  clientX: number,
+  clientY: number,
+): FloorplanPoint {
+  const viewportWidth = Math.max(viewport.width, 1)
+  const viewportHeight = Math.max(viewport.height, 1)
+  const scale = Math.min(viewportWidth / viewBox.width, viewportHeight / viewBox.height)
+  const renderedWidth = viewBox.width * scale
+  const renderedHeight = viewBox.height * scale
+  const renderedLeft = viewport.left + (viewportWidth - renderedWidth) / 2
+  const renderedTop = viewport.top + (viewportHeight - renderedHeight) / 2
+  return [(clientX - renderedLeft) / renderedWidth, (clientY - renderedTop) / renderedHeight]
+}
+
+export function clientToFloorplanPoint(
+  viewBox: FloorplanViewBox,
+  viewport: FloorplanViewport,
+  clientX: number,
+  clientY: number,
+): FloorplanPoint {
+  const [fractionX, fractionY] = clientToViewBoxFraction(viewBox, viewport, clientX, clientY)
+  return [viewBox.x + fractionX * viewBox.width, viewBox.y + fractionY * viewBox.height]
+}
+
+export function scaleFloorplanViewBox(
+  viewBox: FloorplanViewBox,
+  factor: number,
+  anchorX = 0.5,
+  anchorY = 0.5,
+): FloorplanViewBox {
+  const minFactor = Math.max(MIN_VIEWBOX_SIZE / viewBox.width, MIN_VIEWBOX_SIZE / viewBox.height)
+  const maxFactor = Math.min(MAX_VIEWBOX_SIZE / viewBox.width, MAX_VIEWBOX_SIZE / viewBox.height)
+  const clampedFactor = Math.min(Math.max(factor, minFactor), maxFactor)
+  const width = viewBox.width * clampedFactor
+  const height = viewBox.height * clampedFactor
+  return {
+    x: viewBox.x + (viewBox.width - width) * anchorX,
+    y: viewBox.y + (viewBox.height - height) * anchorY,
+    width,
+    height,
+  }
+}
+
+export function scaleFloorplanViewBoxBetweenClients(
+  viewBox: FloorplanViewBox,
+  factor: number,
+  viewport: FloorplanViewport,
+  sourceClient: FloorplanPoint,
+  targetClient: FloorplanPoint,
+): FloorplanViewBox {
+  const sourcePoint = clientToFloorplanPoint(viewBox, viewport, sourceClient[0], sourceClient[1])
+  const [targetX, targetY] = clientToViewBoxFraction(
+    viewBox,
+    viewport,
+    targetClient[0],
+    targetClient[1],
+  )
+  const scaled = scaleFloorplanViewBox(viewBox, factor, 0, 0)
+  return {
+    ...scaled,
+    x: sourcePoint[0] - targetX * scaled.width,
+    y: sourcePoint[1] - targetY * scaled.height,
+  }
+}
+
+export function panFloorplanViewBox(
+  viewBox: FloorplanViewBox,
+  viewport: FloorplanViewport,
+  sourceClient: FloorplanPoint,
+  targetClient: FloorplanPoint,
+): FloorplanViewBox {
+  const sourcePoint = clientToFloorplanPoint(viewBox, viewport, sourceClient[0], sourceClient[1])
+  const targetPoint = clientToFloorplanPoint(viewBox, viewport, targetClient[0], targetClient[1])
+  return {
+    ...viewBox,
+    x: viewBox.x + sourcePoint[0] - targetPoint[0],
+    y: viewBox.y + sourcePoint[1] - targetPoint[1],
+  }
+}
+
+function applyTransform(point: FloorplanPoint, transform: PlanTransform): FloorplanPoint {
+  const cos = Math.cos(transform.rotation)
+  const sin = Math.sin(transform.rotation)
+  return [
+    point[0] * cos - point[1] * sin + transform.tx,
+    point[0] * sin + point[1] * cos + transform.ty,
+  ]
+}
+
+function composeTransform(
+  parent: PlanTransform,
+  child: NonNullable<Extract<FloorplanGeometry, { kind: 'group' }>['transform']>,
+): PlanTransform {
+  const translated = applyTransform(child.translate ?? [0, 0], parent)
+  return {
+    tx: translated[0],
+    ty: translated[1],
+    rotation: parent.rotation + (child.rotate ?? 0),
+  }
+}
+
+function includePoint(bounds: FloorplanBounds | null, point: FloorplanPoint): FloorplanBounds {
+  if (!bounds) return { minX: point[0], minY: point[1], maxX: point[0], maxY: point[1] }
+  return {
+    minX: Math.min(bounds.minX, point[0]),
+    minY: Math.min(bounds.minY, point[1]),
+    maxX: Math.max(bounds.maxX, point[0]),
+    maxY: Math.max(bounds.maxY, point[1]),
+  }
+}
+
+function includePoints(
+  bounds: FloorplanBounds | null,
+  points: readonly FloorplanPoint[],
+  transform: PlanTransform,
+): FloorplanBounds | null {
+  let next = bounds
+  for (const point of points) next = includePoint(next, applyTransform(point, transform))
+  return next
+}
+
+function geometryBounds(
+  geometry: FloorplanGeometry,
+  transform: PlanTransform,
+  bounds: FloorplanBounds | null,
+): FloorplanBounds | null {
+  switch (geometry.kind) {
+    case 'group': {
+      const nextTransform = geometry.transform
+        ? composeTransform(transform, geometry.transform)
+        : transform
+      return geometry.children.reduce(
+        (next, child) => geometryBounds(child, nextTransform, next),
+        bounds,
+      )
+    }
+    case 'polygon':
+    case 'polyline':
+    case 'hatch':
+      return includePoints(bounds, geometry.points, transform)
+    case 'rect':
+      return includePoints(
+        bounds,
+        [
+          [geometry.x, geometry.y],
+          [geometry.x + geometry.width, geometry.y],
+          [geometry.x + geometry.width, geometry.y + geometry.height],
+          [geometry.x, geometry.y + geometry.height],
+        ],
+        transform,
+      )
+    case 'circle': {
+      const center = applyTransform([geometry.cx, geometry.cy], transform)
+      return includePoints(
+        bounds,
+        [
+          [center[0] - geometry.r, center[1] - geometry.r],
+          [center[0] + geometry.r, center[1] + geometry.r],
+        ],
+        IDENTITY,
+      )
+    }
+    case 'line':
+    case 'hit-line':
+    case 'edge-handle':
+      return includePoints(
+        bounds,
+        [
+          [geometry.x1, geometry.y1],
+          [geometry.x2, geometry.y2],
+        ],
+        transform,
+      )
+    case 'text':
+      return includePoint(bounds, applyTransform([geometry.x, geometry.y], transform))
+    case 'image': {
+      const halfWidth = geometry.width / 2
+      const halfHeight = geometry.height / 2
+      const imageTransform = composeTransform(transform, {
+        translate: geometry.center,
+        rotate: geometry.rotation,
+      })
+      return includePoints(
+        bounds,
+        [
+          [-halfWidth, -halfHeight],
+          [halfWidth, -halfHeight],
+          [halfWidth, halfHeight],
+          [-halfWidth, halfHeight],
+        ],
+        imageTransform,
+      )
+    }
+    case 'endpoint-handle':
+    case 'midpoint-handle':
+    case 'move-handle':
+    case 'move-arrow':
+    case 'rotate-arrow':
+    case 'equal-spacing-badge':
+      return includePoint(bounds, applyTransform(geometry.point, transform))
+    case 'dimension-label':
+      return includePoint(bounds, applyTransform([geometry.cx, geometry.cy], transform))
+    case 'dimension':
+      return includePoints(
+        bounds,
+        [
+          geometry.start,
+          geometry.end,
+          geometry.dimensionStart ?? geometry.start,
+          geometry.dimensionEnd ?? geometry.end,
+        ],
+        transform,
+      )
+    case 'dimension-string':
+      return geometry.segments.reduce(
+        (next, segment) =>
+          includePoints(
+            next,
+            [
+              segment.start,
+              segment.end,
+              segment.dimensionStart ?? segment.start,
+              segment.dimensionEnd ?? segment.end,
+            ],
+            transform,
+          ),
+        bounds,
+      )
+    case 'path':
+      return bounds
+    default:
+      return bounds
+  }
+}
+
+export function getFloorplanBounds(
+  geometries: readonly FloorplanGeometry[],
+): FloorplanBounds | null {
+  return geometries.reduce(
+    (bounds, geometry) => geometryBounds(geometry, IDENTITY, bounds),
+    null as FloorplanBounds | null,
+  )
+}
+
+export function padFloorplanBounds(bounds: FloorplanBounds, ratio = 0.12): FloorplanBounds {
+  const width = Math.max(bounds.maxX - bounds.minX, 1)
+  const height = Math.max(bounds.maxY - bounds.minY, 1)
+  const padding = Math.max(Math.max(width, height) * ratio, 0.75)
+  return {
+    minX: bounds.minX - padding,
+    minY: bounds.minY - padding,
+    maxX: bounds.maxX + padding,
+    maxY: bounds.maxY + padding,
+  }
+}

--- a/packages/editor/src/components/viewer/floorplan-preview-navigation.test.ts
+++ b/packages/editor/src/components/viewer/floorplan-preview-navigation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  cameraAzimuthFromFloorplanRotation,
+  floorplanRotationFromCameraAzimuth,
+  floorplanViewBoxFromNavigationPose,
+  nearestEquivalentDegrees,
+  visibleFloorplanViewWidth,
+} from './floorplan-preview-navigation'
+
+describe('floorplan preview navigation', () => {
+  test('keeps continuous compass rotations across the angle seam', () => {
+    expect(nearestEquivalentDegrees(-179, 179)).toBe(181)
+    expect(floorplanRotationFromCameraAzimuth((-179 * Math.PI) / 180, 179)).toBeCloseTo(181)
+  })
+
+  test('uses the same north-up azimuth convention as the editor', () => {
+    expect(cameraAzimuthFromFloorplanRotation(0)).toBe(0)
+    expect(cameraAzimuthFromFloorplanRotation(90)).toBeCloseTo(Math.PI / 2)
+  })
+
+  test('maps a camera pose to an aspect-correct centered view box', () => {
+    expect(
+      floorplanViewBoxFromNavigationPose(
+        {
+          source: '3d',
+          revision: 1,
+          target: [0, 0, 0],
+          azimuth: 0,
+          viewWidth: 20,
+        },
+        { x: 4, y: 3 },
+        0,
+        { width: 1000, height: 500 },
+      ),
+    ).toEqual({ x: -6, y: -2, width: 20, height: 10 })
+  })
+
+  test('reports the actual horizontal span for meet-preserved SVG view boxes', () => {
+    expect(
+      visibleFloorplanViewWidth({ x: 0, y: 0, width: 10, height: 10 }, { width: 200, height: 100 }),
+    ).toBe(20)
+  })
+})

--- a/packages/editor/src/components/viewer/floorplan-preview-navigation.ts
+++ b/packages/editor/src/components/viewer/floorplan-preview-navigation.ts
@@ -1,0 +1,62 @@
+import type { NavigationSyncPose } from '../../store/use-editor'
+import type { FloorplanViewBox } from './floorplan-preview-geometry'
+
+export type FloorplanPreviewViewportSize = {
+  width: number
+  height: number
+}
+
+export function nearestEquivalentDegrees(angle: number, reference: number) {
+  let next = angle
+  while (next - reference > 180) next -= 360
+  while (next - reference < -180) next += 360
+  return next
+}
+
+export function floorplanRotationFromCameraAzimuth(azimuth: number, reference: number) {
+  return nearestEquivalentDegrees((azimuth * 180) / Math.PI, reference)
+}
+
+export function cameraAzimuthFromFloorplanRotation(rotationDeg: number) {
+  return (rotationDeg * Math.PI) / 180
+}
+
+export function rotateFloorplanPoint(
+  point: { x: number; y: number },
+  rotationDeg: number,
+): { x: number; y: number } {
+  if (rotationDeg === 0) return point
+  const radians = (rotationDeg * Math.PI) / 180
+  const cos = Math.cos(radians)
+  const sin = Math.sin(radians)
+  return {
+    x: point.x * cos - point.y * sin,
+    y: point.x * sin + point.y * cos,
+  }
+}
+
+export function visibleFloorplanViewWidth(
+  viewBox: FloorplanViewBox,
+  viewport: FloorplanPreviewViewportSize,
+) {
+  const aspect = Math.max(viewport.width, 1) / Math.max(viewport.height, 1)
+  return Math.max(viewBox.width, viewBox.height * aspect)
+}
+
+export function floorplanViewBoxFromNavigationPose(
+  pose: NavigationSyncPose,
+  localCenter: { x: number; y: number },
+  sceneRotationDeg: number,
+  viewport: FloorplanPreviewViewportSize,
+): FloorplanViewBox {
+  const center = rotateFloorplanPoint(localCenter, sceneRotationDeg)
+  const aspect = Math.max(viewport.width, 1) / Math.max(viewport.height, 1)
+  const width = Math.max(pose.viewWidth, 0.001)
+  const height = width / aspect
+  return {
+    x: center.x - width / 2,
+    y: center.y - height / 2,
+    width,
+    height,
+  }
+}

--- a/packages/editor/src/components/viewer/floorplan-preview.tsx
+++ b/packages/editor/src/components/viewer/floorplan-preview.tsx
@@ -1,0 +1,1069 @@
+'use client'
+
+import {
+  type AnyNode,
+  type AnyNodeId,
+  type FloorplanGeometry,
+  type FloorplanPalette,
+  type GeometryContext,
+  isNodeKindEnabled,
+  nodeRegistry,
+  useScene,
+} from '@pascal-app/core'
+import { AnyNode as AnyNodeSchema } from '@pascal-app/core/schema'
+import { useViewer } from '@pascal-app/viewer'
+import { Maximize2, Minus, Plus } from 'lucide-react'
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type WheelEvent as ReactWheelEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
+import {
+  FLOORPLAN_VIEW_ROTATION_DEG,
+  floorplanLocalToWorldPoint,
+  worldToFloorplanLocalPoint,
+} from '../../lib/floorplan'
+import { getFloorplanNodeExtension } from '../../lib/floorplan/floorplan-extension'
+import { buildFloorplanContext, floorplanLayerRank } from '../../lib/floorplan/floorplan-readonly'
+import { subscribeNavigationSyncPose } from '../../store/navigation-sync-pose-store'
+import useEditor, { type NavigationSyncPose } from '../../store/use-editor'
+import {
+  subscribeFloorplanCameraNavigation,
+  useFloorplanCameraSyncBridge,
+} from '../editor/floorplan-camera-sync'
+import {
+  createFloorplanNavigationSyncScheduler,
+  setFloorplanCompassRotation,
+} from '../editor/floorplan-navigation-presentation'
+import { FloorplanGeometryRenderer } from '../editor-2d/renderers/floorplan-geometry-renderer'
+import { FloorplanCompassButton } from './floorplan-compass-button'
+import {
+  type FloorplanBounds,
+  type FloorplanViewBox,
+  getFloorplanBounds,
+  padFloorplanBounds,
+  panFloorplanViewBox,
+  scaleFloorplanViewBox,
+  scaleFloorplanViewBoxBetweenClients,
+} from './floorplan-preview-geometry'
+import {
+  cameraAzimuthFromFloorplanRotation,
+  floorplanRotationFromCameraAzimuth,
+  floorplanViewBoxFromNavigationPose,
+  nearestEquivalentDegrees,
+  rotateFloorplanPoint,
+  visibleFloorplanViewWidth,
+} from './floorplan-preview-navigation'
+
+const READ_ONLY_PALETTE: FloorplanPalette = {
+  selectedStroke: '#4f46e5',
+  selectedFill: '#e0e7ff',
+  selectedHatch: '#818cf8',
+  wallHoverStroke: '#64748b',
+  endpointHandleFill: '#ffffff',
+  endpointHandleStroke: '#f97316',
+  endpointHandleHoverStroke: '#fb923c',
+  endpointHandleActiveFill: '#fed7aa',
+  endpointHandleActiveStroke: '#ea580c',
+  curveHandleFill: '#ffffff',
+  curveHandleStroke: '#0d9488',
+  curveHandleHoverStroke: '#14b8a6',
+  measurementStroke: '#475569',
+  measurementLabelBackground: '#ffffff',
+  measurementLabelText: '#0f172a',
+}
+const EMPTY_PREVIEW_NODES: Record<string, AnyNode> = {}
+const EMPTY_INSTALLED_PLUGINS: readonly string[] = []
+
+export type FloorplanPreviewScene = {
+  nodes: Record<string, AnyNode>
+  installedPlugins?: readonly string[]
+}
+
+export type FloorplanPreviewProps = {
+  className?: string
+  compassHost?: Element | null
+  levelId?: string | null
+  navigationVisible?: boolean
+  onLevelChange?: (levelId: string) => void
+  scene?: FloorplanPreviewScene | null
+  showCompass?: boolean
+  showLevelSelector?: boolean
+  synchronizeNavigation?: boolean
+}
+
+type PointerPoint = { x: number; y: number }
+type DragState = {
+  mode: 'pan' | 'rotate'
+  pointerId: number
+  point: PointerPoint
+  rotationDeg: number
+  viewBox: FloorplanViewBox
+}
+type PinchState = {
+  pointerIds: [number, number]
+  midpoint: PointerPoint
+  distance: number
+  viewBox: FloorplanViewBox
+}
+type FloorplanRenderEntry = {
+  id: string
+  geometry: FloorplanGeometry
+  includeInInitialFit: boolean
+}
+type FloorplanSourceEntry = {
+  node: AnyNode
+  contextOverrides?: Pick<GeometryContext, 'children' | 'siblings' | 'parent'>
+}
+type MeasuredFit = { key: string; bounds: FloorplanBounds }
+
+const useClientLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect
+
+function FloorplanCameraSyncMount() {
+  useFloorplanCameraSyncBridge()
+  return null
+}
+
+function boundsToViewBox(bounds: FloorplanBounds): FloorplanViewBox {
+  return {
+    x: bounds.minX,
+    y: bounds.minY,
+    width: Math.max(bounds.maxX - bounds.minX, 1),
+    height: Math.max(bounds.maxY - bounds.minY, 1),
+  }
+}
+
+function levelLabel(level: AnyNode): string {
+  const named = (level as { name?: string }).name?.trim()
+  if (named) return named
+  const ordinal = (level as { level?: number }).level ?? 0
+  if (ordinal === 0) return 'Ground floor'
+  if (ordinal < 0) return `Basement ${Math.abs(ordinal)}`
+  return `Level ${ordinal}`
+}
+
+function collectLevelTree(root: AnyNode, nodes: Record<string, AnyNode>): AnyNode[] {
+  const result: AnyNode[] = [root]
+  const seen = new Set<string>()
+  const queue = [...((root as { children?: AnyNodeId[] }).children ?? [])]
+  let index = 0
+  while (index < queue.length) {
+    const id = queue[index++]
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    const node = nodes[id]
+    if (!node) continue
+    result.push(node)
+    queue.push(...((node as { children?: AnyNodeId[] }).children ?? []))
+  }
+  return result
+}
+
+export function normalizeFloorplanPreviewNodes(
+  nodes: Record<string, unknown>,
+): Record<string, AnyNode> {
+  const normalized: Record<string, AnyNode> = {}
+  for (const [id, node] of Object.entries(nodes)) {
+    const builtin = AnyNodeSchema.safeParse(node)
+    if (builtin.success) {
+      normalized[builtin.data.id] = builtin.data
+      continue
+    }
+    const type =
+      node && typeof node === 'object' && !Array.isArray(node)
+        ? (node as { type?: unknown }).type
+        : null
+    const registered =
+      typeof type === 'string' ? nodeRegistry.get(type)?.schema.safeParse(node) : null
+    if (registered?.success) {
+      const parsed = registered.data as AnyNode
+      normalized[parsed.id] = parsed
+    } else {
+      console.warn(`[floorplan-preview] Skipping invalid node ${id}`, builtin.error.issues)
+    }
+  }
+  return normalized
+}
+
+function isVisibleInFloorplan(node: AnyNode, nodes: Record<string, AnyNode>): boolean {
+  const seen = new Set<string>()
+  let current: AnyNode | undefined = node
+  while (current) {
+    if (seen.has(current.id)) return true
+    seen.add(current.id)
+    if (current.visible === false) return false
+    current = current.parentId ? nodes[current.parentId] : undefined
+  }
+  return true
+}
+
+function buildFloorplanGeometries(
+  nodes: Record<string, AnyNode>,
+  installedPlugins: readonly string[] | undefined,
+  level: AnyNode,
+  unit: 'metric' | 'imperial',
+  metricNotation: 'meters' | 'millimeters',
+): FloorplanRenderEntry[] {
+  const building = level.parentId ? nodes[level.parentId] : undefined
+  const levelTree = collectLevelTree(level, nodes)
+  const entries: FloorplanSourceEntry[] = levelTree.map((node) => ({ node }))
+  const entryIds = new Set(entries.map((entry) => entry.node.id))
+  if (building) {
+    for (const candidate of Object.values(nodes)) {
+      const definition = nodeRegistry.get(candidate.type)
+      if (
+        definition?.floorplanScope === 'building' &&
+        candidate.parentId === building.id &&
+        !entryIds.has(candidate.id)
+      ) {
+        entries.push({
+          node: candidate,
+          contextOverrides: { children: [], siblings: [], parent: level },
+        })
+        entryIds.add(candidate.id)
+      }
+    }
+  }
+  for (const candidate of Object.values(nodes)) {
+    const definition = nodeRegistry.get(candidate.type)
+    const linkedLevelIds = getFloorplanNodeExtension(definition)?.linkedLevelIds
+    if (
+      definition?.floorplan &&
+      linkedLevelIds?.(candidate).includes(level.id) &&
+      !entryIds.has(candidate.id)
+    ) {
+      const childIds = (candidate as { children?: AnyNodeId[] }).children
+      const children = Array.isArray(childIds)
+        ? childIds.map((id) => nodes[id]).filter((child): child is AnyNode => child !== undefined)
+        : []
+      entries.push({
+        node: candidate,
+        contextOverrides: { children, siblings: [], parent: level },
+      })
+      entryIds.add(candidate.id)
+    }
+  }
+
+  const renderable = entries
+    .filter((entry) => isVisibleInFloorplan(entry.node, nodes))
+    .filter((entry) => isNodeKindEnabled(entry.node.type, installedPlugins))
+    .filter((entry) => nodeRegistry.get(entry.node.type)?.floorplan)
+    .sort((a, b) => floorplanLayerRank(a.node.type) - floorplanLayerRank(b.node.type))
+  const byType = new Map<string, AnyNode[]>()
+  for (const node of levelTree) {
+    if (!isNodeKindEnabled(node.type, installedPlugins)) continue
+    if (!nodeRegistry.get(node.type)?.computeFloorplanLevelData) continue
+    const siblings = byType.get(node.type) ?? []
+    siblings.push(node)
+    byType.set(node.type, siblings)
+  }
+  const levelData = new Map<string, unknown>()
+  for (const [type, siblings] of byType) {
+    const definition = nodeRegistry.get(type)
+    if (definition?.computeFloorplanLevelData) {
+      levelData.set(type, definition.computeFloorplanLevelData({ siblings, nodes }))
+    }
+  }
+
+  const geometries: FloorplanRenderEntry[] = []
+  for (const { node, contextOverrides } of renderable) {
+    const definition = nodeRegistry.get(node.type)
+    if (!definition?.floorplan) continue
+    const baseContext = buildFloorplanContext(
+      node,
+      nodes,
+      {
+        automaticDimensions: false,
+        selected: false,
+        unit,
+        metricNotation,
+        purpose: 'document',
+        highlighted: false,
+        hovered: false,
+        moving: false,
+        palette: READ_ONLY_PALETTE,
+      },
+      levelData.get(node.type),
+    )
+    const context = contextOverrides ? { ...baseContext, ...contextOverrides } : baseContext
+    try {
+      const geometry = definition.floorplan(node as never, context)
+      if (geometry) {
+        geometries.push({
+          id: node.id,
+          geometry,
+          includeInInitialFit: definition.category !== 'furnish',
+        })
+      }
+    } catch (error) {
+      console.error(`[floorplan-preview] Failed to render ${node.type}:${node.id}`, error)
+    }
+  }
+  return geometries
+}
+
+export function FloorplanPreview({
+  className,
+  compassHost,
+  levelId,
+  navigationVisible = true,
+  onLevelChange,
+  scene,
+  showCompass = true,
+  showLevelSelector = true,
+  synchronizeNavigation = false,
+}: FloorplanPreviewProps) {
+  const storeNodes = useScene((state) => (scene ? EMPTY_PREVIEW_NODES : state.nodes))
+  const storeInstalledPlugins = useScene((state) =>
+    scene ? EMPTY_INSTALLED_PLUGINS : state.installedPlugins,
+  )
+  const unit = useViewer((state) => state.unit)
+  const metricNotation = useViewer((state) => state.metricNotation)
+  const externalNodes = useMemo(
+    () => (scene?.nodes ? normalizeFloorplanPreviewNodes(scene.nodes) : null),
+    [scene?.nodes],
+  )
+  const nodes = externalNodes ?? storeNodes
+  const installedPlugins = scene ? scene.installedPlugins : storeInstalledPlugins
+  const levels = useMemo(
+    () =>
+      Object.values(nodes)
+        .filter((node) => node.type === 'level')
+        .sort(
+          (a, b) => ((a as { level?: number }).level ?? 0) - ((b as { level?: number }).level ?? 0),
+        ),
+    [nodes],
+  )
+  const [internalLevelId, setInternalLevelId] = useState<string | null>(null)
+  const activeLevelId =
+    (levelId && levels.some((level) => level.id === levelId) ? levelId : null) ??
+    (internalLevelId && levels.some((level) => level.id === internalLevelId)
+      ? internalLevelId
+      : null) ??
+    levels[0]?.id ??
+    null
+  const activeLevel = activeLevelId ? nodes[activeLevelId as AnyNodeId] : undefined
+  const activeBuilding = activeLevel?.parentId
+    ? nodes[activeLevel.parentId as AnyNodeId]
+    : undefined
+  const buildingPosition = useMemo<[number, number, number]>(
+    () => (activeBuilding?.type === 'building' ? activeBuilding.position : [0, 0, 0]),
+    [activeBuilding],
+  )
+  const buildingRotationY = activeBuilding?.type === 'building' ? activeBuilding.rotation[1] : 0
+  const buildingRotationDeg = (buildingRotationY * 180) / Math.PI
+  const renderEntries = useMemo(
+    () =>
+      activeLevel
+        ? buildFloorplanGeometries(nodes, installedPlugins, activeLevel, unit, metricNotation)
+        : [],
+    [activeLevel, installedPlugins, metricNotation, nodes, unit],
+  )
+  const framingEntries = useMemo(() => {
+    const structural = renderEntries.filter((entry) => entry.includeInInitialFit)
+    return structural.length > 0 ? structural : renderEntries
+  }, [renderEntries])
+  const fitKey = `${activeLevelId ?? 'none'}:${framingEntries.map((entry) => entry.id).join('|')}`
+  const geometricFitBounds = useMemo(
+    () => getFloorplanBounds(framingEntries.map((entry) => entry.geometry)),
+    [framingEntries],
+  )
+  const [measuredFit, setMeasuredFit] = useState<MeasuredFit | null>(null)
+  const fittedViewBox = useMemo(() => {
+    const bounds = measuredFit?.key === fitKey ? measuredFit.bounds : geometricFitBounds
+    return bounds
+      ? boundsToViewBox(padFloorplanBounds(bounds))
+      : { x: -5, y: -5, width: 10, height: 10 }
+  }, [fitKey, geometricFitBounds, measuredFit])
+  const [viewBox, setViewBox] = useState<FloorplanViewBox>(fittedViewBox)
+  const viewBoxRef = useRef(viewBox)
+  const interactionRef = useRef<HTMLDivElement | null>(null)
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const gridRef = useRef<SVGRectElement | null>(null)
+  const sceneRef = useRef<SVGGElement | null>(null)
+  const compassNeedleRef = useRef<SVGSVGElement | null>(null)
+  const fitElementRefs = useRef(new Map<string, SVGGElement>())
+  const pointersRef = useRef(new Map<number, PointerPoint>())
+  const dragRef = useRef<DragState | null>(null)
+  const pinchRef = useRef<PinchState | null>(null)
+  const [isPanning, setIsPanning] = useState(false)
+  const [isRotating, setIsRotating] = useState(false)
+  const [viewportSize, setViewportSize] = useState({ width: 1000, height: 1000 })
+  const [rotationDeg, setRotationDeg] = useState(0)
+  const rotationDegRef = useRef(rotationDeg)
+  const latestNavigationPoseRef = useRef<NavigationSyncPose | null>(null)
+  const gridPatternId = useId().replaceAll(':', '')
+
+  const updateViewBox = useCallback(
+    (update: FloorplanViewBox | ((current: FloorplanViewBox) => FloorplanViewBox)) => {
+      setViewBox((current) => {
+        const next = typeof update === 'function' ? update(current) : update
+        viewBoxRef.current = next
+        return next
+      })
+    },
+    [],
+  )
+
+  const presentViewBox = useCallback((next: FloorplanViewBox) => {
+    viewBoxRef.current = next
+    const value = `${next.x} ${next.y} ${next.width} ${next.height}`
+    svgRef.current?.setAttribute('viewBox', value)
+    const grid = gridRef.current
+    if (grid) {
+      grid.setAttribute('x', String(next.x))
+      grid.setAttribute('y', String(next.y))
+      grid.setAttribute('width', String(next.width))
+      grid.setAttribute('height', String(next.height))
+    }
+  }, [])
+
+  const presentRotation = useCallback(
+    (nextRotationDeg: number) => {
+      rotationDegRef.current = nextRotationDeg
+      const sceneRotationDeg = FLOORPLAN_VIEW_ROTATION_DEG + nextRotationDeg - buildingRotationDeg
+      const sceneElement = sceneRef.current
+      if (sceneElement) {
+        if (sceneRotationDeg === 0) sceneElement.removeAttribute('transform')
+        else sceneElement.setAttribute('transform', `rotate(${sceneRotationDeg})`)
+      }
+      setFloorplanCompassRotation(compassNeedleRef.current, nextRotationDeg)
+    },
+    [buildingRotationDeg],
+  )
+
+  const commitPresentation = useCallback(
+    (nextViewBox: FloorplanViewBox, nextRotationDeg: number) => {
+      presentViewBox(nextViewBox)
+      presentRotation(nextRotationDeg)
+      setViewBox(nextViewBox)
+      setRotationDeg(nextRotationDeg)
+    },
+    [presentRotation, presentViewBox],
+  )
+
+  const publishNavigation = useCallback(
+    (nextViewBox: FloorplanViewBox, nextRotationDeg: number) => {
+      if (!synchronizeNavigation) return
+      const sceneRotationDeg = FLOORPLAN_VIEW_ROTATION_DEG + nextRotationDeg - buildingRotationDeg
+      const displayedCenter = {
+        x: nextViewBox.x + nextViewBox.width / 2,
+        y: nextViewBox.y + nextViewBox.height / 2,
+      }
+      const localCenter = rotateFloorplanPoint(displayedCenter, -sceneRotationDeg)
+      const worldCenter = floorplanLocalToWorldPoint(
+        localCenter,
+        buildingPosition,
+        buildingRotationY,
+      )
+      useEditor.getState().publishNavigationSyncPose({
+        source: '2d',
+        target: [
+          worldCenter.x,
+          latestNavigationPoseRef.current?.target[1] ?? buildingPosition[1],
+          worldCenter.z,
+        ],
+        azimuth: cameraAzimuthFromFloorplanRotation(nextRotationDeg),
+        viewWidth: visibleFloorplanViewWidth(nextViewBox, viewportSize),
+      })
+    },
+    [buildingPosition, buildingRotationDeg, buildingRotationY, synchronizeNavigation, viewportSize],
+  )
+
+  const applyNavigationPresentationRef = useRef<(pose: NavigationSyncPose) => void>(() => {})
+  const commitNavigationPresentationRef = useRef<(pose: NavigationSyncPose) => void>(() => {})
+  const navigationSchedulerRef = useRef<ReturnType<
+    typeof createFloorplanNavigationSyncScheduler<NavigationSyncPose>
+  > | null>(null)
+  if (!navigationSchedulerRef.current) {
+    navigationSchedulerRef.current = createFloorplanNavigationSyncScheduler<NavigationSyncPose>({
+      applyPresentation: (pose) => applyNavigationPresentationRef.current(pose),
+      commit: (pose) => commitNavigationPresentationRef.current(pose),
+    })
+  }
+
+  applyNavigationPresentationRef.current = (pose) => {
+    latestNavigationPoseRef.current = pose
+    const nextRotationDeg = floorplanRotationFromCameraAzimuth(pose.azimuth, rotationDegRef.current)
+    presentRotation(nextRotationDeg)
+    if (!navigationVisible) return
+    const localCenter = worldToFloorplanLocalPoint(
+      pose.target[0],
+      pose.target[2],
+      buildingPosition,
+      buildingRotationY,
+    )
+    presentViewBox(
+      floorplanViewBoxFromNavigationPose(
+        pose,
+        localCenter,
+        FLOORPLAN_VIEW_ROTATION_DEG + nextRotationDeg - buildingRotationDeg,
+        viewportSize,
+      ),
+    )
+  }
+
+  commitNavigationPresentationRef.current = (_pose) => {
+    if (!navigationVisible) return
+    setViewBox(viewBoxRef.current)
+    setRotationDeg(rotationDegRef.current)
+  }
+
+  useClientLayoutEffect(() => {
+    let bounds: FloorplanBounds | null = null
+    for (const entry of framingEntries) {
+      const element = fitElementRefs.current.get(entry.id)
+      if (!element || typeof element.getBBox !== 'function') continue
+      let box: DOMRect
+      try {
+        box = element.getBBox()
+      } catch {
+        continue
+      }
+      if (![box.x, box.y, box.width, box.height].every(Number.isFinite)) continue
+      if (box.width === 0 && box.height === 0) continue
+      const next = {
+        minX: box.x,
+        minY: box.y,
+        maxX: box.x + box.width,
+        maxY: box.y + box.height,
+      }
+      bounds = bounds
+        ? {
+            minX: Math.min(bounds.minX, next.minX),
+            minY: Math.min(bounds.minY, next.minY),
+            maxX: Math.max(bounds.maxX, next.maxX),
+            maxY: Math.max(bounds.maxY, next.maxY),
+          }
+        : next
+    }
+    if (bounds) setMeasuredFit({ key: fitKey, bounds })
+  }, [fitKey, framingEntries])
+
+  useClientLayoutEffect(() => {
+    if (synchronizeNavigation && latestNavigationPoseRef.current) return
+    updateViewBox(fittedViewBox)
+    pointersRef.current.clear()
+    dragRef.current = null
+    pinchRef.current = null
+    setIsPanning(false)
+    setIsRotating(false)
+  }, [fittedViewBox, synchronizeNavigation, updateViewBox])
+
+  useEffect(() => {
+    const svg = svgRef.current
+    if (!svg) return
+    const updateSize = () => {
+      const rect = svg.getBoundingClientRect()
+      setViewportSize({ width: Math.max(rect.width, 1), height: Math.max(rect.height, 1) })
+    }
+    updateSize()
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateSize)
+      return () => window.removeEventListener('resize', updateSize)
+    }
+    const observer = new ResizeObserver(updateSize)
+    observer.observe(svg)
+    return () => observer.disconnect()
+  }, [])
+
+  useClientLayoutEffect(() => {
+    presentRotation(rotationDegRef.current)
+  }, [presentRotation])
+
+  useEffect(() => {
+    if (!synchronizeNavigation) return
+    const scheduler = navigationSchedulerRef.current
+    if (!scheduler) return
+    const receivePose = (pose: NavigationSyncPose) => {
+      latestNavigationPoseRef.current = pose
+      if (navigationVisible) scheduler.update(pose)
+      else applyNavigationPresentationRef.current(pose)
+    }
+    const unsubscribeCamera = subscribeFloorplanCameraNavigation(receivePose)
+    const unsubscribeStored = subscribeNavigationSyncPose((pose) => {
+      if (pose.source === '2d' && !navigationVisible) receivePose(pose)
+    })
+    return () => {
+      unsubscribeCamera()
+      unsubscribeStored()
+      scheduler.discard()
+    }
+  }, [navigationVisible, synchronizeNavigation])
+
+  useEffect(() => {
+    if (!(synchronizeNavigation && navigationVisible && latestNavigationPoseRef.current)) return
+    navigationSchedulerRef.current?.update(latestNavigationPoseRef.current)
+  }, [navigationVisible, synchronizeNavigation])
+
+  const chooseLevel = useCallback(
+    (nextLevelId: string) => {
+      setInternalLevelId(nextLevelId)
+      onLevelChange?.(nextLevelId)
+    },
+    [onLevelChange],
+  )
+
+  const updateLocalViewBox = useCallback(
+    (
+      update: FloorplanViewBox | ((current: FloorplanViewBox) => FloorplanViewBox),
+      commit = true,
+    ) => {
+      const current = viewBoxRef.current
+      const next = typeof update === 'function' ? update(current) : update
+      presentViewBox(next)
+      if (commit) setViewBox(next)
+      publishNavigation(next, rotationDegRef.current)
+      return next
+    },
+    [presentViewBox, publishNavigation],
+  )
+
+  const zoom = useCallback(
+    (factor: number, anchorX = 0.5, anchorY = 0.5) => {
+      updateLocalViewBox((current) => scaleFloorplanViewBox(current, factor, anchorX, anchorY))
+    },
+    [updateLocalViewBox],
+  )
+
+  const onWheel = useCallback(
+    (event: ReactWheelEvent<SVGSVGElement>) => {
+      event.preventDefault()
+      const rect = event.currentTarget.getBoundingClientRect()
+      updateLocalViewBox((current) =>
+        scaleFloorplanViewBoxBetweenClients(
+          current,
+          event.deltaY > 0 ? 1.12 : 0.88,
+          rect,
+          [event.clientX, event.clientY],
+          [event.clientX, event.clientY],
+        ),
+      )
+    },
+    [updateLocalViewBox],
+  )
+
+  const onPointerDown = useCallback((event: ReactPointerEvent<SVGSVGElement>) => {
+    if (event.pointerType === 'mouse' && event.button !== 0 && event.button !== 2) return
+    event.preventDefault()
+    interactionRef.current?.focus()
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId)
+    } catch {
+      // Pointer capture is an enhancement; the gesture still works while events stay over the SVG.
+    }
+    const point = { x: event.clientX, y: event.clientY }
+    pointersRef.current.set(event.pointerId, point)
+    const pointers = Array.from(pointersRef.current.entries())
+    if (pointers.length === 1) {
+      dragRef.current = {
+        mode: event.pointerType === 'mouse' && event.button === 2 ? 'rotate' : 'pan',
+        pointerId: event.pointerId,
+        point,
+        rotationDeg: rotationDegRef.current,
+        viewBox: viewBoxRef.current,
+      }
+      pinchRef.current = null
+    } else {
+      const [first, second] = pointers
+      if (!first || !second) return
+      const dx = second[1].x - first[1].x
+      const dy = second[1].y - first[1].y
+      pinchRef.current = {
+        pointerIds: [first[0], second[0]],
+        midpoint: { x: (first[1].x + second[1].x) / 2, y: (first[1].y + second[1].y) / 2 },
+        distance: Math.max(Math.hypot(dx, dy), 1),
+        viewBox: viewBoxRef.current,
+      }
+      dragRef.current = null
+    }
+    setIsPanning(true)
+    setIsRotating(dragRef.current?.mode === 'rotate')
+  }, [])
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<SVGSVGElement>) => {
+      if (!pointersRef.current.has(event.pointerId)) return
+      pointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
+      const rect = event.currentTarget.getBoundingClientRect()
+      const pinch = pinchRef.current
+      if (pinch) {
+        const first = pointersRef.current.get(pinch.pointerIds[0])
+        const second = pointersRef.current.get(pinch.pointerIds[1])
+        if (!(first && second)) return
+        const dx = second.x - first.x
+        const dy = second.y - first.y
+        const midpoint: PointerPoint = { x: (first.x + second.x) / 2, y: (first.y + second.y) / 2 }
+        updateLocalViewBox(
+          scaleFloorplanViewBoxBetweenClients(
+            pinch.viewBox,
+            pinch.distance / Math.max(Math.hypot(dx, dy), 1),
+            rect,
+            [pinch.midpoint.x, pinch.midpoint.y],
+            [midpoint.x, midpoint.y],
+          ),
+          false,
+        )
+        return
+      }
+      const drag = dragRef.current
+      if (!drag || drag.pointerId !== event.pointerId) return
+      if (drag.mode === 'rotate') {
+        const nextRotationDeg = drag.rotationDeg + (event.clientX - drag.point.x) * 0.35
+        const initialSceneRotationDeg =
+          FLOORPLAN_VIEW_ROTATION_DEG + drag.rotationDeg - buildingRotationDeg
+        const nextSceneRotationDeg =
+          FLOORPLAN_VIEW_ROTATION_DEG + nextRotationDeg - buildingRotationDeg
+        const displayedCenter = {
+          x: drag.viewBox.x + drag.viewBox.width / 2,
+          y: drag.viewBox.y + drag.viewBox.height / 2,
+        }
+        const localCenter = rotateFloorplanPoint(displayedCenter, -initialSceneRotationDeg)
+        const nextCenter = rotateFloorplanPoint(localCenter, nextSceneRotationDeg)
+        const nextViewBox = {
+          ...drag.viewBox,
+          x: nextCenter.x - drag.viewBox.width / 2,
+          y: nextCenter.y - drag.viewBox.height / 2,
+        }
+        presentRotation(nextRotationDeg)
+        presentViewBox(nextViewBox)
+        publishNavigation(nextViewBox, nextRotationDeg)
+        return
+      }
+      updateLocalViewBox(
+        panFloorplanViewBox(
+          drag.viewBox,
+          rect,
+          [drag.point.x, drag.point.y],
+          [event.clientX, event.clientY],
+        ),
+        false,
+      )
+    },
+    [buildingRotationDeg, presentRotation, presentViewBox, publishNavigation, updateLocalViewBox],
+  )
+
+  const onPointerUp = useCallback((event: ReactPointerEvent<SVGSVGElement>) => {
+    pointersRef.current.delete(event.pointerId)
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    pinchRef.current = null
+    const [remaining] = pointersRef.current.entries()
+    if (remaining) {
+      dragRef.current = {
+        mode: 'pan',
+        pointerId: remaining[0],
+        point: remaining[1],
+        rotationDeg: rotationDegRef.current,
+        viewBox: viewBoxRef.current,
+      }
+      setIsRotating(false)
+    } else {
+      dragRef.current = null
+      setIsPanning(false)
+      setIsRotating(false)
+      setViewBox(viewBoxRef.current)
+      setRotationDeg(rotationDegRef.current)
+    }
+  }, [])
+
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const panStep = 0.08
+      switch (event.key) {
+        case '+':
+        case '=':
+          event.preventDefault()
+          zoom(0.8)
+          return
+        case '-':
+        case '_':
+          event.preventDefault()
+          zoom(1.2)
+          return
+        case '0':
+        case 'f':
+        case 'F':
+          event.preventDefault()
+          updateLocalViewBox(fittedViewBox)
+          return
+        case 'ArrowLeft':
+          event.preventDefault()
+          updateLocalViewBox((current) => ({
+            ...current,
+            x: current.x - current.width * panStep,
+          }))
+          return
+        case 'ArrowRight':
+          event.preventDefault()
+          updateLocalViewBox((current) => ({
+            ...current,
+            x: current.x + current.width * panStep,
+          }))
+          return
+        case 'ArrowUp':
+          event.preventDefault()
+          updateLocalViewBox((current) => ({
+            ...current,
+            y: current.y - current.height * panStep,
+          }))
+          return
+        case 'ArrowDown':
+          event.preventDefault()
+          updateLocalViewBox((current) => ({
+            ...current,
+            y: current.y + current.height * panStep,
+          }))
+      }
+    },
+    [fittedViewBox, updateLocalViewBox, zoom],
+  )
+
+  const alignToNorth = useCallback(() => {
+    const currentRotationDeg = rotationDegRef.current
+    const nextRotationDeg = nearestEquivalentDegrees(0, currentRotationDeg)
+    if (!navigationVisible) {
+      const pose = latestNavigationPoseRef.current
+      if (!pose) return
+      useEditor.getState().publishNavigationSyncPose({
+        source: '2d',
+        target: [...pose.target],
+        azimuth: cameraAzimuthFromFloorplanRotation(nextRotationDeg),
+        viewWidth: pose.viewWidth,
+      })
+      return
+    }
+
+    const currentViewBox = viewBoxRef.current
+    const currentSceneRotationDeg =
+      FLOORPLAN_VIEW_ROTATION_DEG + currentRotationDeg - buildingRotationDeg
+    const nextSceneRotationDeg = FLOORPLAN_VIEW_ROTATION_DEG + nextRotationDeg - buildingRotationDeg
+    const currentCenter = {
+      x: currentViewBox.x + currentViewBox.width / 2,
+      y: currentViewBox.y + currentViewBox.height / 2,
+    }
+    const localCenter = rotateFloorplanPoint(currentCenter, -currentSceneRotationDeg)
+    const nextCenter = rotateFloorplanPoint(localCenter, nextSceneRotationDeg)
+    const nextViewBox = {
+      ...currentViewBox,
+      x: nextCenter.x - currentViewBox.width / 2,
+      y: nextCenter.y - currentViewBox.height / 2,
+    }
+    commitPresentation(nextViewBox, nextRotationDeg)
+    publishNavigation(nextViewBox, nextRotationDeg)
+  }, [buildingRotationDeg, commitPresentation, navigationVisible, publishNavigation])
+
+  const screenUnitsPerPixel = Math.max(
+    viewBox.width / Math.max(viewportSize.width, 1),
+    viewBox.height / Math.max(viewportSize.height, 1),
+  )
+
+  const compassControl = (
+    <FloorplanCompassButton
+      needleRef={compassNeedleRef}
+      northRotationDeg={rotationDeg}
+      onAlignNorth={alignToNorth}
+    />
+  )
+
+  if (levels.length === 0) {
+    return (
+      <div
+        className={className}
+        style={{ display: 'grid', placeItems: 'center', background: '#f8fafc', color: '#64748b' }}
+      >
+        No floor plans are available for this scene.
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={className}
+      style={{ position: 'relative', overflow: 'hidden', background: '#f8fafc' }}
+    >
+      {synchronizeNavigation ? <FloorplanCameraSyncMount /> : null}
+      <div
+        aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight + - 0 F"
+        aria-label={`${activeLevel ? levelLabel(activeLevel) : 'Floor plan'} 2D view`}
+        onKeyDown={onKeyDown}
+        role="application"
+        ref={interactionRef}
+        style={{ width: '100%', height: '100%' }}
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: The plan canvas supports keyboard pan, zoom, and fit controls.
+        tabIndex={0}
+      >
+        <svg
+          aria-hidden="true"
+          data-floorplan-preview=""
+          onContextMenu={(event) => event.preventDefault()}
+          onPointerCancel={onPointerUp}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onWheel={onWheel}
+          preserveAspectRatio="xMidYMid meet"
+          ref={svgRef}
+          style={{
+            width: '100%',
+            height: '100%',
+            cursor: isRotating ? 'ew-resize' : isPanning ? 'grabbing' : 'grab',
+            touchAction: 'none',
+          }}
+          viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`}
+        >
+          <defs>
+            <pattern height="1" id={gridPatternId} patternUnits="userSpaceOnUse" width="1">
+              <path
+                d="M 1 0 L 0 0 0 1"
+                fill="none"
+                stroke="#cbd5e1"
+                strokeOpacity="0.32"
+                strokeWidth="0.012"
+              />
+            </pattern>
+          </defs>
+          <rect
+            fill={`url(#${gridPatternId})`}
+            height={viewBox.height}
+            ref={gridRef}
+            width={viewBox.width}
+            x={viewBox.x}
+            y={viewBox.y}
+          />
+          <g
+            pointerEvents="none"
+            ref={sceneRef}
+            transform={
+              FLOORPLAN_VIEW_ROTATION_DEG + rotationDeg - buildingRotationDeg === 0
+                ? undefined
+                : `rotate(${FLOORPLAN_VIEW_ROTATION_DEG + rotationDeg - buildingRotationDeg})`
+            }
+          >
+            {renderEntries.map((entry) => (
+              <g
+                key={entry.id}
+                ref={(element) => {
+                  if (element) fitElementRefs.current.set(entry.id, element)
+                  else fitElementRefs.current.delete(entry.id)
+                }}
+              >
+                <FloorplanGeometryRenderer
+                  geometry={entry.geometry}
+                  pointerEventsOverride="none"
+                  screenUnitsPerPixel={screenUnitsPerPixel}
+                />
+              </g>
+            ))}
+          </g>
+        </svg>
+      </div>
+
+      {showLevelSelector && levels.length > 1 ? (
+        <label
+          style={{
+            position: 'absolute',
+            bottom: 16,
+            left: 64,
+            display: 'grid',
+            gap: 4,
+            color: '#475569',
+            fontSize: 11,
+            fontWeight: 600,
+          }}
+        >
+          Floor
+          <select
+            aria-label="Floor"
+            onChange={(event) => chooseLevel(event.target.value)}
+            style={{
+              border: '1px solid rgba(148,163,184,.55)',
+              borderRadius: 999,
+              background: 'rgba(255,255,255,.94)',
+              padding: '8px 30px 8px 12px',
+              color: '#0f172a',
+              boxShadow: '0 8px 24px rgba(15,23,42,.10)',
+            }}
+            value={activeLevelId ?? ''}
+          >
+            {levels.map((level) => (
+              <option key={level.id} value={level.id}>
+                {levelLabel(level)}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+
+      {showCompass
+        ? compassHost
+          ? createPortal(compassControl, compassHost)
+          : compassControl
+        : null}
+
+      <div
+        style={{
+          position: 'absolute',
+          right: 16,
+          bottom: 16,
+          display: 'flex',
+          gap: 4,
+          border: '1px solid rgba(148,163,184,.45)',
+          borderRadius: 999,
+          background: 'rgba(255,255,255,.94)',
+          padding: 4,
+          boxShadow: '0 8px 24px rgba(15,23,42,.10)',
+        }}
+      >
+        <button
+          aria-label="Zoom out"
+          onClick={() => zoom(1.2)}
+          style={controlStyle}
+          title="Zoom out"
+          type="button"
+        >
+          <Minus size={16} />
+        </button>
+        <button
+          aria-label="Fit floor plan"
+          onClick={() => updateLocalViewBox(fittedViewBox)}
+          style={controlStyle}
+          title="Fit floor plan"
+          type="button"
+        >
+          <Maximize2 size={15} />
+        </button>
+        <button
+          aria-label="Zoom in"
+          onClick={() => zoom(0.8)}
+          style={controlStyle}
+          title="Zoom in"
+          type="button"
+        >
+          <Plus size={16} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const controlStyle = {
+  display: 'grid',
+  width: 32,
+  height: 32,
+  placeItems: 'center',
+  border: 0,
+  borderRadius: 999,
+  background: 'transparent',
+  color: '#334155',
+  cursor: 'pointer',
+} as const

--- a/packages/editor/src/components/viewer/use-viewer-camera-navigation-sync.ts
+++ b/packages/editor/src/components/viewer/use-viewer-camera-navigation-sync.ts
@@ -1,0 +1,140 @@
+'use client'
+
+import { type CameraPose, emitter } from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
+import type { CameraControlsImpl } from '@react-three/drei'
+import { useThree } from '@react-three/fiber'
+import { type RefObject, useCallback, useEffect, useRef } from 'react'
+import type { Camera, OrthographicCamera, PerspectiveCamera } from 'three'
+import { Vector3 } from 'three'
+import { normalizeCameraPose } from '../../lib/camera-pose'
+import { publishCameraPose } from '../../store/camera-pose-store'
+
+const position = new Vector3()
+const target = new Vector3()
+
+function isPerspectiveCamera(camera: Camera): camera is PerspectiveCamera {
+  return (camera as PerspectiveCamera).isPerspectiveCamera === true
+}
+
+function isOrthographicCamera(camera: Camera): camera is OrthographicCamera {
+  return (camera as OrthographicCamera).isOrthographicCamera === true
+}
+
+function cameraViewWidth(camera: Camera, distance: number, width: number, height: number) {
+  if (isPerspectiveCamera(camera)) {
+    const fov = (camera.getEffectiveFOV() * Math.PI) / 180
+    return Math.max(0.001, 2 * distance * Math.tan(fov / 2) * (width / Math.max(height, 1)))
+  }
+  if (isOrthographicCamera(camera)) {
+    return Math.max(0.001, (camera.right - camera.left) / camera.zoom)
+  }
+  return Math.max(0.001, distance)
+}
+
+function applyViewWidth(
+  controls: CameraControlsImpl,
+  camera: Camera,
+  viewWidth: number,
+  width: number,
+  height: number,
+) {
+  if (isPerspectiveCamera(camera)) {
+    const fov = (camera.getEffectiveFOV() * Math.PI) / 180
+    const denominator = 2 * Math.tan(fov / 2) * (width / Math.max(height, 1))
+    if (denominator > 0) controls.dollyTo(Math.max(0.001, viewWidth / denominator), false)
+    return
+  }
+  if (isOrthographicCamera(camera) && viewWidth > 0) {
+    controls.zoomTo(Math.max(0.001, (camera.right - camera.left) / viewWidth), false)
+  }
+}
+
+export function useViewerCameraNavigationSync(controls: RefObject<CameraControlsImpl | null>) {
+  const camera = useThree((state) => state.camera)
+  const size = useThree((state) => state.size)
+  const suppressPublish = useRef(false)
+  const pendingPose = useRef<CameraPose | null>(null)
+
+  const publishCurrentPose = useCallback(() => {
+    const control = controls.current
+    if (!control || suppressPublish.current) return
+    control.getPosition(position, false)
+    control.getTarget(target, false)
+    const projection = isPerspectiveCamera(camera)
+      ? 'perspective'
+      : isOrthographicCamera(camera)
+        ? 'orthographic'
+        : null
+    if (!projection) return
+    const pose = normalizeCameraPose({
+      position: [position.x, position.y, position.z],
+      target: [target.x, target.y, target.z],
+      projection,
+      viewWidth: cameraViewWidth(camera, position.distanceTo(target), size.width, size.height),
+      ...(isPerspectiveCamera(camera) ? { fov: camera.fov } : {}),
+    })
+    if (pose) publishCameraPose(pose)
+  }, [camera, controls, size.height, size.width])
+
+  const applyPendingPose = useCallback(() => {
+    const control = controls.current
+    const pose = pendingPose.current
+    if (!(control && pose)) return
+    const projectionMatches =
+      (pose.projection === 'perspective' && isPerspectiveCamera(camera)) ||
+      (pose.projection === 'orthographic' && isOrthographicCamera(camera))
+    if (!projectionMatches) return
+
+    pendingPose.current = null
+    suppressPublish.current = true
+    try {
+      if (pose.fov !== undefined && isPerspectiveCamera(camera)) {
+        camera.fov = pose.fov
+        camera.updateProjectionMatrix()
+      }
+      control.setLookAt(
+        pose.position[0],
+        pose.position[1],
+        pose.position[2],
+        pose.target[0],
+        pose.target[1],
+        pose.target[2],
+        false,
+      )
+      if (pose.viewWidth !== undefined) {
+        applyViewWidth(control, camera, pose.viewWidth, size.width, size.height)
+      }
+      control.update(0)
+    } finally {
+      suppressPublish.current = false
+      publishCurrentPose()
+    }
+  }, [camera, controls, publishCurrentPose, size.height, size.width])
+
+  useEffect(() => {
+    applyPendingPose()
+  }, [applyPendingPose])
+
+  useEffect(() => {
+    const applyPose = (value: CameraPose) => {
+      const pose = normalizeCameraPose(value)
+      if (!pose) return
+      pendingPose.current = pose
+      if (useViewer.getState().cameraMode !== pose.projection) {
+        useViewer.getState().setCameraMode(pose.projection)
+        return
+      }
+      applyPendingPose()
+    }
+    emitter.on('camera-controls:apply-pose', applyPose)
+    return () => emitter.off('camera-controls:apply-pose', applyPose)
+  }, [applyPendingPose])
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(publishCurrentPose)
+    return () => cancelAnimationFrame(frame)
+  }, [publishCurrentPose])
+
+  return publishCurrentPose
+}

--- a/packages/editor/src/components/viewer/viewer-stage-modes.test.ts
+++ b/packages/editor/src/components/viewer/viewer-stage-modes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  normalizeViewerStageModes,
+  resolveMobileViewerStageMode,
+  resolveViewerStageMode,
+  viewerStageIncludes3D,
+} from './viewer-stage-modes'
+
+describe('viewer stage modes', () => {
+  test('supports every ordered combination without duplicates', () => {
+    expect(normalizeViewerStageModes(['split', '3d', 'split'])).toEqual(['3d', 'split'])
+    expect(normalizeViewerStageModes(['2d'])).toEqual(['2d'])
+    expect(normalizeViewerStageModes([])).toEqual(['3d'])
+  })
+
+  test('falls back to the first enabled mode', () => {
+    expect(resolveViewerStageMode('split', ['3d', '2d'])).toBe('3d')
+    expect(resolveViewerStageMode(undefined, ['2d', 'split'])).toBe('2d')
+  })
+
+  test('uses an enabled single-pane mode on mobile but preserves split-only embeds', () => {
+    expect(resolveMobileViewerStageMode('split', ['3d', 'split'])).toBe('3d')
+    expect(resolveMobileViewerStageMode('split', ['2d', 'split'])).toBe('2d')
+    expect(resolveMobileViewerStageMode('split', ['split'])).toBe('split')
+  })
+
+  test('does not require a GPU canvas for a 2D-only embed', () => {
+    expect(viewerStageIncludes3D(['2d'])).toBe(false)
+    expect(viewerStageIncludes3D(['split'])).toBe(true)
+    expect(viewerStageIncludes3D(['3d', '2d'])).toBe(true)
+  })
+})

--- a/packages/editor/src/components/viewer/viewer-stage-modes.ts
+++ b/packages/editor/src/components/viewer/viewer-stage-modes.ts
@@ -1,0 +1,32 @@
+export const VIEWER_STAGE_MODES = ['3d', '2d', 'split'] as const
+
+export type ViewerStageMode = (typeof VIEWER_STAGE_MODES)[number]
+
+export function normalizeViewerStageModes(
+  modes: readonly ViewerStageMode[] | undefined,
+): ViewerStageMode[] {
+  const requested = modes ?? VIEWER_STAGE_MODES
+  const unique = VIEWER_STAGE_MODES.filter((mode) => requested.includes(mode))
+  return unique.length > 0 ? unique : ['3d']
+}
+
+export function resolveViewerStageMode(
+  mode: ViewerStageMode | undefined,
+  modes: readonly ViewerStageMode[],
+): ViewerStageMode {
+  return mode && modes.includes(mode) ? mode : (modes[0] ?? '3d')
+}
+
+export function resolveMobileViewerStageMode(
+  mode: ViewerStageMode,
+  modes: readonly ViewerStageMode[],
+): ViewerStageMode {
+  if (mode !== 'split') return mode
+  if (modes.includes('2d')) return '2d'
+  if (modes.includes('3d')) return '3d'
+  return 'split'
+}
+
+export function viewerStageIncludes3D(modes: readonly ViewerStageMode[]) {
+  return modes.includes('3d') || modes.includes('split')
+}

--- a/packages/editor/src/components/viewer/viewer-stage-switcher.tsx
+++ b/packages/editor/src/components/viewer/viewer-stage-switcher.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { Box, Columns2, Map as MapIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { cn } from '../../lib/utils'
+import { normalizeViewerStageModes, type ViewerStageMode } from './viewer-stage-modes'
+
+export type { ViewerStageMode } from './viewer-stage-modes'
+
+export type ViewerStageSwitcherProps = {
+  className?: string
+  hideSplitOnMobile?: boolean
+  mode: ViewerStageMode
+  modes?: readonly ViewerStageMode[]
+  onChange: (mode: ViewerStageMode) => void
+}
+
+export function ViewerStageSwitcher({
+  className,
+  hideSplitOnMobile = true,
+  mode,
+  modes,
+  onChange,
+}: ViewerStageSwitcherProps) {
+  const enabledModes = normalizeViewerStageModes(modes)
+
+  return (
+    <div
+      aria-label="Viewer layout"
+      className={cn(
+        'dark absolute top-4 left-1/2 z-30 flex -translate-x-1/2 items-center gap-1 rounded-full border border-white/10 bg-neutral-950/82 p-1 text-white shadow-elevation-4 backdrop-blur-xl',
+        className,
+      )}
+      role="group"
+    >
+      {enabledModes.includes('3d') ? (
+        <StageButton
+          active={mode === '3d'}
+          icon={<Box />}
+          label="3D"
+          onClick={() => onChange('3d')}
+        />
+      ) : null}
+      {enabledModes.includes('2d') ? (
+        <StageButton
+          active={mode === '2d'}
+          icon={<MapIcon />}
+          label="2D"
+          onClick={() => onChange('2d')}
+        />
+      ) : null}
+      {enabledModes.includes('split') ? (
+        <StageButton
+          active={mode === 'split'}
+          className={hideSplitOnMobile && enabledModes.length > 1 ? 'hidden md:flex' : undefined}
+          icon={<Columns2 />}
+          label="Split"
+          onClick={() => onChange('split')}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function StageButton({
+  active,
+  className,
+  icon,
+  label,
+  onClick,
+}: {
+  active: boolean
+  className?: string
+  icon: ReactNode
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      aria-pressed={active}
+      className={cn(
+        'flex h-8 items-center gap-1.5 rounded-full px-3 font-medium text-xs',
+        active
+          ? 'bg-white text-neutral-950 shadow-sm'
+          : 'text-neutral-300 transition-colors hover:bg-white/10 hover:text-white',
+        className,
+      )}
+      onClick={onClick}
+      type="button"
+    >
+      <span className="[&>svg]:size-3.5">{icon}</span>
+      {label}
+    </button>
+  )
+}

--- a/packages/editor/src/components/viewer/viewer-stage.test.tsx
+++ b/packages/editor/src/components/viewer/viewer-stage.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { LevelNode } from '@pascal-app/core/schema'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { FloorplanPreviewScene } from './floorplan-preview'
+import { ViewerStage } from './viewer-stage'
+
+const level = LevelNode.parse({ id: 'level_ground', type: 'level' })
+const scene: FloorplanPreviewScene = { nodes: { [level.id]: level } }
+
+describe('ViewerStage', () => {
+  test('owns synchronized 2D and 3D composition by default', () => {
+    const markup = renderToStaticMarkup(
+      <ViewerStage mode="split" scene={scene} showLevelSelector={false}>
+        <div data-test-viewer-content="" />
+      </ViewerStage>,
+    )
+
+    expect(markup).toContain('data-pascal-viewer-stage="split"')
+    expect(markup).toContain('data-pascal-navigation-sync="on"')
+    expect(markup).toContain('data-pascal-viewer-3d="true"')
+    expect(markup).toContain('data-floorplan-preview=""')
+    expect(markup).toContain('viewBox="0 0 48 48"')
+  })
+
+  test('keeps a 2D-only embed free of a 3D canvas mount', () => {
+    const markup = renderToStaticMarkup(
+      <ViewerStage mode="2d" modes={['2d']} scene={scene} showLevelSelector={false} />,
+    )
+
+    expect(markup).toContain('data-pascal-viewer-stage="2d"')
+    expect(markup).not.toContain('data-pascal-viewer-3d')
+    expect(markup).toContain('data-floorplan-preview=""')
+  })
+
+  test('supports an explicit navigation synchronization opt-out', () => {
+    const markup = renderToStaticMarkup(
+      <ViewerStage
+        mode="split"
+        scene={scene}
+        showLevelSelector={false}
+        synchronizeNavigation={false}
+      />,
+    )
+
+    expect(markup).toContain('data-pascal-navigation-sync="off"')
+  })
+})

--- a/packages/editor/src/components/viewer/viewer-stage.tsx
+++ b/packages/editor/src/components/viewer/viewer-stage.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { type AnyNode, type AnyNodeId, useScene } from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
+import type { ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { cn } from '../../lib/utils'
+import { FloorplanPreview, type FloorplanPreviewScene } from './floorplan-preview'
+import {
+  normalizeViewerStageModes,
+  resolveMobileViewerStageMode,
+  resolveViewerStageMode,
+  type ViewerStageMode,
+  viewerStageIncludes3D,
+} from './viewer-stage-modes'
+import { ViewerStageSwitcher } from './viewer-stage-switcher'
+
+export type ViewerStageProps = {
+  children?: ReactNode
+  className?: string
+  collapseSplitOnMobile?: boolean
+  compassHost?: Element | null
+  defaultMode?: ViewerStageMode
+  floorplanClassName?: string
+  levelId?: string | null
+  mode?: ViewerStageMode
+  modes?: readonly ViewerStageMode[]
+  onLevelChange?: (levelId: string) => void
+  onModeChange?: (mode: ViewerStageMode) => void
+  scene?: FloorplanPreviewScene | null
+  showCompass?: boolean
+  showLevelSelector?: boolean
+  showSwitcher?: boolean
+  switcherClassName?: string
+  synchronizeNavigation?: boolean
+  threeDClassName?: string
+}
+
+const EMPTY_LEVEL_IDS: string[] = []
+
+function levelNodeIds(nodes: Record<string, AnyNode>) {
+  return Object.values(nodes)
+    .filter((node) => node.type === 'level')
+    .sort(
+      (left, right) =>
+        ((left as { level?: number }).level ?? 0) - ((right as { level?: number }).level ?? 0),
+    )
+    .map((node) => node.id)
+}
+
+function selectViewerLevel(nodes: Record<string, AnyNode>, levelId: string) {
+  const level = nodes[levelId as AnyNodeId]
+  if (level?.type !== 'level') return
+  const building = level.parentId ? nodes[level.parentId as AnyNodeId] : null
+  const viewer = useViewer.getState()
+  viewer.setSelection({
+    buildingId: building?.type === 'building' ? building.id : null,
+    levelId: level.id,
+    selectedIds: [],
+    zoneId: null,
+  })
+  viewer.setLevelMode('solo')
+}
+
+export function ViewerStage({
+  children,
+  className,
+  collapseSplitOnMobile = true,
+  compassHost,
+  defaultMode,
+  floorplanClassName,
+  levelId,
+  mode: controlledMode,
+  modes,
+  onLevelChange,
+  onModeChange,
+  scene,
+  showCompass = true,
+  showLevelSelector = true,
+  showSwitcher = true,
+  switcherClassName,
+  synchronizeNavigation = true,
+  threeDClassName,
+}: ViewerStageProps) {
+  const enabledModes = useMemo(() => normalizeViewerStageModes(modes), [modes])
+  const [internalMode, setInternalMode] = useState(() =>
+    resolveViewerStageMode(defaultMode, enabledModes),
+  )
+  const activeMode = resolveViewerStageMode(controlledMode ?? internalMode, enabledModes)
+  const storeLevelIds = useScene(
+    useShallow((state) => (scene ? EMPTY_LEVEL_IDS : levelNodeIds(state.nodes))),
+  )
+  const externalLevelIds = useMemo(() => (scene ? levelNodeIds(scene.nodes) : null), [scene])
+  const levelIds = externalLevelIds ?? storeLevelIds
+  const selectedLevelId = useViewer((state) => state.selection.levelId)
+  const [internalLevelId, setInternalLevelId] = useState<string | null>(null)
+  const [internalCompassHost, setInternalCompassHost] = useState<HTMLDivElement | null>(null)
+  const resolvedCompassHost = compassHost ?? internalCompassHost
+  const floorplanEnabled = enabledModes.includes('2d') || enabledModes.includes('split')
+  const threeDEnabled = viewerStageIncludes3D(enabledModes)
+  const mountFloorplan = floorplanEnabled || showCompass
+
+  const requestMode = useCallback(
+    (nextMode: ViewerStageMode) => {
+      if (!enabledModes.includes(nextMode)) return
+      if (controlledMode === undefined) setInternalMode(nextMode)
+      onModeChange?.(nextMode)
+    },
+    [controlledMode, enabledModes, onModeChange],
+  )
+
+  useEffect(() => {
+    if (controlledMode !== undefined) {
+      if (controlledMode !== activeMode) onModeChange?.(activeMode)
+      return
+    }
+    if (internalMode !== activeMode) setInternalMode(activeMode)
+  }, [activeMode, controlledMode, internalMode, onModeChange])
+
+  useEffect(() => {
+    if (!collapseSplitOnMobile) return
+    const mediaQuery = window.matchMedia('(max-width: 767px)')
+    const resolveMode = () => {
+      if (!mediaQuery.matches) return
+      const nextMode = resolveMobileViewerStageMode(activeMode, enabledModes)
+      if (nextMode !== activeMode) requestMode(nextMode)
+    }
+    resolveMode()
+    mediaQuery.addEventListener('change', resolveMode)
+    return () => mediaQuery.removeEventListener('change', resolveMode)
+  }, [activeMode, collapseSplitOnMobile, enabledModes, requestMode])
+
+  const chooseLevel = useCallback(
+    (nextLevelId: string, notify = true) => {
+      setInternalLevelId(nextLevelId)
+      selectViewerLevel(scene?.nodes ?? useScene.getState().nodes, nextLevelId)
+      if (notify) onLevelChange?.(nextLevelId)
+    },
+    [onLevelChange, scene],
+  )
+
+  useEffect(() => {
+    if (activeMode === '3d' || levelIds.length === 0) return
+    const nextLevelId =
+      (levelId && levelIds.includes(levelId) ? levelId : null) ??
+      (selectedLevelId && levelIds.includes(selectedLevelId) ? selectedLevelId : null) ??
+      (internalLevelId && levelIds.includes(internalLevelId) ? internalLevelId : null) ??
+      levelIds[0] ??
+      null
+    if (nextLevelId) chooseLevel(nextLevelId, false)
+  }, [activeMode, chooseLevel, internalLevelId, levelId, levelIds, selectedLevelId])
+
+  return (
+    <div
+      className={cn('relative h-full w-full overflow-hidden bg-neutral-100', className)}
+      data-pascal-navigation-sync={synchronizeNavigation ? 'on' : 'off'}
+      data-pascal-viewer-stage={activeMode}
+    >
+      {showCompass && compassHost === undefined ? (
+        <div className="pointer-events-none absolute inset-0 z-30" ref={setInternalCompassHost} />
+      ) : null}
+
+      {showSwitcher && enabledModes.length > 1 ? (
+        <ViewerStageSwitcher
+          className={switcherClassName}
+          hideSplitOnMobile={collapseSplitOnMobile}
+          mode={activeMode}
+          modes={enabledModes}
+          onChange={requestMode}
+        />
+      ) : null}
+
+      <div
+        className={
+          activeMode === 'split'
+            ? 'absolute inset-0 grid grid-rows-2 md:grid-cols-2 md:grid-rows-1'
+            : 'absolute inset-0'
+        }
+      >
+        {threeDEnabled ? (
+          <div
+            className={cn(
+              activeMode === '2d'
+                ? 'pointer-events-none invisible absolute inset-0 h-full w-full'
+                : 'relative h-full min-h-0 w-full min-w-0',
+              threeDClassName,
+            )}
+            data-pascal-viewer-3d
+          >
+            {children}
+          </div>
+        ) : null}
+
+        {mountFloorplan ? (
+          <FloorplanPreview
+            className={cn(
+              activeMode === '3d'
+                ? 'hidden'
+                : activeMode === 'split'
+                  ? 'min-h-0 min-w-0 border-border border-t md:border-t-0 md:border-l'
+                  : 'h-full w-full',
+              floorplanClassName,
+            )}
+            compassHost={resolvedCompassHost}
+            levelId={levelId ?? internalLevelId}
+            navigationVisible={activeMode !== '3d'}
+            onLevelChange={chooseLevel}
+            scene={scene}
+            showCompass={showCompass}
+            showLevelSelector={showLevelSelector}
+            synchronizeNavigation={synchronizeNavigation}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -275,6 +275,16 @@ export {
   SnapTargetIcon,
 } from './components/ui/snap-target-badge'
 export {
+  FloorplanCompassButton,
+  type FloorplanCompassButtonProps,
+} from './components/viewer/floorplan-compass-button'
+export {
+  FloorplanPreview,
+  type FloorplanPreviewProps,
+  type FloorplanPreviewScene,
+} from './components/viewer/floorplan-preview'
+export { useViewerCameraNavigationSync } from './components/viewer/use-viewer-camera-navigation-sync'
+export {
   ViewerControlsBar,
   type ViewerControlsBarProps,
 } from './components/viewer/viewer-controls-bar'
@@ -282,6 +292,19 @@ export {
   ViewerSceneHeader,
   type ViewerSceneHeaderProps,
 } from './components/viewer/viewer-scene-header'
+export { ViewerStage, type ViewerStageProps } from './components/viewer/viewer-stage'
+export {
+  normalizeViewerStageModes,
+  resolveMobileViewerStageMode,
+  resolveViewerStageMode,
+  VIEWER_STAGE_MODES,
+  viewerStageIncludes3D,
+} from './components/viewer/viewer-stage-modes'
+export {
+  type ViewerStageMode,
+  ViewerStageSwitcher,
+  type ViewerStageSwitcherProps,
+} from './components/viewer/viewer-stage-switcher'
 export {
   WalkthroughHud,
   type WalkthroughHudProps,

--- a/packages/editor/src/lib/floorplan/floorplan-readonly.test.ts
+++ b/packages/editor/src/lib/floorplan/floorplan-readonly.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { LevelNode, WallNode } from '@pascal-app/core/schema'
+import { buildFloorplanContext } from './floorplan-readonly'
+
+const viewState = {
+  selected: false,
+  unit: 'metric' as const,
+  highlighted: false,
+  hovered: false,
+  moving: false,
+  palette: undefined,
+}
+
+describe('read-only floorplan context', () => {
+  test('does not invent siblings for parentless nodes', () => {
+    const first = LevelNode.parse({ id: 'level_first', type: 'level' })
+    const second = LevelNode.parse({ id: 'level_second', type: 'level' })
+    const nodes = { [first.id]: first, [second.id]: second }
+
+    expect(buildFloorplanContext(first, nodes, viewState).siblings).toEqual([])
+  })
+
+  test('resolves same-kind siblings from the parent child order', () => {
+    const first = WallNode.parse({
+      id: 'wall_first',
+      type: 'wall',
+      parentId: 'level_ground',
+      start: [0, 0],
+      end: [1, 0],
+    })
+    const second = WallNode.parse({
+      id: 'wall_second',
+      type: 'wall',
+      parentId: 'level_ground',
+      start: [1, 0],
+      end: [2, 0],
+    })
+    const level = LevelNode.parse({
+      id: 'level_ground',
+      type: 'level',
+      children: [first.id, second.id],
+    })
+    const nodes = { [level.id]: level, [first.id]: first, [second.id]: second }
+
+    expect(buildFloorplanContext(first, nodes, viewState).siblings).toEqual([second])
+  })
+})

--- a/packages/editor/src/lib/floorplan/floorplan-readonly.ts
+++ b/packages/editor/src/lib/floorplan/floorplan-readonly.ts
@@ -1,0 +1,84 @@
+import type { AnyNode, AnyNodeId, FloorplanPalette, GeometryContext } from '@pascal-app/core'
+import {
+  createFloorplanContextExtensions,
+  type FloorplanWallDimensionReference,
+} from './floorplan-extension'
+
+export type FloorplanViewState = {
+  automaticDimensions?: boolean
+  selected: boolean
+  unit: 'metric' | 'imperial'
+  metricNotation?: 'meters' | 'millimeters'
+  purpose?: 'edit' | 'document'
+  wallDimensionReference?: FloorplanWallDimensionReference
+  highlighted: boolean
+  hovered: boolean
+  moving: boolean
+  palette: FloorplanPalette | undefined
+}
+
+export function buildFloorplanContext(
+  node: AnyNode,
+  nodes: Record<string, AnyNode>,
+  viewState: FloorplanViewState,
+  levelData?: unknown,
+): GeometryContext {
+  const resolve = <N = AnyNode>(id: AnyNodeId): N | undefined => nodes[id] as N | undefined
+  const childIds = (node as { children?: AnyNodeId[] }).children
+  const children = Array.isArray(childIds)
+    ? childIds.map((id) => nodes[id]).filter((child): child is AnyNode => child !== undefined)
+    : []
+  const parentId = node.parentId as AnyNodeId | null
+  const parent = parentId ? (nodes[parentId] ?? null) : null
+  let siblings: AnyNode[] = []
+  if (parent) {
+    const parentChildIds = (parent as { children?: AnyNodeId[] }).children
+    siblings = Array.isArray(parentChildIds)
+      ? parentChildIds
+          .filter((id) => id !== node.id)
+          .map((id) => nodes[id])
+          .filter((sibling): sibling is AnyNode => sibling?.type === node.type)
+      : Object.values(nodes).filter(
+          (candidate) =>
+            candidate.id !== node.id &&
+            candidate.type === node.type &&
+            candidate.parentId === node.parentId,
+        )
+  }
+
+  return {
+    resolve,
+    children,
+    siblings,
+    parent,
+    levelData,
+    extensions: createFloorplanContextExtensions({
+      automaticDimensions: viewState.automaticDimensions,
+      metricNotation: viewState.metricNotation ?? 'meters',
+      purpose: viewState.purpose ?? 'edit',
+      wallDimensionReference: viewState.wallDimensionReference,
+    }),
+    viewState: viewState.palette
+      ? {
+          selected: viewState.selected,
+          unit: viewState.unit,
+          highlighted: viewState.highlighted,
+          hovered: viewState.hovered,
+          moving: viewState.moving,
+          palette: viewState.palette,
+        }
+      : undefined,
+  }
+}
+
+export function floorplanLayerRank(type: string): number {
+  switch (type) {
+    case 'zone':
+      return 0
+    case 'slab':
+    case 'ceiling':
+      return 1
+    default:
+      return 2
+  }
+}

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -68,6 +68,58 @@ function App() {
 }
 ```
 
+## 2D and Split-View Embeds
+
+`@pascal-app/viewer` owns the 3D canvas. The npm-facing multi-view shell lives in
+`@pascal-app/editor`, where it can compose that canvas with the read-only SVG floor plan without
+coupling editor-only floor-plan state into the viewer runtime.
+
+Use `modes` to expose any combination of `3d`, `2d`, and `split`. A single enabled mode hides the
+switcher automatically. `mode` and `onModeChange` can be supplied for controlled embeds; otherwise
+`defaultMode` is used.
+
+```tsx
+import { ViewerStage, useViewerCameraNavigationSync } from '@pascal-app/editor'
+import { Viewer } from '@pascal-app/viewer'
+import { CameraControls, type CameraControlsImpl } from '@react-three/drei'
+import { useRef } from 'react'
+
+function SyncedCameraControls() {
+  const controls = useRef<CameraControlsImpl>(null)
+  const publishCameraPose = useViewerCameraNavigationSync(controls)
+
+  return <CameraControls makeDefault onUpdate={publishCameraPose} ref={controls} />
+}
+
+function EmbeddedViewer() {
+  return (
+    <div style={{ width: 960, height: 640 }}>
+      <ViewerStage defaultMode="3d" modes={['3d', '2d']}>
+        <Viewer>
+          <SyncedCameraControls />
+        </Viewer>
+      </ViewerStage>
+    </div>
+  )
+}
+```
+
+Common configurations:
+
+```tsx
+<ViewerStage modes={['3d']}>{viewer}</ViewerStage>
+<ViewerStage modes={['2d']} />
+<ViewerStage modes={['3d', '2d']}>{viewer}</ViewerStage>
+<ViewerStage modes={['3d', 'split']}>{viewer}</ViewerStage>
+<ViewerStage modes={['3d', '2d', 'split']}>{viewer}</ViewerStage>
+```
+
+For a 2D-only embed, no 3D canvas is mounted. When 3D or split is enabled, the 3D canvas stays
+mounted while 2D is active, avoiding renderer reinitialization. Camera poses,
+floor-plan pan/zoom/rotation, and the compass synchronize through transient subscriptions; live
+navigation does not require a React render per frame. Set `showCompass={false}` or
+`showSwitcher={false}` when the host supplies its own controls.
+
 ## Viewer State
 
 ```typescript


### PR DESCRIPTION
## What does this PR do?

Adds a reusable `ViewerStage` to `@pascal-app/editor` with configurable 3D, 2D, and split layouts. The shared stage owns level selection, the existing editor compass, mobile split collapse, and transient 2D/3D camera synchronization so the editor preview and hosted viewer can use one abstraction.

The floorplan remains registry-driven and read-only, 2D-only embeds do not mount a GPU canvas, and externally supplied scenes avoid subscriptions to the global scene graph. Public exports and npm usage documentation are included.

## How to test

1. Run `bun run check`, `bun run check-types`, and `bun run build`.
2. Run `bun --cwd packages/editor test` and confirm all editor tests pass.
3. Open an editor scene with a floor plan, enter preview, and verify 3D, 2D, and split modes share the selected level, camera target/zoom/rotation, and bottom-left compass.
4. Verify `ViewerStage` with `modes={['3d']}` combinations exposes only the requested layouts and that `modes={['2d']}` mounts no 3D canvas.

## Screenshots / screen recording

Verified interactively in the editor preview and hosted viewer; no recording attached.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch