### PR TITLE
chore: bump plugin-bones to 041041da — dawn: AC power circuits, seed parity, disconnect RO slide

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#8f40d06b1815b4a6da7ef50dd6ed79d7689abc5c",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#041041dab1366ecd59bf3c74d0dd47a243cc6845",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#8f40d06b1815b4a6da7ef50dd6ed79d7689abc5c",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#041041dab1366ecd59bf3c74d0dd47a243cc6845",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#8f40d06", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-8f40d06"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#041041d", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-041041d"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Pin bump only. Dawn mini-batch on top of night-4:

- **AC condensers get their power** (completes the user ask): each unit's disconnect carries a dedicated `AC-n` circuit — panel homerun with the standard wall-following router (RO detours, drill height), 30A/10 AWG ≤3 tons / 40A/8 AWG above, honest panel-schedule + plan-legend ratings, and a brute-force-verified circuit color family (>64 RGB from every real circuit id).
- **Seed parity**: the heat-pump service node seeds at the engine's slid condenser anchor — the sign stands on the unit; on-wall-anchor and inside-corner edge cases guarded.
- **Disconnect RO slide**: a unit dragged in front of a window no longer mounts its disconnect on the glass — the box slides clear within sight (≤1.5 m), unclearable cases warn.

Loop-verified (two adversarial rounds; Playwright visual PASS with the box-beside-window exhibit). 865 plugin tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> No in-repo logic changes, but the new plugin revision alters MEP routing, panel schedules, and equipment placement in the editor.
> 
> **Overview**
> **Dependency-only change:** pins `@pascal-app/plugin-bones` from `8f40d06` to `041041da` in `apps/editor/package.json` and refreshes the matching `bun.lock` entry.
> 
> That plugin revision (Dawn mini-batch) brings **AC condenser power circuits** — per-unit `AC-n` homeruns from the panel with sizing/legend updates — **heat-pump service seed alignment** to the slid condenser anchor, and **disconnect placement** that slides off windows within sight instead of mounting on glass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb26f28ebb3f93aeb3987bac75d1b01df06125f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->