### PR TITLE
fix(core): don't rely on crypto.randomUUID for asset ids

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -129,6 +129,7 @@
         "@types/bun": "^1.3.0",
         "@types/react": "^19.2.2",
         "@types/three": "^0.184.0",
+        "fake-indexeddb": "^6.2.5",
         "typescript": "6.0.3",
       },
       "peerDependencies": {
@@ -1262,6 +1263,8 @@
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,6 +88,7 @@
     "@types/bun": "^1.3.0",
     "@types/react": "^19.2.2",
     "@types/three": "^0.184.0",
+    "fake-indexeddb": "^6.2.5",
     "typescript": "6.0.3"
   },
   "keywords": [

--- a/packages/core/src/lib/asset-storage.test.ts
+++ b/packages/core/src/lib/asset-storage.test.ts
@@ -1,0 +1,63 @@
+import 'fake-indexeddb/auto'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { loadAssetUrl, saveAsset } from './asset-storage'
+
+function file(contents: string, name = 'test.txt'): File {
+  return new File([contents], name, { type: 'text/plain' })
+}
+
+describe('saveAsset', () => {
+  const originalRandomUUID = crypto.randomUUID
+
+  afterEach(() => {
+    crypto.randomUUID = originalRandomUUID
+  })
+
+  test('returns an asset:// URL', async () => {
+    const url = await saveAsset(file('hello'))
+    expect(url.startsWith('asset://')).toBe(true)
+  })
+
+  test('generates distinct ids across calls', async () => {
+    const [a, b] = await Promise.all([saveAsset(file('a')), saveAsset(file('b'))])
+    expect(a).not.toBe(b)
+  })
+
+  // Regression test: crypto.randomUUID() throws/`undefined`s on plain-HTTP
+  // origins because it requires a secure context (HTTPS or localhost). Every
+  // upload used to fail on such deployments (see packages/editor's
+  // reference-panel.tsx, local-guide-image.ts, both of which call saveAsset).
+  test('still works when crypto.randomUUID is unavailable (insecure context)', async () => {
+    // @ts-expect-error simulating a browser without Web Crypto's randomUUID
+    crypto.randomUUID = undefined
+
+    const url = await saveAsset(file('insecure-context'))
+    expect(url.startsWith('asset://')).toBe(true)
+
+    const loaded = await loadAssetUrl(url)
+    expect(loaded).not.toBeNull()
+  })
+})
+
+describe('loadAssetUrl', () => {
+  test('round-trips a saved asset back to an object URL', async () => {
+    const url = await saveAsset(file('round-trip'))
+    const objectUrl = await loadAssetUrl(url)
+    expect(objectUrl?.startsWith('blob:')).toBe(true)
+  })
+
+  test('passes through blob: and http(s) URLs unchanged', async () => {
+    expect(await loadAssetUrl('blob:http://example.com/1234')).toBe('blob:http://example.com/1234')
+    expect(await loadAssetUrl('https://cdn.example.com/a.glb')).toBe(
+      'https://cdn.example.com/a.glb',
+    )
+  })
+
+  test('returns null for an unknown asset id', async () => {
+    expect(await loadAssetUrl('asset://does-not-exist')).toBeNull()
+  })
+
+  test('returns null for an empty URL', async () => {
+    expect(await loadAssetUrl('')).toBeNull()
+  })
+})

--- a/packages/core/src/lib/asset-storage.ts
+++ b/packages/core/src/lib/asset-storage.ts
@@ -1,15 +1,19 @@
 import { get, set } from 'idb-keyval'
+import { customAlphabet } from 'nanoid'
 
 export const ASSET_PREFIX = 'asset_data:'
 
 // Cache for active object URLs to prevent leaks and flickering
 const urlCache = new Map<string, string>()
 
+// Unlike crypto.randomUUID(), nanoid works outside secure contexts.
+const nanoAssetId = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 16)
+
 /**
  * Save a file to IndexedDB and return a custom protocol URL
  */
 export async function saveAsset(file: File): Promise<string> {
-  const id = crypto.randomUUID()
+  const id = nanoAssetId()
   await set(`${ASSET_PREFIX}${id}`, file)
   return `asset://${id}`
 }


### PR DESCRIPTION
## Summary

`saveAsset()` (called on every file upload/drop, from `reference-panel.tsx` and `local-guide-image.ts`) used `crypto.randomUUID()` to generate the IndexedDB key. That method requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) (HTTPS or `localhost`) and is `undefined` otherwise, so it throws on plain-HTTP origins — e.g. an internal-network deployment reached over a bare IP or hostname. Every upload fails immediately there.

Switched to `nanoid`'s `customAlphabet`, which has no secure-context requirement and is already used for ids elsewhere in this package (`schema/base.ts`). I preferred that over the narrower `typeof`-check + counter fallback in `packages/nodes/src/cabinet/stack.ts`: that counter resets to 0 on every reload, which is fine for `stack.ts`'s transient in-memory compartment ids but not here — asset ids are persisted as IndexedDB keys and as `asset://<id>` references inside saved/exported scenes, so a colliding fallback could silently overwrite a different asset. `nanoid` gives the same collision resistance on every code path instead of degrading on insecure origins.

## Test plan

- Added a regression test in `packages/core/src/lib/asset-storage.test.ts`. There was no existing test for this module because `idb-keyval` (used here) needs a real `indexedDB` global, which Bun's test runtime doesn't provide — added `fake-indexeddb` as a devDependency to fill that gap.
- The new test stubs `crypto.randomUUID` as unavailable and asserts `saveAsset()`/`loadAssetUrl()` still round-trip correctly. Confirmed it fails against the old implementation (`TypeError: crypto.randomUUID is not a function`) and passes with the fix.
- Full `packages/core` suite (957 tests) passes.
- `bun run check` (biome) clean across the repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized ID generation change with regression tests; no auth or API surface changes, though persisted `asset://` id format shifts from UUID to nanoid strings.
> 
> **Overview**
> **Fixes file uploads on plain-HTTP deployments** by changing how persisted asset IDs are generated in `saveAsset()`.
> 
> `saveAsset()` previously used `crypto.randomUUID()`, which is unavailable outside a secure context (HTTPS/localhost), so uploads from editor flows that call it could throw immediately on internal HTTP hosts. IDs are now produced with **`nanoid`'s `customAlphabet`** (16-char alphanumeric), which works in insecure contexts and stays suitable for long-lived IndexedDB keys and `asset://` references in saved scenes.
> 
> **Test coverage** for `asset-storage` is added via `fake-indexeddb` in Bun tests, including a regression that stubs `crypto.randomUUID` as missing and asserts save/load still round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5611b02e9dc67473a20851baf394a523bf12d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->