### PR TITLE
chore: bump plugin-bones to 05ca742 — night-4: movable outlets, AC condensers, cavity-fit framing

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#6e7dcfa41484223ec7b636b6de977301010c0121",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#8f40d06b1815b4a6da7ef50dd6ed79d7689abc5c",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#f308cf36042371fb03e8aef154ab4a1578d3f3a6",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#05ca74229e8f602fbb66fe5156fcd49ca045f4a7",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#05ca74229e8f602fbb66fe5156fcd49ca045f4a7",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#6e7dcfa41484223ec7b636b6de977301010c0121",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#05ca74229e8f602fbb66fe5156fcd49ca045f4a7",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#6e7dcfa41484223ec7b636b6de977301010c0121",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#05ca742", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-05ca742"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#6e7dcfa", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-6e7dcfa"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#f308cf36042371fb03e8aef154ab4a1578d3f3a6",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#05ca74229e8f602fbb66fe5156fcd49ca045f4a7",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -101,7 +101,7 @@
     },
     "packages/cli": {
       "name": "@pascal-app/cli",
-      "version": "0.1.5",
+      "version": "1.0.0-beta.1",
       "bin": {
         "pascal": "dist/bin/pascal.js",
       },
@@ -116,7 +116,7 @@
     },
     "packages/core": {
       "name": "@pascal-app/core",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "dependencies": {
         "dedent": "^1.7.1",
         "idb-keyval": "^6.2.2",
@@ -142,7 +142,7 @@
     },
     "packages/editor": {
       "name": "@pascal-app/editor",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -179,8 +179,8 @@
         "zustand": "^5.0.11",
       },
       "devDependencies": {
-        "@pascal-app/core": "^1.0.0-beta.4",
-        "@pascal-app/viewer": "^1.0.0-beta.4",
+        "@pascal-app/core": "^1.0.0-beta.5",
+        "@pascal-app/viewer": "^1.0.0-beta.5",
         "@pascal/typescript-config": "*",
         "@types/blob-stream": "^0.1.33",
         "@types/bun": "^1.3.0",
@@ -192,8 +192,8 @@
         "typescript": "6.0.3",
       },
       "peerDependencies": {
-        "@pascal-app/core": "^1.0.0-beta.4",
-        "@pascal-app/viewer": "^1.0.0-beta.4",
+        "@pascal-app/core": "^1.0.0-beta.5",
+        "@pascal-app/viewer": "^1.0.0-beta.5",
         "@react-three/drei": "^10",
         "@react-three/fiber": "^9",
         "next": ">=15",
@@ -221,7 +221,7 @@
     },
     "packages/ifc-converter": {
       "name": "@pascal-app/ifc-converter",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "dependencies": {
         "@pascal-app/core": "*",
         "nanoid": "^5.1.6",
@@ -235,7 +235,7 @@
     },
     "packages/mcp": {
       "name": "@pascal-app/mcp",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "bin": {
         "pascal-mcp": "./dist/bin/pascal-mcp.js",
       },
@@ -245,22 +245,22 @@
         "zod": "^4.3.5",
       },
       "devDependencies": {
-        "@pascal-app/core": "^1.0.0-beta.4",
+        "@pascal-app/core": "^1.0.0-beta.5",
         "@pascal/typescript-config": "*",
         "@types/node": "^22.19.20",
         "typescript": "6.0.3",
       },
       "peerDependencies": {
-        "@pascal-app/core": "^1.0.0-beta.4",
+        "@pascal-app/core": "^1.0.0-beta.5",
       },
     },
     "packages/nodes": {
       "name": "@pascal-app/nodes",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "devDependencies": {
-        "@pascal-app/core": "^1.0.0-beta.4",
-        "@pascal-app/editor": "^1.0.0-beta.4",
-        "@pascal-app/viewer": "^1.0.0-beta.4",
+        "@pascal-app/core": "^1.0.0-beta.5",
+        "@pascal-app/editor": "^1.0.0-beta.5",
+        "@pascal-app/viewer": "^1.0.0-beta.5",
         "@pascal/typescript-config": "*",
         "@types/bun": "^1.3.0",
         "@types/node": "^22.19.12",
@@ -269,9 +269,9 @@
         "typescript": "6.0.3",
       },
       "peerDependencies": {
-        "@pascal-app/core": "^1.0.0-beta.4",
-        "@pascal-app/editor": "^1.0.0-beta.4",
-        "@pascal-app/viewer": "^1.0.0-beta.4",
+        "@pascal-app/core": "^1.0.0-beta.5",
+        "@pascal-app/editor": "^1.0.0-beta.5",
+        "@pascal-app/viewer": "^1.0.0-beta.5",
         "@react-three/drei": "^10",
         "@react-three/fiber": "^9",
         "lucide-react": "^1",
@@ -303,14 +303,14 @@
     },
     "packages/viewer": {
       "name": "@pascal-app/viewer",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "dependencies": {
         "three-bvh-csg": "^0.0.18",
         "three-mesh-bvh": "^0.9.8",
         "zustand": "^5",
       },
       "devDependencies": {
-        "@pascal-app/core": "^1.0.0-beta.4",
+        "@pascal-app/core": "^1.0.0-beta.5",
         "@pascal/typescript-config": "*",
         "@types/node": "^22",
         "@types/react": "^19.2.2",
@@ -318,7 +318,7 @@
         "typescript": "6.0.3",
       },
       "peerDependencies": {
-        "@pascal-app/core": "^1.0.0-beta.4",
+        "@pascal-app/core": "^1.0.0-beta.5",
         "@react-three/drei": "^10",
         "@react-three/fiber": "^9",
         "react": "^18 || ^19",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#f308cf3", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-f308cf3"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#05ca742", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-05ca742"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#6e7dcfa41484223ec7b636b6de977301010c0121",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#8f40d06b1815b4a6da7ef50dd6ed79d7689abc5c",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#6e7dcfa", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-6e7dcfa"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#8f40d06", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-8f40d06"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Pin bump only. Night-4 batch (plugin master, two pilot branches merged):

- **Movable outlets (Q7)** — every derived receptacle/switch is a hoverable, draggable node (door-style drag along its wall); engine-side code-aware snapping: never in a rough opening, mounts beside a stud (or books a blocking member), height clamps, NEC 210.52 spacing advisory; wires re-route on release. Byte-equality pin guards untouched scenes.
- **AC condensers** — 1-N outdoor units sized by conditioned area (climate-zone divisor, cited), on 4" concrete pads with clearances, refrigerant line-set pairs to the air handler, NEC 440.14 disconnect + whip per unit; full takeoff rows.
- **Cavity-fit framing** — the S1 same-wall framing-vs-finishes interpenetration class is retired: member geometry compresses to the drawn wall (thickness − 1") while size/labels/takeoff/cut lengths stay nominal; one aggregated Flags row per class. Thickness-swept SAT matrix gates it.
- **E4 closed** — no wire crosses open room air at living height; island crossings clear every wall in the scene; island service feeders run buried (NEC 300.5).
- **Selected-wall cull exemption** — the wall you're inspecting keeps its full finish stack visible from any angle (dedupe-twin aware).

855 plugin tests + tsc green. Adversarial verify loop (skeptic + Playwright visual) running at this exact sha on localhost; the community bump waits for its PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes live entirely in the external plugin (electrical, HVAC, framing, routing); risk is moderate because those domains affect generated geometry and code compliance, not app auth or data.
> 
> **Overview**
> **Dependency-only change:** bumps `@pascal-app/plugin-bones` in the editor app from commit `f308cf3` to `8f40d06` and refreshes `bun.lock` so installs resolve the new GitHub pin.
> 
> That pin pulls in the night-4 **plugin-bones** batch described in the PR (movable outlets with wall drag and NEC-aware snapping, AC condensers with pads/line sets/disconnects, cavity-fit framing geometry, E4 wire routing rules, and selected-wall cull exemption)—with **no** first-party source edits in this repo beyond the pin.
> 
> The lockfile diff also aligns recorded workspace versions for several `@pascal-app/*` packages (e.g. core/editor/viewer `1.0.0-beta.5`, mcp `1.0.0-beta.6`, cli `1.0.0-beta.1`) as part of the same lock refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3de2e2f4b5743142af84c875d65dcf035b6d305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->