### PR TITLE
fix(editor): retry bun install on transient GitHub 429

### DIFF
--- a/apps/editor/vercel.json
+++ b/apps/editor/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && npx -y bun@1.3.13 run build --filter=editor",
-  "installCommand": "cd ../.. && npx -y bun@1.3.13 install --frozen-lockfile",
+  "installCommand": "cd ../.. && (npx -y bun@1.3.13 install --frozen-lockfile || (sleep 20 && npx -y bun@1.3.13 install --frozen-lockfile) || (sleep 60 && npx -y bun@1.3.13 install --frozen-lockfile))",
   "outputDirectory": ".next",
   "cleanUrls": true,
   "trailingSlash": false


### PR DESCRIPTION
## Why

A production deploy of `pascalorg/private-editor` (which consumes this repo as a submodule) failed today with no code defect involved:

```
Running "install" command: `cd ../.. && npx -y bun@1.3.13 install --frozen-lockfile`
error: GET https://codeload.github.com/pascalorg/plugin-bones/legacy.tar.gz/<sha> - 429
error: GET https://codeload.github.com/pascalorg/plugin-articraft/legacy.tar.gz/<sha> - 429
error: GET https://codeload.github.com/sudhir9297/streetscape-pascal-plugin/legacy.tar.gz/<sha> - 429
error: @pascal-app/plugin-bones@github:pascalorg/plugin-bones#<sha> failed to resolve
Error: Command "..." exited with 1
```

`apps/editor/package.json` pins four plugins as `github:` tarball dependencies, so every build re-downloads them from `codeload.github.com`. Anonymous archive downloads are rate-limited **per source IP**, and CI build machines share egress addresses — an unrelated burst on that IP throttles ours. The build dies inside `installCommand`, before any compilation. All the pinned SHAs were fine (each URL returned `200` on retry).

## What

Retry the install twice — after 20s, then 60s — before failing.

The retry is chained `||` subshells rather than a `for` loop on purpose: a loop whose last statement is `sleep` exits `0` even when every attempt failed, which would let the build proceed with missing dependencies. Verified the chain propagates a non-zero exit when all three attempts fail, and short-circuits on the first success.

## Note

The complementary fix is a `GITHUB_TOKEN` build env var — `bun install --help` documents it as *"Supply a token to download code from GitHub with a higher rate limit"*, which moves these fetches off the shared anonymous bucket. All the plugin repos are public, so a scopeless token is sufficient. That is being set on the Vercel projects separately; this change is what makes the repo survive a throttle window unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-only install resilience in `vercel.json`; no runtime, auth, or application logic changes.
> 
> **Overview**
> Vercel editor builds were failing when `bun install` hit **GitHub `codeload` 429** while fetching pinned `github:` plugin tarballs, with no application code involved.
> 
> The **`installCommand` in `apps/editor/vercel.json`** now runs the same frozen install up to **three times**, waiting **20s** then **60s** between failures, using chained `||` subshells so a successful attempt stops the chain and an exhausted chain still exits non-zero (unlike a loop that could end on `sleep` and mask failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc591247f0679164ac76a0bd4b58e11bb321c9de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->