### PR TITLE
feat(editor): edit shared parameters on a homogeneous multi-selection

### DIFF
--- a/packages/editor/src/components/ui/controls/segmented-control.tsx
+++ b/packages/editor/src/components/ui/controls/segmented-control.tsx
@@ -7,6 +7,7 @@ interface SegmentedControlProps<T extends string> {
   onChange: (value: T) => void
   options: { label: React.ReactNode; value: T }[]
   className?: string
+  mixed?: boolean
 }
 
 export function SegmentedControl<T extends string>({
@@ -14,6 +15,7 @@ export function SegmentedControl<T extends string>({
   onChange,
   options,
   className,
+  mixed = false,
 }: SegmentedControlProps<T>) {
   return (
     <div
@@ -23,7 +25,7 @@ export function SegmentedControl<T extends string>({
       )}
     >
       {options.map((option) => {
-        const isSelected = value === option.value
+        const isSelected = !mixed && value === option.value
         return (
           <button
             className={cn(

--- a/packages/editor/src/components/ui/controls/slider-control.tsx
+++ b/packages/editor/src/components/ui/controls/slider-control.tsx
@@ -22,6 +22,7 @@ interface SliderControlProps {
   className?: string
   unit?: string
   restoreOnCommit?: boolean
+  mixed?: boolean
 }
 
 function stepPrecision(s: number): number {
@@ -64,6 +65,7 @@ export function SliderControl({
   className,
   unit = '',
   restoreOnCommit = true,
+  mixed = false,
 }: SliderControlProps) {
   // Display/storage conversion so the value honors the metric/imperial toggle.
   // `value`, `onChange`, `onCommit`, `min`/`max`/`clamp` are always in the
@@ -76,6 +78,10 @@ export function SliderControl({
   const [isDragging, setIsDragging] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
   const [inputValue, setInputValue] = useState(toDisplay(value).toFixed(precision))
+  // Live readout while dragging. Multi-edit previews write live overrides
+  // instead of the scene, so `value` would otherwise stay frozen even though
+  // the meshes are moving.
+  const [dragDisplay, setDragDisplay] = useState<number | null>(null)
 
   const dragRef = useRef<{
     // Original value at drag start — preserved across modifier re-anchors so
@@ -89,8 +95,9 @@ export function SliderControl({
     stepMultiplier: number
   } | null>(null)
   const labelRef = useRef<HTMLDivElement>(null)
-  const valueRef = useRef(value)
-  valueRef.current = value
+  const shown = dragDisplay ?? value
+  const valueRef = useRef(shown)
+  valueRef.current = shown
 
   const clamp = useCallback((val: number) => Math.min(Math.max(val, min), max), [min, max])
   // Apply a signed display-unit delta to a stored value, rounding in the
@@ -185,6 +192,7 @@ export function SliderControl({
       const newValue = applyDisplayDelta(anchorValue, (dx / 4) * s, s)
       if (newValue !== valueRef.current) {
         valueRef.current = newValue
+        setDragDisplay(newValue)
         onChange(newValue)
       }
     },
@@ -209,6 +217,7 @@ export function SliderControl({
         useScene.temporal.getState().resume()
         onCommit?.(finalVal)
       }
+      setDragDisplay(null)
     },
     [onChange, onCommit, restoreOnCommit],
   )
@@ -272,7 +281,7 @@ export function SliderControl({
     [submitValue, value, precision, step, applyDisplayDelta, onChange, toDisplay],
   )
 
-  const displayValue = toDisplay(value)
+  const displayValue = toDisplay(shown)
 
   return (
     <div
@@ -340,6 +349,13 @@ export function SliderControl({
               </span>
             )}
           </>
+        ) : mixed && !isDragging ? (
+          <div
+            className="flex cursor-text items-center text-muted-foreground transition-colors hover:text-foreground"
+            onClick={handleValueClick}
+          >
+            <span className="font-mono tracking-tight">Mixed</span>
+          </div>
         ) : (
           <div
             className="flex cursor-text items-center text-foreground/60 transition-colors hover:text-foreground"

--- a/packages/editor/src/components/ui/controls/toggle-control.tsx
+++ b/packages/editor/src/components/ui/controls/toggle-control.tsx
@@ -8,9 +8,16 @@ interface ToggleControlProps {
   checked: boolean
   onChange: (checked: boolean) => void
   className?: string
+  mixed?: boolean
 }
 
-export function ToggleControl({ label, checked, onChange, className }: ToggleControlProps) {
+export function ToggleControl({
+  label,
+  checked,
+  onChange,
+  className,
+  mixed = false,
+}: ToggleControlProps) {
   return (
     <div
       className={cn(
@@ -26,12 +33,18 @@ export function ToggleControl({ label, checked, onChange, className }: ToggleCon
       <div
         className={cn(
           'flex h-5 w-5 items-center justify-center rounded-[4px] border transition-all duration-200',
-          checked
-            ? 'border-primary bg-primary text-primary-foreground'
-            : 'border-border bg-black/20 text-transparent group-hover:border-muted-foreground',
+          mixed
+            ? 'border-muted-foreground/70 bg-black/20 text-muted-foreground'
+            : checked
+              ? 'border-primary bg-primary text-primary-foreground'
+              : 'border-border bg-black/20 text-transparent group-hover:border-muted-foreground',
         )}
       >
-        <Check className="h-3.5 w-3.5" strokeWidth={3} />
+        {mixed ? (
+          <div className="h-0.5 w-2.5 rounded-full bg-current" />
+        ) : (
+          <Check className="h-3.5 w-3.5" strokeWidth={3} />
+        )}
       </div>
     </div>
   )

--- a/packages/editor/src/components/ui/panels/homogeneous-selection.test.ts
+++ b/packages/editor/src/components/ui/panels/homogeneous-selection.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+import type { AnyNode, AnyNodeId } from '@pascal-app/core'
+import {
+  resolveHomogeneousSelection,
+  resolveUniqueSelectionIds,
+} from './homogeneous-selection'
+
+function node(
+  id: string,
+  type: string,
+  metadata?: Record<string, unknown>,
+): AnyNode {
+  return {
+    object: 'node',
+    id: id as AnyNodeId,
+    type,
+    parentId: null,
+    visible: true,
+    metadata: metadata ?? {},
+    children: [],
+  } as unknown as AnyNode
+}
+
+describe('resolveHomogeneousSelection', () => {
+  test('mixed selection is null', () => {
+    const nodes = {
+      wall_a: node('wall_a', 'wall'),
+      slab_a: node('slab_a', 'slab'),
+    }
+    expect(resolveHomogeneousSelection(['wall_a', 'slab_a'], nodes)).toBeNull()
+  })
+
+  test('three walls share the wall type', () => {
+    const nodes = {
+      wall_a: node('wall_a', 'wall'),
+      wall_b: node('wall_b', 'wall'),
+      wall_c: node('wall_c', 'wall'),
+    }
+    expect(resolveHomogeneousSelection(['wall_a', 'wall_b', 'wall_c'], nodes)).toBe('wall')
+  })
+
+  test('proxy-promoted children resolve to the parent type', () => {
+    const nodes = {
+      cabinet_run: node('cabinet_run', 'cabinet'),
+      'cabinet-module_a': node('cabinet-module_a', 'cabinet-module', {
+        nodeSelectionProxyId: 'cabinet_run',
+      }),
+      'cabinet-module_b': node('cabinet-module_b', 'cabinet-module', {
+        nodeSelectionProxyId: 'cabinet_run',
+      }),
+      'cabinet-module_c': node('cabinet-module_c', 'cabinet-module', {
+        nodeSelectionProxyId: 'cabinet_run',
+      }),
+      cabinet_run_b: node('cabinet_run_b', 'cabinet'),
+      'cabinet-module_d': node('cabinet-module_d', 'cabinet-module', {
+        nodeSelectionProxyId: 'cabinet_run_b',
+      }),
+    }
+    expect(resolveHomogeneousSelection(['cabinet-module_a', 'cabinet-module_d'], nodes)).toBe(
+      'cabinet',
+    )
+    expect(resolveUniqueSelectionIds(['cabinet-module_a', 'cabinet-module_b', 'cabinet-module_c'], nodes)).toEqual(
+      ['cabinet_run'],
+    )
+    expect(resolveHomogeneousSelection(['cabinet-module_a', 'cabinet-module_b'], nodes)).toBeNull()
+  })
+
+  test('stale ids are skipped without breaking a homogeneous remainder', () => {
+    const nodes = {
+      wall_a: node('wall_a', 'wall'),
+      wall_b: node('wall_b', 'wall'),
+    }
+    expect(resolveHomogeneousSelection(['wall_a', 'gone', 'wall_b'], nodes)).toBe('wall')
+  })
+
+  test('a single live node after skips is not homogeneous', () => {
+    const nodes = { wall_a: node('wall_a', 'wall') }
+    expect(resolveHomogeneousSelection(['wall_a', 'gone'], nodes)).toBeNull()
+  })
+})

--- a/packages/editor/src/components/ui/panels/homogeneous-selection.ts
+++ b/packages/editor/src/components/ui/panels/homogeneous-selection.ts
@@ -1,0 +1,48 @@
+import {
+  type AnyNode,
+  type AnyNodeId,
+  resolveSelectionProxyId,
+} from '@pascal-app/core'
+
+/**
+ * Resolve selection proxies and drop duplicates / missing ids. Session groups
+ * are just selections — mixed-type groups stay mixed after this pass, and a
+ * pair of children that both proxy to the same parent collapse to one id.
+ */
+export function resolveUniqueSelectionIds(
+  ids: readonly string[],
+  nodes: Readonly<Record<string, AnyNode | undefined>>,
+): AnyNodeId[] {
+  const resolved: AnyNodeId[] = []
+  const seen = new Set<string>()
+  for (const id of ids) {
+    const node = nodes[id]
+    if (!node) continue
+    const resolvedId = resolveSelectionProxyId(node, nodes)
+    if (seen.has(resolvedId)) continue
+    seen.add(resolvedId)
+    resolved.push(resolvedId)
+  }
+  return resolved
+}
+
+/**
+ * Shared type when every resolved id is the same kind and at least two nodes
+ * remain. Otherwise null — including mixed session groups and proxy-collapsed
+ * selections that shrink below two distinct nodes.
+ */
+export function resolveHomogeneousSelection(
+  ids: readonly string[],
+  nodes: Readonly<Record<string, AnyNode | undefined>>,
+): AnyNode['type'] | null {
+  const resolvedIds = resolveUniqueSelectionIds(ids, nodes)
+  if (resolvedIds.length < 2) return null
+  const first = nodes[resolvedIds[0] ?? '']
+  if (!first) return null
+  for (let i = 1; i < resolvedIds.length; i++) {
+    const node = nodes[resolvedIds[i] ?? '']
+    if (!node || node.type !== first.type) return null
+  }
+  return first.type
+}
+

--- a/packages/editor/src/components/ui/panels/mobile-selection-bar.tsx
+++ b/packages/editor/src/components/ui/panels/mobile-selection-bar.tsx
@@ -8,7 +8,9 @@ import { cn } from '../../../lib/utils'
 import { getNodeDisplay } from './node-display'
 
 interface MobileSelectionBarProps {
-  node: AnyNode
+  node: AnyNode | null
+  label?: string
+  icon?: string
   onMove: () => void
   onDuplicate: () => void
   onDelete: () => void
@@ -20,19 +22,23 @@ const ACTION_BTN =
 
 export function MobileSelectionBar({
   node,
+  label,
+  icon,
   onMove,
   onDuplicate,
   onDelete,
   onEdit,
 }: MobileSelectionBarProps) {
-  const { icon, label } = getNodeDisplay(node)
+  const display = getNodeDisplay(node)
+  const resolvedLabel = label ?? display.label
+  const resolvedIcon = icon ?? display.icon
 
   const stop: MouseEventHandler<HTMLButtonElement> = (e) => e.stopPropagation()
 
   return (
     <div className="pointer-events-auto absolute right-3 bottom-6 left-3 z-50 flex h-12 items-stretch gap-1 rounded-2xl border border-border/50 bg-background/95 px-2 shadow-2xl backdrop-blur-xl">
       <button
-        aria-label={`Edit ${label}`}
+        aria-label={`Edit ${resolvedLabel}`}
         className={cn(
           'flex min-w-0 flex-1 items-center gap-2 rounded-lg px-2 text-left transition-colors hover:bg-white/8',
         )}
@@ -43,10 +49,10 @@ export function MobileSelectionBar({
           alt=""
           className="shrink-0 rounded object-contain"
           height={20}
-          src={icon}
+          src={resolvedIcon}
           width={20}
         />
-        <span className="truncate font-medium text-foreground text-sm">{label}</span>
+        <span className="truncate font-medium text-foreground text-sm">{resolvedLabel}</span>
       </button>
 
       <div className="flex items-center gap-0.5 border-border/40 border-l pl-1">

--- a/packages/editor/src/components/ui/panels/multi-field-value.test.ts
+++ b/packages/editor/src/components/ui/panels/multi-field-value.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  type AnyNode,
+  type AnyNodeId,
+  BuildingNode,
+  clearSceneHistory,
+  LevelNode,
+  useLiveNodeOverrides,
+  useScene,
+  WallNode,
+} from '@pascal-app/core'
+import {
+  buildMultiNodePatches,
+  commitMultiNodeFields,
+  fieldVisibleForAll,
+  reduceFieldValue,
+  reduceHeightBoundMode,
+} from './multi-field-value'
+
+type RafFn = (cb: (time: number) => void) => number
+;(globalThis as unknown as { requestAnimationFrame?: RafFn }).requestAnimationFrame ??= (cb) => {
+  cb(0)
+  return 0
+}
+;(globalThis as unknown as { cancelAnimationFrame?: (id: number) => void }).cancelAnimationFrame ??=
+  () => {}
+
+const BUILDING_ID = 'building_multi_edit' as AnyNodeId
+const LEVEL_ID = 'level_multi_edit' as AnyNodeId
+const WALL_A = 'wall_multi_a' as AnyNodeId
+const WALL_B = 'wall_multi_b' as AnyNodeId
+const WALL_C = 'wall_multi_c' as AnyNodeId
+
+function makeNode(id: string, type: string, fields: Record<string, unknown> = {}): AnyNode {
+  return {
+    object: 'node',
+    id: id as AnyNodeId,
+    type,
+    parentId: null,
+    visible: true,
+    metadata: {},
+    children: [],
+    ...fields,
+  } as unknown as AnyNode
+}
+
+describe('reduceFieldValue', () => {
+  test('same values collapse to one', () => {
+    const nodes = {
+      a: makeNode('a', 'wall', { height: 2.4, thickness: 0.2 }),
+      b: makeNode('b', 'wall', { height: 2.4, thickness: 0.15 }),
+    }
+    expect(reduceFieldValue(['a', 'b'], 'height', nodes)).toEqual({ kind: 'same', value: 2.4 })
+    expect(reduceFieldValue(['a', 'b'], 'thickness', nodes)).toEqual({ kind: 'mixed' })
+  })
+
+  test('vec3 compares elementwise', () => {
+    const nodes = {
+      a: makeNode('a', 'item', { position: [1, 0, 2] }),
+      b: makeNode('b', 'item', { position: [1, 0, 2] }),
+      c: makeNode('c', 'item', { position: [1, 0, 3] }),
+    }
+    expect(reduceFieldValue(['a', 'b'], 'position', nodes)).toEqual({
+      kind: 'same',
+      value: [1, 0, 2],
+    })
+    expect(reduceFieldValue(['a', 'c'], 'position', nodes)).toEqual({ kind: 'mixed' })
+  })
+})
+
+describe('reduceHeightBoundMode', () => {
+  test('absent height is follows-level, present height is custom', () => {
+    const nodes = {
+      a: makeNode('a', 'wall'),
+      b: makeNode('b', 'wall'),
+      c: makeNode('c', 'wall', { height: 3 }),
+    }
+    expect(reduceHeightBoundMode(['a', 'b'], nodes)).toEqual({ kind: 'same', value: 'storey' })
+    expect(reduceHeightBoundMode(['c'], nodes)).toEqual({ kind: 'same', value: 'custom' })
+    expect(reduceHeightBoundMode(['a', 'c'], nodes)).toEqual({ kind: 'mixed' })
+  })
+})
+
+describe('fieldVisibleForAll', () => {
+  test('hides when any node would hide the field', () => {
+    const nodes = {
+      a: makeNode('a', 'slab', { recessed: false }),
+      b: makeNode('b', 'slab', { recessed: true }),
+    }
+    const visibleIf = (n: AnyNode) => !(n as { recessed?: boolean }).recessed
+    expect(fieldVisibleForAll(['a'], visibleIf, nodes)).toBe(true)
+    expect(fieldVisibleForAll(['a', 'b'], visibleIf, nodes)).toBe(false)
+  })
+})
+
+describe('buildMultiNodePatches', () => {
+  test('a mixed field that is never edited produces no patch for it', () => {
+    const nodes = {
+      a: makeNode('a', 'wall', { height: 2.4, thickness: 0.2 }),
+      b: makeNode('b', 'wall', { height: 3, thickness: 0.15 }),
+    }
+    const patches = buildMultiNodePatches(
+      ['a' as AnyNodeId, 'b' as AnyNodeId],
+      () => ({ thickness: 0.3 }),
+      nodes,
+    )
+    expect(patches).toEqual([
+      { id: 'a' as AnyNodeId, data: { thickness: 0.3 } },
+      { id: 'b' as AnyNodeId, data: { thickness: 0.3 } },
+    ])
+    for (const patch of patches) {
+      expect(patch.data).not.toHaveProperty('height')
+    }
+  })
+
+  test('derive and reconcile fan out per node into one batch', () => {
+    const nodes = {
+      a: makeNode('a', 'wall', { height: 2 }),
+      b: makeNode('b', 'wall', { height: 2 }),
+    }
+    const patches = buildMultiNodePatches(
+      ['a' as AnyNodeId, 'b' as AnyNodeId],
+      () => ({ height: 4 }),
+      nodes,
+      {
+        derive: (next) => ({ thickness: (next as { height: number }).height / 10 }),
+        reconcile: (prev) => [
+          { id: `${prev.id}_follow` as AnyNodeId, data: { height: 4 } },
+        ],
+      },
+    )
+    expect(patches).toEqual([
+      { id: 'a' as AnyNodeId, data: { height: 4, thickness: 0.4 } },
+      { id: 'b' as AnyNodeId, data: { height: 4, thickness: 0.4 } },
+      { id: 'a_follow' as AnyNodeId, data: { height: 4 } },
+      { id: 'b_follow' as AnyNodeId, data: { height: 4 } },
+    ])
+  })
+})
+
+describe('commitMultiNodeFields', () => {
+  beforeEach(() => {
+    const wallA = WallNode.parse({
+      id: WALL_A,
+      parentId: LEVEL_ID,
+      start: [0, 0],
+      end: [4, 0],
+      height: 2.4,
+    })
+    const wallB = WallNode.parse({
+      id: WALL_B,
+      parentId: LEVEL_ID,
+      start: [4, 0],
+      end: [4, 3],
+      height: 3,
+    })
+    const wallC = WallNode.parse({
+      id: WALL_C,
+      parentId: LEVEL_ID,
+      start: [4, 3],
+      end: [0, 3],
+      height: 2.7,
+    })
+    const level = LevelNode.parse({
+      id: LEVEL_ID,
+      parentId: BUILDING_ID,
+      children: [WALL_A, WALL_B, WALL_C],
+      level: 0,
+    })
+    const building = BuildingNode.parse({
+      id: BUILDING_ID,
+      parentId: null,
+      children: [LEVEL_ID],
+    })
+    useScene.setState({
+      nodes: {
+        [BUILDING_ID]: building,
+        [LEVEL_ID]: level,
+        [WALL_A]: wallA,
+        [WALL_B]: wallB,
+        [WALL_C]: wallC,
+      },
+      rootNodeIds: [BUILDING_ID],
+      dirtyNodes: new Set<AnyNodeId>(),
+      collections: {},
+      materials: {},
+      readOnly: false,
+    } as never)
+    clearSceneHistory()
+    useLiveNodeOverrides.getState().clearAll()
+  })
+
+  afterEach(() => {
+    useLiveNodeOverrides.getState().clearAll()
+  })
+
+  test('dragging height onto three walls is one undo step', () => {
+    commitMultiNodeFields([WALL_A, WALL_B, WALL_C], () => ({ height: 4 }))
+    expect((useScene.getState().nodes[WALL_A] as { height?: number }).height).toBe(4)
+    expect((useScene.getState().nodes[WALL_B] as { height?: number }).height).toBe(4)
+    expect((useScene.getState().nodes[WALL_C] as { height?: number }).height).toBe(4)
+    expect(useScene.temporal.getState().pastStates).toHaveLength(1)
+
+    useScene.temporal.getState().undo()
+    expect((useScene.getState().nodes[WALL_A] as { height?: number }).height).toBe(2.4)
+    expect((useScene.getState().nodes[WALL_B] as { height?: number }).height).toBe(3)
+    expect((useScene.getState().nodes[WALL_C] as { height?: number }).height).toBe(2.7)
+  })
+})

--- a/packages/editor/src/components/ui/panels/multi-field-value.ts
+++ b/packages/editor/src/components/ui/panels/multi-field-value.ts
@@ -1,0 +1,163 @@
+import {
+  type AnyNode,
+  type AnyNodeId,
+  type ParametricDescriptor,
+  useLiveNodeOverrides,
+  useScene,
+} from '@pascal-app/core'
+
+export type ReducedFieldValue<T = unknown> =
+  | { kind: 'same'; value: T }
+  | { kind: 'mixed' }
+
+const MIXED: { kind: 'mixed' } = { kind: 'mixed' }
+
+function fieldValuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true
+  if (Array.isArray(a) && Array.isArray(b) && a.length === b.length) {
+    return a.every((value, i) => Object.is(value, b[i]))
+  }
+  return false
+}
+
+export function reduceFieldValue(
+  nodeIds: readonly string[],
+  key: string,
+  nodes: Readonly<Record<string, AnyNode | undefined>>,
+): ReducedFieldValue {
+  let seen = false
+  let shared: unknown
+  for (const id of nodeIds) {
+    const node = nodes[id]
+    if (!node) continue
+    const value = (node as Record<string, unknown>)[key]
+    if (!seen) {
+      seen = true
+      shared = value
+      continue
+    }
+    if (!fieldValuesEqual(shared, value)) return MIXED
+  }
+  if (!seen) return MIXED
+  return { kind: 'same', value: shared }
+}
+
+export type HeightBoundMode = 'storey' | 'custom'
+
+export function reduceHeightBoundMode(
+  nodeIds: readonly string[],
+  nodes: Readonly<Record<string, AnyNode | undefined>>,
+): ReducedFieldValue<HeightBoundMode> {
+  let seen = false
+  let shared: HeightBoundMode | undefined
+  for (const id of nodeIds) {
+    const node = nodes[id]
+    if (!node) continue
+    const mode: HeightBoundMode = (node as { height?: number }).height == null ? 'storey' : 'custom'
+    if (!seen) {
+      seen = true
+      shared = mode
+      continue
+    }
+    if (mode !== shared) return MIXED
+  }
+  if (!seen || !shared) return MIXED
+  return { kind: 'same', value: shared }
+}
+
+export function fieldVisibleForAll(
+  nodeIds: readonly string[],
+  visibleIf: ((node: AnyNode) => boolean) | undefined,
+  nodes: Readonly<Record<string, AnyNode | undefined>>,
+): boolean {
+  if (!visibleIf) return true
+  for (const id of nodeIds) {
+    const node = nodes[id]
+    if (!node || !visibleIf(node)) return false
+  }
+  return true
+}
+
+export function firstNumericFieldValue(
+  nodeIds: readonly string[],
+  key: string,
+  nodes: Readonly<Record<string, AnyNode | undefined>>,
+  fallback = 0,
+): number {
+  for (const id of nodeIds) {
+    const node = nodes[id]
+    const value = node ? (node as Record<string, unknown>)[key] : undefined
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return fallback
+}
+
+export function firstVec3FieldValue(
+  nodeIds: readonly string[],
+  key: string,
+  nodes: Readonly<Record<string, AnyNode | undefined>>,
+): [number, number, number] {
+  for (const id of nodeIds) {
+    const node = nodes[id]
+    const value = node ? (node as Record<string, unknown>)[key] : undefined
+    if (Array.isArray(value) && value.length >= 3) {
+      return [Number(value[0]) || 0, Number(value[1]) || 0, Number(value[2]) || 0]
+    }
+  }
+  return [0, 0, 0]
+}
+
+export function buildMultiNodePatches(
+  nodeIds: readonly AnyNodeId[],
+  patchFor: (node: AnyNode) => Partial<AnyNode>,
+  nodes: Readonly<Record<string, AnyNode | undefined>>,
+  parametrics?: Pick<ParametricDescriptor<AnyNode>, 'derive' | 'reconcile'>,
+): Array<{ id: AnyNodeId; data: Partial<AnyNode> }> {
+  const updates: Array<{ id: AnyNodeId; data: Partial<AnyNode> }> = []
+  const followUps: Array<{ id: AnyNodeId; data: Partial<AnyNode> }> = []
+  for (const id of nodeIds) {
+    const node = nodes[id]
+    if (!node) continue
+    let patch = patchFor(node)
+    if (Object.keys(patch).length === 0) continue
+    if (parametrics?.derive) {
+      const next = { ...node, ...patch } as AnyNode
+      patch = { ...patch, ...parametrics.derive(next, patch) } as Partial<AnyNode>
+    }
+    updates.push({ id, data: patch })
+    if (parametrics?.reconcile) {
+      const next = { ...node, ...patch } as AnyNode
+      followUps.push(...parametrics.reconcile(node, next))
+    }
+  }
+  return [...updates, ...followUps]
+}
+
+export function previewMultiNodeFields(
+  entries: ReadonlyArray<readonly [AnyNodeId, Partial<AnyNode>]>,
+): void {
+  if (entries.length === 0) return
+  useLiveNodeOverrides.getState().setMany(entries)
+  const scene = useScene.getState()
+  for (const [id] of entries) scene.markDirty(id)
+}
+
+export function commitMultiNodeFields(
+  nodeIds: readonly AnyNodeId[],
+  patchFor: (node: AnyNode) => Partial<AnyNode>,
+  parametrics?: Pick<ParametricDescriptor<AnyNode>, 'derive' | 'reconcile'>,
+): void {
+  const scene = useScene.getState()
+  const patches = buildMultiNodePatches(nodeIds, patchFor, scene.nodes, parametrics)
+  const keys = new Set<string>()
+  for (const patch of patches) {
+    for (const key of Object.keys(patch.data)) keys.add(key)
+  }
+  const live = useLiveNodeOverrides.getState()
+  const keyList = [...keys]
+  for (const id of nodeIds) {
+    if (keyList.length > 0) live.clearFields(id, keyList)
+    scene.markDirty(id)
+  }
+  if (patches.length > 0) scene.updateNodes(patches)
+}

--- a/packages/editor/src/components/ui/panels/multi-height-mode.tsx
+++ b/packages/editor/src/components/ui/panels/multi-height-mode.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import {
+  type AnyNode,
+  type AnyNodeId,
+  type CeilingNode,
+  type ParametricDescriptor,
+  GROUND_SUPPORT_ID,
+  getCeilingClampBound,
+  getWallEffectiveHeightForNodes,
+  resolveCeilingHeight,
+  terrainSupportLift,
+  useScene,
+  type WallNode,
+} from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
+import { useCallback } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { formatLinearMeasurement } from '../../../lib/measurements'
+import { SegmentedControl } from '../controls/segmented-control'
+import { SliderControl } from '../controls/slider-control'
+import {
+  commitMultiNodeFields,
+  firstNumericFieldValue,
+  previewMultiNodeFields,
+  reduceFieldValue,
+  reduceHeightBoundMode,
+} from './multi-field-value'
+import { precisionForStep } from './parametric-field-utils'
+
+function wallFollowsLevelPatch(wall: WallNode, nodes: Record<string, AnyNode>): Partial<WallNode> {
+  const terrainSupported =
+    wall.parentId != null &&
+    terrainSupportLift(nodes, wall.parentId, wall.start[0], wall.start[1]) != null
+  return {
+    height: undefined,
+    supportOffset: undefined,
+    ...(wall.supportSlabId === GROUND_SUPPORT_ID && !terrainSupported
+      ? { supportSlabId: undefined }
+      : {}),
+  }
+}
+
+function effectiveHeight(node: AnyNode, nodes: Record<string, AnyNode>): number {
+  if (node.type === 'wall') return getWallEffectiveHeightForNodes(node, nodes)
+  if (node.type === 'ceiling') return resolveCeilingHeight(node, nodes)
+  const height = (node as { height?: number }).height
+  return typeof height === 'number' ? height : 0
+}
+
+function ceilingCustomHeight(node: CeilingNode, nodes: Record<string, AnyNode>): number {
+  const resolved = resolveCeilingHeight(node, nodes)
+  const parent = node.parentId ? nodes[node.parentId] : undefined
+  const max =
+    parent?.type === 'level'
+      ? getCeilingClampBound(parent.id, nodes as Record<AnyNodeId, AnyNode>, node.polygon ?? [])
+      : Number.POSITIVE_INFINITY
+  return Math.min(resolved, max)
+}
+
+export function MultiHeightModeField({
+  nodeIds,
+  nodeType,
+  parametrics,
+  min = 1.5,
+  max = 20,
+  step = 0.05,
+}: {
+  nodeIds: AnyNodeId[]
+  nodeType: 'wall' | 'ceiling'
+  parametrics: ParametricDescriptor<AnyNode>
+  min?: number
+  max?: number
+  step?: number
+}) {
+  const unit = useViewer((s) => s.unit)
+  const metricNotation = useViewer((s) => s.metricNotation)
+  const mode = useScene(useShallow((s) => reduceHeightBoundMode(nodeIds, s.nodes)))
+  const storedHeight = useScene(useShallow((s) => reduceFieldValue(nodeIds, 'height', s.nodes)))
+  const heightOrigin = useScene((s) => firstNumericFieldValue(nodeIds, 'height', s.nodes, min))
+  const liveHeight = useScene((s) => {
+    let seen = false
+    let shared: number | undefined
+    for (const id of nodeIds) {
+      const node = s.nodes[id]
+      if (!node) continue
+      const height = effectiveHeight(node, s.nodes as Record<string, AnyNode>)
+      if (!seen) {
+        seen = true
+        shared = height
+        continue
+      }
+      if (!Object.is(shared, height)) return Number.NaN
+    }
+    return seen && shared !== undefined ? shared : Number.NaN
+  })
+
+  const applyMode = useCallback(
+    (next: 'storey' | 'custom') => {
+      const nodes = useScene.getState().nodes as Record<string, AnyNode>
+      commitMultiNodeFields(
+        nodeIds,
+        (node) => {
+          const isCustom = (node as { height?: number }).height != null
+          if (next === 'custom') {
+            if (isCustom) return {}
+            if (node.type === 'ceiling') {
+              return { height: ceilingCustomHeight(node, nodes) }
+            }
+            if (node.type === 'wall') {
+              return { height: Math.max(0.1, getWallEffectiveHeightForNodes(node, nodes)) }
+            }
+            return {}
+          }
+          if (!isCustom) return {}
+          if (node.type === 'wall') return wallFollowsLevelPatch(node, nodes)
+          return { height: undefined }
+        },
+        parametrics,
+      )
+    },
+    [nodeIds, parametrics],
+  )
+
+  const previewHeight = useCallback(
+    (height: number) => {
+      previewMultiNodeFields(nodeIds.map((id) => [id, { height }] as const))
+    },
+    [nodeIds],
+  )
+  const commitHeight = useCallback(
+    (height: number) => {
+      commitMultiNodeFields(nodeIds, () => ({ height }), parametrics)
+    },
+    [nodeIds, parametrics],
+  )
+
+  const mixedMode = mode.kind === 'mixed'
+  const isFollows = mode.kind === 'same' && mode.value === 'storey'
+  const isCustom = mode.kind === 'same' && mode.value === 'custom'
+  const sliderValue =
+    storedHeight.kind === 'same' && typeof storedHeight.value === 'number'
+      ? storedHeight.value
+      : heightOrigin
+  const sliderMixed = storedHeight.kind === 'mixed' || mixedMode
+  const currentLabel = Number.isFinite(liveHeight)
+    ? formatLinearMeasurement(liveHeight, unit, metricNotation)
+    : 'Mixed'
+
+  return (
+    <>
+      {nodeType === 'wall' && (
+        <div className="px-1 font-medium text-[10px] text-muted-foreground/80 uppercase tracking-wider">
+          Top
+        </div>
+      )}
+      <SegmentedControl
+        mixed={mixedMode}
+        onChange={applyMode}
+        options={[
+          { label: 'Follows level', value: 'storey' },
+          { label: 'Custom height', value: 'custom' },
+        ]}
+        value={mode.kind === 'same' ? mode.value : 'storey'}
+      />
+      {isFollows ? (
+        <div className="px-1 text-[11px] text-muted-foreground">Currently {currentLabel}</div>
+      ) : isCustom ? (
+        <SliderControl
+          label="Height"
+          max={max}
+          min={min}
+          mixed={sliderMixed}
+          onChange={previewHeight}
+          onCommit={commitHeight}
+          precision={precisionForStep(step)}
+          restoreOnCommit={false}
+          step={step}
+          unit="m"
+          value={sliderValue}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/packages/editor/src/components/ui/panels/multi-parametric-inspector.tsx
+++ b/packages/editor/src/components/ui/panels/multi-parametric-inspector.tsx
@@ -1,0 +1,265 @@
+'use client'
+
+import {
+  type AnyNode,
+  type AnyNodeId,
+  nodeRegistry,
+  type ParamField,
+  type ParametricDescriptor,
+  useScene,
+} from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
+import { useCallback, useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { selectionMatchesSessionGroup } from '../../../lib/session-groups'
+import useSessionGroups from '../../../store/use-session-groups'
+import { PanelSection } from '../controls/panel-section'
+import { SliderControl } from '../controls/slider-control'
+import { resolveUniqueSelectionIds } from './homogeneous-selection'
+import {
+  commitMultiNodeFields,
+  fieldVisibleForAll,
+  firstNumericFieldValue,
+  firstVec3FieldValue,
+  previewMultiNodeFields,
+  reduceFieldValue,
+} from './multi-field-value'
+import { MultiHeightModeField } from './multi-height-mode'
+import { MultiSelectionActions } from './multi-selection-panel'
+import { getTypeDisplay } from './node-display'
+import { ParametricFieldControl } from './parametric-field-control'
+import { PanelWrapper } from './panel-wrapper'
+import { formatSelectionBreakdown } from './selection-breakdown'
+
+export function MultiParametricInspector({ footer }: { footer?: React.ReactNode }) {
+  const selectedIds = useViewer((s) => s.selection.selectedIds)
+  const setSelection = useViewer((s) => s.setSelection)
+  const nodeIds = useScene(
+    useShallow((s) => resolveUniqueSelectionIds(selectedIds, s.nodes)),
+  )
+  const nodeType = useScene((s) => {
+    const first = nodeIds[0] ? s.nodes[nodeIds[0]] : undefined
+    return first?.type ?? null
+  })
+  const breakdown = useScene((s) =>
+    formatSelectionBreakdown(nodeIds.map((id) => s.nodes[id]?.type)),
+  )
+  const sessionGroups = useSessionGroups((s) => s.groups)
+  const matchedGroup = useMemo(
+    () => selectionMatchesSessionGroup(sessionGroups, selectedIds),
+    [sessionGroups, selectedIds],
+  )
+
+  const def = nodeType ? nodeRegistry.get(nodeType) : undefined
+  const parametrics = def?.parametrics as ParametricDescriptor<AnyNode> | undefined
+
+  const handleClose = useCallback(() => {
+    setSelection({ selectedIds: [] })
+  }, [setSelection])
+
+  if (nodeIds.length < 2 || !nodeType || !parametrics) return null
+
+  const display = getTypeDisplay(nodeType)
+  const title = matchedGroup ? `${matchedGroup.label} · ${breakdown}` : breakdown || display.label
+
+  return (
+    <PanelWrapper footer={footer} icon={display.icon} onClose={handleClose} title={title} width={320}>
+      {matchedGroup && (
+        <div className="border-border/50 border-b px-3 py-2 text-muted-foreground text-xs">
+          {matchedGroup.label} (session only). Plain click reselects all members. Not saved with the
+          project.
+        </div>
+      )}
+      {parametrics.groups.map((group, gi) => (
+        <MultiGroupFields
+          fields={group.fields as ParamField<AnyNode>[]}
+          key={`group-${gi}`}
+          nodeIds={nodeIds}
+          nodeType={nodeType}
+          parametrics={parametrics}
+          title={group.label}
+        />
+      ))}
+      <div className="border-border/50 border-t p-3">
+        <MultiSelectionActions />
+      </div>
+    </PanelWrapper>
+  )
+}
+
+function MultiGroupFields({
+  title,
+  fields,
+  nodeIds,
+  nodeType,
+  parametrics,
+}: {
+  title: string
+  fields: ParamField<AnyNode>[]
+  nodeIds: AnyNodeId[]
+  nodeType: AnyNode['type']
+  parametrics: ParametricDescriptor<AnyNode>
+}) {
+  const genericFields = fields.filter((field) => field.kind !== 'custom')
+  const anyVisible = useScene((s) =>
+    genericFields.some((field) =>
+      fieldVisibleForAll(nodeIds, (field as { visibleIf?: (n: AnyNode) => boolean }).visibleIf, s.nodes),
+    ),
+  )
+  if (genericFields.length === 0 || !anyVisible) return null
+  return (
+    <PanelSection title={title}>
+      {genericFields.map((field, fi) => {
+        if (
+          String(field.key) === 'height' &&
+          (nodeType === 'wall' || nodeType === 'ceiling') &&
+          field.kind === 'number'
+        ) {
+          return (
+            <MultiHeightModeField
+              key={`field-${fi}-height-mode`}
+              max={field.max}
+              min={field.min}
+              nodeIds={nodeIds}
+              nodeType={nodeType}
+              parametrics={parametrics}
+              step={field.step}
+            />
+          )
+        }
+        return (
+          <MultiFieldRenderer
+            field={field}
+            key={`field-${fi}-${String(field.key)}`}
+            nodeIds={nodeIds}
+            parametrics={parametrics}
+          />
+        )
+      })}
+    </PanelSection>
+  )
+}
+
+function MultiFieldRenderer({
+  field,
+  nodeIds,
+  parametrics,
+}: {
+  field: ParamField<AnyNode>
+  nodeIds: AnyNodeId[]
+  parametrics: ParametricDescriptor<AnyNode>
+}) {
+  const key = String(field.key)
+  const visible = useScene((s) =>
+    fieldVisibleForAll(nodeIds, (field as { visibleIf?: (n: AnyNode) => boolean }).visibleIf, s.nodes),
+  )
+  const reduced = useScene(useShallow((s) => reduceFieldValue(nodeIds, key, s.nodes)))
+  const numericOrigin = useScene((s) => firstNumericFieldValue(nodeIds, key, s.nodes))
+  const vecOrigin = useScene(useShallow((s) => firstVec3FieldValue(nodeIds, key, s.nodes)))
+
+  const preview = useCallback(
+    (patch: Partial<AnyNode>) => {
+      previewMultiNodeFields(nodeIds.map((id) => [id, patch] as const))
+    },
+    [nodeIds],
+  )
+  const commit = useCallback(
+    (patch: Partial<AnyNode>) => {
+      commitMultiNodeFields(nodeIds, () => patch, parametrics)
+    },
+    [nodeIds, parametrics],
+  )
+
+  if (!visible) return null
+
+  if (field.kind === 'vec3') {
+    return (
+      <MultiVec3Field
+        fieldKey={key}
+        mixed={reduced.kind === 'mixed'}
+        nodeIds={nodeIds}
+        origin={vecOrigin}
+        parametrics={parametrics}
+        value={reduced.kind === 'same' && Array.isArray(reduced.value) ? (reduced.value as [number, number, number]) : vecOrigin}
+      />
+    )
+  }
+
+  const value =
+    reduced.kind === 'same' ? reduced.value : field.kind === 'number' ? numericOrigin : undefined
+
+  return (
+    <ParametricFieldControl
+      field={field}
+      mixed={reduced.kind === 'mixed'}
+      onChange={field.kind === 'number' ? preview : commit}
+      onCommit={field.kind === 'number' ? commit : undefined}
+      value={value}
+    />
+  )
+}
+
+function MultiVec3Field({
+  fieldKey,
+  mixed,
+  nodeIds,
+  origin,
+  parametrics,
+  value,
+}: {
+  fieldKey: string
+  mixed: boolean
+  nodeIds: AnyNodeId[]
+  origin: [number, number, number]
+  parametrics: ParametricDescriptor<AnyNode>
+  value: [number, number, number]
+}) {
+  const axes: Array<{ label: string; index: 0 | 1 | 2 }> = [
+    { label: 'X', index: 0 },
+    { label: 'Y', index: 1 },
+    { label: 'Z', index: 2 },
+  ]
+  return (
+    <>
+      {axes.map(({ label, index }) => {
+        const axisValue = value[index] ?? origin[index] ?? 0
+        const patchAxis = (next: number): Array<readonly [AnyNodeId, Partial<AnyNode>]> => {
+          const nodes = useScene.getState().nodes
+          return nodeIds.flatMap((id) => {
+            const node = nodes[id]
+            if (!node) return []
+            const current = (node as Record<string, unknown>)[fieldKey]
+            const nextVec = (
+              Array.isArray(current) && current.length >= 3 ? [...current] : [...origin]
+            ) as [number, number, number]
+            nextVec[index] = next
+            return [[id, { [fieldKey]: nextVec } as Partial<AnyNode>] as const]
+          })
+        }
+        return (
+          <SliderControl
+            key={`${fieldKey}-${label}`}
+            label={label}
+            max={axisValue + 5}
+            min={axisValue - 5}
+            mixed={mixed}
+            onChange={(next) => previewMultiNodeFields(patchAxis(next))}
+            onCommit={(next) => {
+              const entries = patchAxis(next)
+              commitMultiNodeFields(
+                nodeIds,
+                (node) => entries.find(([id]) => id === node.id)?.[1] ?? {},
+                parametrics,
+              )
+            }}
+            precision={2}
+            restoreOnCommit={false}
+            step={0.05}
+            unit="m"
+            value={Math.round(axisValue * 100) / 100}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/packages/editor/src/components/ui/panels/multi-selection-panel.tsx
+++ b/packages/editor/src/components/ui/panels/multi-selection-panel.tsx
@@ -18,6 +18,53 @@ import { ActionButton, ActionGroup } from '../controls/action-button'
 import { PanelWrapper } from './panel-wrapper'
 import { formatSelectionBreakdown } from './selection-breakdown'
 
+export function MultiSelectionActions() {
+  const selectedIds = useViewer((s) => s.selection.selectedIds)
+  const sessionGroups = useSessionGroups((s) => s.groups)
+  const sceneNodes = useScene((s) => s.nodes)
+  const liveIds = useMemo(() => new Set(Object.keys(sceneNodes)), [sceneNodes])
+  const showGroup = useMemo(
+    () => canCreateSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
+  )
+  const showUngroup = useMemo(
+    () => selectionIntersectsSessionGroup(sessionGroups, selectedIds, liveIds),
+    [sessionGroups, selectedIds, liveIds],
+  )
+
+  return (
+    <ActionGroup>
+      {showGroup && (
+        <ActionButton
+          icon={<Group className="h-4 w-4" />}
+          label="Group"
+          onClick={() => groupCurrentSelection()}
+          title="Group (Ctrl/Cmd+G)"
+        />
+      )}
+      {showUngroup && (
+        <ActionButton
+          icon={<Ungroup className="h-4 w-4" />}
+          label="Ungroup"
+          onClick={() => ungroupCurrentSelection()}
+          title="Ungroup (Ctrl/Cmd+Shift+G)"
+        />
+      )}
+      <ActionButton
+        icon={<Copy className="h-4 w-4" />}
+        label="Duplicate"
+        onClick={() => duplicateSelectionAndPickUp()}
+      />
+      <ActionButton
+        className="border-red-500/40 text-red-200 hover:bg-red-500/15"
+        icon={<Trash2 className="h-4 w-4 text-red-400" />}
+        label="Delete"
+        onClick={() => deleteSelection()}
+      />
+    </ActionGroup>
+  )
+}
+
 /**
  * Docked multi-selection panel. Includes Group / Ungroup for session selection sets.
  */
@@ -32,14 +79,6 @@ export function MultiSelectionPanel({ footer }: { footer?: React.ReactNode }) {
   const liveIds = useMemo(() => new Set(Object.keys(sceneNodes)), [sceneNodes])
   const matchedGroup = useMemo(
     () => selectionMatchesSessionGroup(sessionGroups, selectedIds, liveIds),
-    [sessionGroups, selectedIds, liveIds],
-  )
-  const showGroup = useMemo(
-    () => canCreateSessionGroup(sessionGroups, selectedIds, liveIds),
-    [sessionGroups, selectedIds, liveIds],
-  )
-  const showUngroup = useMemo(
-    () => selectionIntersectsSessionGroup(sessionGroups, selectedIds, liveIds),
     [sessionGroups, selectedIds, liveIds],
   )
 
@@ -63,35 +102,7 @@ export function MultiSelectionPanel({ footer }: { footer?: React.ReactNode }) {
         </div>
       )}
       <div className="border-border/50 border-t p-3">
-        <ActionGroup>
-          {showGroup && (
-            <ActionButton
-              icon={<Group className="h-4 w-4" />}
-              label="Group"
-              onClick={() => groupCurrentSelection()}
-              title="Group (Ctrl/Cmd+G)"
-            />
-          )}
-          {showUngroup && (
-            <ActionButton
-              icon={<Ungroup className="h-4 w-4" />}
-              label="Ungroup"
-              onClick={() => ungroupCurrentSelection()}
-              title="Ungroup (Ctrl/Cmd+Shift+G)"
-            />
-          )}
-          <ActionButton
-            icon={<Copy className="h-4 w-4" />}
-            label="Duplicate"
-            onClick={() => duplicateSelectionAndPickUp()}
-          />
-          <ActionButton
-            className="border-red-500/40 text-red-200 hover:bg-red-500/15"
-            icon={<Trash2 className="h-4 w-4" />}
-            label="Delete"
-            onClick={() => deleteSelection()}
-          />
-        </ActionGroup>
+        <MultiSelectionActions />
       </div>
     </PanelWrapper>
   )

--- a/packages/editor/src/components/ui/panels/node-display.ts
+++ b/packages/editor/src/components/ui/panels/node-display.ts
@@ -23,6 +23,10 @@ const TYPE_DEFAULTS: Record<string, NodeDisplay> = {
   guide: { icon: '/icons/floorplan.webp', label: 'Guide image' },
 }
 
+export function getTypeDisplay(type: string): NodeDisplay {
+  return TYPE_DEFAULTS[type] ?? { icon: '/icons/select.webp', label: type }
+}
+
 export function getNodeDisplay(node: AnyNode | null | undefined): NodeDisplay {
   if (!node) return { icon: '/icons/select.webp', label: 'Selection' }
   const fallback = TYPE_DEFAULTS[node.type] ?? { icon: '/icons/select.webp', label: node.type }

--- a/packages/editor/src/components/ui/panels/panel-manager.tsx
+++ b/packages/editor/src/components/ui/panels/panel-manager.tsx
@@ -26,13 +26,17 @@ import { useCallback, useEffect, useState } from 'react'
 import { useIsMobile } from '../../../hooks/use-mobile'
 import { sfxEmitter } from '../../../lib/sfx-bus'
 import useEditor from '../../../store/use-editor'
+import { deleteSelection, duplicateSelectionAndPickUp, startGroupPickUp } from '../../editor/group-actions'
+import { resolveHomogeneousSelection } from './homogeneous-selection'
 import { MobilePanelSheet } from './mobile-panel-sheet'
 import { MobileSelectionBar } from './mobile-selection-bar'
+import { MultiParametricInspector } from './multi-parametric-inspector'
 import { MultiSelectionPanel } from './multi-selection-panel'
-import { getNodeDisplay } from './node-display'
+import { getNodeDisplay, getTypeDisplay } from './node-display'
 import { resetDesktopInspectorCollapsed } from './panel-wrapper'
 import { ParametricInspector } from './parametric-inspector'
 import { ReferencePanel } from './reference-panel'
+import { formatSelectionBreakdown } from './selection-breakdown'
 
 type MovableNode =
   | ItemNode
@@ -169,6 +173,46 @@ function MobilePanelLayer({
   )
 }
 
+function MobileMultiPanelLayer({
+  breakdown,
+  panel,
+  type,
+}: {
+  breakdown: string
+  panel: React.ReactNode
+  type: string | null
+}) {
+  const [isSheetOpen, setIsSheetOpen] = useState(false)
+  const display = type ? getTypeDisplay(type) : { icon: '/icons/select.webp', label: 'Selection' }
+  const title = breakdown || display.label
+
+  useEffect(() => {
+    setIsSheetOpen(false)
+  }, [breakdown])
+
+  return (
+    <>
+      <MobileSelectionBar
+        icon={display.icon}
+        label={title}
+        node={null}
+        onDelete={() => deleteSelection()}
+        onDuplicate={() => duplicateSelectionAndPickUp()}
+        onEdit={() => setIsSheetOpen((v) => !v)}
+        onMove={() => startGroupPickUp()}
+      />
+      <MobilePanelSheet
+        icon={display.icon}
+        onClose={() => setIsSheetOpen(false)}
+        open={isSheetOpen}
+        title={title}
+      >
+        {panel}
+      </MobilePanelSheet>
+    </>
+  )
+}
+
 export function PanelManager({
   inspectorFooter,
   multiSelectionFooter,
@@ -193,6 +237,14 @@ export function PanelManager({
     const id = selectedIds[0]
     return id ? (s.nodes[id as AnyNodeId] ?? null) : null
   })
+  const homogeneousType = useScene((s) =>
+    selectedIds.length > 1 ? resolveHomogeneousSelection(selectedIds, s.nodes) : null,
+  )
+  const multiBreakdown = useScene((s) =>
+    selectedIds.length > 1
+      ? formatSelectionBreakdown(selectedIds.map((id) => s.nodes[id as AnyNodeId]?.type))
+      : '',
+  )
 
   // Node and reference selection are mutually exclusive: selecting a guide
   // clears the node selection (handleGuideSelect), but node selection never
@@ -219,6 +271,21 @@ export function PanelManager({
     if (selectedReferenceId) {
       return <MobilePanelLayer isReference={true} node={null} panel={<ReferencePanel />} />
     }
+    if (selectedIds.length > 1) {
+      return (
+        <MobileMultiPanelLayer
+          breakdown={multiBreakdown}
+          panel={
+            homogeneousType ? (
+              <MultiParametricInspector footer={multiSelectionFooter} />
+            ) : (
+              <MultiSelectionPanel footer={multiSelectionFooter} />
+            )
+          }
+          type={homogeneousType}
+        />
+      )
+    }
     return (
       <MobilePanelLayer
         isReference={false}
@@ -244,9 +311,12 @@ export function PanelManager({
     )
   }
 
-  // Multi-selection: compact docked panel (desktop only — the mobile branch
-  // above keeps today's behavior and renders nothing for multi-selections).
+  // Multi-selection: parametric inspector when every resolved id shares a type,
+  // otherwise the actions-only panel. Mobile uses the same panels in a sheet.
   if (selectedIds.length > 1) {
+    if (homogeneousType) {
+      return <MultiParametricInspector footer={multiSelectionFooter} />
+    }
     return <MultiSelectionPanel footer={multiSelectionFooter} />
   }
 

--- a/packages/editor/src/components/ui/panels/parametric-field-control.tsx
+++ b/packages/editor/src/components/ui/panels/parametric-field-control.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import type { AnyNode, ParamField } from '@pascal-app/core'
+import { SegmentedControl } from '../controls/segmented-control'
+import { SliderControl } from '../controls/slider-control'
+import { ToggleControl } from '../controls/toggle-control'
+import { precisionForStep, prettifyEnumValue, prettifyKey } from './parametric-field-utils'
+
+interface ParametricFieldControlProps {
+  field: ParamField<AnyNode>
+  value: unknown
+  mixed?: boolean
+  onChange: (patch: Partial<AnyNode>) => void
+  onCommit?: (patch: Partial<AnyNode>) => void
+}
+
+export function ParametricFieldControl({
+  field,
+  value,
+  mixed = false,
+  onChange,
+  onCommit,
+}: ParametricFieldControlProps) {
+  const key = String(field.key)
+
+  switch (field.kind) {
+    case 'number': {
+      const num = typeof value === 'number' ? value : 0
+      const step = field.step ?? 0.01
+      const precision = precisionForStep(step)
+      return (
+        <SliderControl
+          label={prettifyKey(key)}
+          max={field.max}
+          min={field.min}
+          mixed={mixed}
+          onChange={(next) => onChange({ [key]: next } as Partial<AnyNode>)}
+          onCommit={onCommit ? (next) => onCommit({ [key]: next } as Partial<AnyNode>) : undefined}
+          precision={precision}
+          restoreOnCommit={!onCommit}
+          step={step}
+          unit={field.unit ?? ''}
+          value={num}
+        />
+      )
+    }
+
+    case 'boolean': {
+      const checked = !mixed && value === true
+      return (
+        <ToggleControl
+          checked={checked}
+          label={prettifyKey(key)}
+          mixed={mixed}
+          onChange={(next) => {
+            const patch = { [key]: next } as Partial<AnyNode>
+            onChange(patch)
+            onCommit?.(patch)
+          }}
+        />
+      )
+    }
+
+    case 'enum': {
+      const str = typeof value === 'string' ? value : (field.options[0] ?? '')
+      const apply = (next: string) => {
+        const patch = { [key]: next } as Partial<AnyNode>
+        onChange(patch)
+        onCommit?.(patch)
+      }
+      if (field.display === 'segmented') {
+        return (
+          <SegmentedControl
+            mixed={mixed}
+            onChange={apply}
+            options={field.options.map((opt) => ({ label: prettifyEnumValue(opt), value: opt }))}
+            value={str}
+          />
+        )
+      }
+      return (
+        <div className="flex items-center justify-between px-3 py-2">
+          <span className="text-foreground/80 text-xs">{prettifyKey(key)}</span>
+          <select
+            className="rounded-md border border-border/50 bg-[#2C2C2E] px-2 py-1 text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-foreground/30"
+            onChange={(e) => apply(e.target.value)}
+            value={mixed ? '' : str}
+          >
+            {mixed && (
+              <option disabled value="">
+                Mixed
+              </option>
+            )}
+            {field.options.map((opt) => (
+              <option key={opt} value={opt}>
+                {prettifyEnumValue(opt)}
+              </option>
+            ))}
+          </select>
+        </div>
+      )
+    }
+
+    case 'color': {
+      const str = typeof value === 'string' ? value : '#888888'
+      const apply = (next: string) => {
+        const patch = { [key]: next } as Partial<AnyNode>
+        onChange(patch)
+        onCommit?.(patch)
+      }
+      return (
+        <div className="flex items-center justify-between px-3 py-2">
+          <span className="text-foreground/80 text-xs">{prettifyKey(key)}</span>
+          <div className="flex items-center gap-2">
+            <input
+              className="h-6 w-8 cursor-pointer rounded border border-border/50 bg-transparent"
+              onChange={(e) => apply(e.target.value)}
+              type="color"
+              value={str}
+            />
+            <input
+              className="w-20 rounded-md border border-border/50 bg-[#2C2C2E] px-2 py-1 text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-foreground/30"
+              onChange={(e) => apply(e.target.value)}
+              type="text"
+              value={mixed ? 'Mixed' : str}
+            />
+          </div>
+        </div>
+      )
+    }
+
+    case 'vec3': {
+      const v =
+        Array.isArray(value) && value.length >= 3
+          ? (value as [number, number, number])
+          : ([0, 0, 0] as [number, number, number])
+      const axes: Array<{ label: string; index: 0 | 1 | 2 }> = [
+        { label: 'X', index: 0 },
+        { label: 'Y', index: 1 },
+        { label: 'Z', index: 2 },
+      ]
+      return (
+        <>
+          {axes.map(({ label, index }) => {
+            const axisValue = v[index] ?? 0
+            const apply = (next: number): Partial<AnyNode> => {
+              const updated = [...v] as [number, number, number]
+              updated[index] = next
+              return { [key]: updated } as Partial<AnyNode>
+            }
+            return (
+              <SliderControl
+                key={`${key}-${label}`}
+                label={label}
+                max={axisValue + 5}
+                min={axisValue - 5}
+                mixed={mixed}
+                onChange={(next) => onChange(apply(next))}
+                onCommit={onCommit ? (next) => onCommit(apply(next)) : undefined}
+                precision={2}
+                restoreOnCommit={!onCommit}
+                step={0.05}
+                unit="m"
+                value={Math.round(axisValue * 100) / 100}
+              />
+            )
+          })}
+        </>
+      )
+    }
+
+    default:
+      return null
+  }
+}

--- a/packages/editor/src/components/ui/panels/parametric-field-utils.ts
+++ b/packages/editor/src/components/ui/panels/parametric-field-utils.ts
@@ -1,0 +1,18 @@
+export function precisionForStep(step: number): number {
+  if (step <= 0) return 0
+  return Math.max(0, Math.ceil(-Math.log10(step)))
+}
+
+export function prettifyKey(key: string): string {
+  const spaced = key.replace(/([A-Z])/g, ' $1').toLowerCase()
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+export function prettifyEnumValue(value: string): string {
+  return value
+    .split(/[-_\s]/)
+    .map((word, i) =>
+      i === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word.toLowerCase(),
+    )
+    .join(' ')
+}

--- a/packages/editor/src/components/ui/panels/parametric-inspector.tsx
+++ b/packages/editor/src/components/ui/panels/parametric-inspector.tsx
@@ -20,9 +20,7 @@ import { collectZoneContentIds } from '../../../lib/zone-content'
 import useEditor from '../../../store/use-editor'
 import { ActionButton, ActionGroup } from '../controls/action-button'
 import { PanelSection } from '../controls/panel-section'
-import { SegmentedControl } from '../controls/segmented-control'
-import { SliderControl } from '../controls/slider-control'
-import { ToggleControl } from '../controls/toggle-control'
+import { ParametricFieldControl } from './parametric-field-control'
 import { InspectorFooterContext, PanelWrapper } from './panel-wrapper'
 
 /**
@@ -311,136 +309,11 @@ function FieldRenderer({ field, nodeId, onUpdate }: FieldRendererProps) {
   })
   if (!visible) return null
 
-  switch (field.kind) {
-    case 'number': {
-      const num = typeof value === 'number' ? value : 0
-      const step = field.step ?? 0.01
-      const precision = precisionForStep(step)
-      return (
-        <SliderControl
-          label={prettifyKey(key)}
-          max={field.max}
-          min={field.min}
-          onChange={(next) => onUpdate({ [key]: next } as Partial<AnyNode>)}
-          precision={precision}
-          step={step}
-          unit={field.unit ?? ''}
-          value={num}
-        />
-      )
-    }
-
-    case 'boolean': {
-      const checked = value === true
-      return (
-        <ToggleControl
-          checked={checked}
-          label={prettifyKey(key)}
-          onChange={(next) => onUpdate({ [key]: next } as Partial<AnyNode>)}
-        />
-      )
-    }
-
-    case 'enum': {
-      const str = typeof value === 'string' ? value : (field.options[0] ?? '')
-      if (field.display === 'segmented') {
-        return (
-          <SegmentedControl
-            onChange={(next) => onUpdate({ [key]: next } as Partial<AnyNode>)}
-            options={field.options.map((opt) => ({ label: prettifyEnumValue(opt), value: opt }))}
-            value={str}
-          />
-        )
-      }
-      return (
-        <div className="flex items-center justify-between px-3 py-2">
-          <span className="text-foreground/80 text-xs">{prettifyKey(key)}</span>
-          <select
-            className="rounded-md border border-border/50 bg-[#2C2C2E] px-2 py-1 text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-foreground/30"
-            onChange={(e) => onUpdate({ [key]: e.target.value } as Partial<AnyNode>)}
-            value={str}
-          >
-            {field.options.map((opt) => (
-              <option key={opt} value={opt}>
-                {prettifyEnumValue(opt)}
-              </option>
-            ))}
-          </select>
-        </div>
-      )
-    }
-
-    case 'color': {
-      const str = typeof value === 'string' ? value : '#888888'
-      return (
-        <div className="flex items-center justify-between px-3 py-2">
-          <span className="text-foreground/80 text-xs">{prettifyKey(key)}</span>
-          <div className="flex items-center gap-2">
-            <input
-              className="h-6 w-8 cursor-pointer rounded border border-border/50 bg-transparent"
-              onChange={(e) => onUpdate({ [key]: e.target.value } as Partial<AnyNode>)}
-              type="color"
-              value={str}
-            />
-            <input
-              className="w-20 rounded-md border border-border/50 bg-[#2C2C2E] px-2 py-1 text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-foreground/30"
-              onChange={(e) => onUpdate({ [key]: e.target.value } as Partial<AnyNode>)}
-              type="text"
-              value={str}
-            />
-          </div>
-        </div>
-      )
-    }
-
-    case 'vec3': {
-      const v = Array.isArray(value) && value.length >= 3
-        ? (value as [number, number, number])
-        : [0, 0, 0]
-      const axes: Array<{ label: string; index: 0 | 1 | 2 }> = [
-        { label: 'X', index: 0 },
-        { label: 'Y', index: 1 },
-        { label: 'Z', index: 2 },
-      ]
-      return (
-        <>
-          {axes.map(({ label, index }) => {
-            // v is a [number, number, number] tuple; the explicit local
-            // resolves TS's noUncheckedIndexedAccess concern that v[index]
-            // could be undefined.
-            const axisValue = v[index] ?? 0
-            return (
-              <SliderControl
-                key={`${key}-${label}`}
-                label={label}
-                max={axisValue + 5}
-                min={axisValue - 5}
-                onChange={(next) => {
-                  const updated = [...v] as [number, number, number]
-                  updated[index] = next
-                  onUpdate({ [key]: updated } as Partial<AnyNode>)
-                }}
-                precision={2}
-                step={0.05}
-                unit="m"
-                value={Math.round(axisValue * 100) / 100}
-              />
-            )
-          })}
-        </>
-      )
-    }
-
-    case 'custom':
-      // The field owns its rendering and update logic — used for
-      // derived values (length from start/end), dynamic-bounded
-      // sliders (curve sagitta), composed editors.
-      return <CustomFieldRenderer Comp={field.component} nodeId={nodeId} onUpdate={onUpdate} />
-
-    default:
-      // material / ref / unrecognized kinds — not implemented in v1.
-      return null
+  if (field.kind === 'custom') {
+    return <CustomFieldRenderer Comp={field.component} nodeId={nodeId} onUpdate={onUpdate} />
   }
+
+  return <ParametricFieldControl field={field} onChange={onUpdate} value={value} />
 }
 
 function CustomFieldRenderer({
@@ -458,27 +331,4 @@ function CustomFieldRenderer({
   const node = useScene((s) => s.nodes[nodeId])
   if (!node) return null
   return <Comp node={node} onUpdate={onUpdate} />
-}
-
-// ─── helpers ─────────────────────────────────────────────────────────
-
-function precisionForStep(step: number): number {
-  if (step <= 0) return 0
-  return Math.max(0, Math.ceil(-Math.log10(step)))
-}
-
-function prettifyKey(key: string): string {
-  // 'bracketStyle' → 'Bracket style'
-  const spaced = key.replace(/([A-Z])/g, ' $1').toLowerCase()
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
-}
-
-function prettifyEnumValue(value: string): string {
-  // 'minimal' → 'Minimal'; 'roof-segment' → 'Roof segment'
-  return value
-    .split(/[-_\s]/)
-    .map((word, i) =>
-      i === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word.toLowerCase(),
-    )
-    .join(' ')
 }


### PR DESCRIPTION
## What does this PR do?

Selecting several nodes of the same type now opens a shared parameters inspector instead of the actions-only multi-select panel. Edits are absolute (every node gets the value you land on), mixed fields show a mixed indicator until touched, and one `updateNodes` call keeps the whole change as a single undo step.

Walls and ceilings keep Follows level vs Custom height. Slider drags preview through live overrides so geometry updates without history churn, and the slider readout tracks the drag. Mobile uses the same panel in the existing sheet.

## How to test

1. `bun dev` (or hosted community against this SHA). Open a project with several walls.
2. Shift-click 3 walls of mixed heights. Confirm the inspector title is like "3 walls", mixed Height shows Mixed, and Follows level / Custom height is present.
3. Switch to Custom height if needed, drag Height, confirm all three walls update in 3D and the slider number moves while dragging. Cmd+Z restores all three at once.
4. Shift-click a wall and a slab. Confirm the actions-only panel (Group / Duplicate / Delete) with no shared parameters.

## Screenshots / screen recording

N/A in this PR — verified locally in community on :3001. A reviewer clip of the 3-wall height drag is still useful.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

Made with [Cursor](https://cursor.com)