### PR TITLE
fix: hidden walls no longer swallow pointer events

### DIFF
--- a/packages/nodes/src/wall/renderer.tsx
+++ b/packages/nodes/src/wall/renderer.tsx
@@ -52,7 +52,31 @@ const WallRenderer = ({ node }: { node: WallNode }) => {
     }
   }, [collisionPlaceholderGeometry, placeholderGeometry])
 
-  const handlers = useNodeEvents(node, 'wall')
+  const rawHandlers = useNodeEvents(node, 'wall')
+  // Hidden walls are pointer-TRANSPARENT: when the wall-mode pass hides this
+  // wall (`WallCutout` stamps `userData.wallHidden` — X-ray 'down' mode,
+  // cutaway-hidden faces, auto-mode interior partitions), its invisible
+  // full-height collision mesh must not swallow pointer events aimed at
+  // visible objects behind it (wall-mounted plugin nodes, items). Returning
+  // early without stopPropagation lets R3F continue to the next intersection.
+  // Delete mode keeps the events so hidden walls stay hover-targetable for
+  // deletion (the deleteInvisible highlight flow).
+  const handlers = useMemo(() => {
+    const gated = {} as typeof rawHandlers
+    for (const key of Object.keys(rawHandlers) as (keyof typeof rawHandlers)[]) {
+      const fn = rawHandlers[key] as (e: unknown) => void
+      ;(gated as Record<string, (e: unknown) => void>)[key] = (e: unknown) => {
+        if (
+          ref.current?.userData?.wallHidden === true &&
+          useViewer.getState().hoverHighlightMode !== 'delete'
+        ) {
+          return
+        }
+        fn(e)
+      }
+    }
+    return gated
+  }, [rawHandlers])
   const shading = useViewer((s) => s.shading)
   const textures = useViewer((s) => s.textures)
   const colorPreset = useViewer((s) => s.colorPreset)

--- a/packages/viewer/src/systems/wall/wall-cutout.tsx
+++ b/packages/viewer/src/systems/wall/wall-cutout.tsx
@@ -164,6 +164,19 @@ export const WallCutout = () => {
         if (wallNode?.type !== 'wall') return
 
         const hideWall = getWallHideState(wallNode, wallMesh as Mesh, wallMode, u)
+        // Pointer transparency for hidden walls: the wall's full-height
+        // collision mesh keeps raycasting even when the wall draws with the
+        // invisible material ('down' mode, cutaway-hidden faces, auto-mode
+        // interior partitions), so it silently swallows clicks aimed at
+        // VISIBLE objects standing behind it — e.g. a plugin's wall-mounted
+        // device/service boxes in X-ray mode (night-5 D4: the arm click on a
+        // south-wall receptacle selected an invisible wall two meters in
+        // front of it instead, and the follow-up click committed a WALL
+        // move). The wall renderer's pointer handlers read this stamp and
+        // pass hidden walls through (delete mode excepted — hidden walls
+        // must stay hover-targetable for deletion). Translucent walls are
+        // visible, so they keep their events.
+        ;(wallMesh as Mesh).userData.wallHidden = wallMode !== 'translucent' && hideWall
         const isDeleteHighlighted = deleteHoveredWallId === wallId
         const isSelectionHighlighted = !isDeleteHighlighted && highlightedWallIds.has(wallId)
         const levelId = resolveLevelId(wallNode, sceneState.nodes)


### PR DESCRIPTION
While the viewer's wall mode hides walls (X-ray plugins set 'down'), each wall keeps a full-height invisible raycast mesh whose pointer handlers still fire and stopPropagation — clicks aimed at visible objects behind them hit the phantom wall instead (measured: a click meant for a device box at 3.93m was captured by an invisible wall at 1.03m), silently selecting walls and even arming accidental wall moves that then trigger zone/slab auto-sync mutations.

Fix: `WallCutout` stamps `userData.wallHidden`; the wall renderer's pointer handlers early-return while hidden (no emit, no stopPropagation) so the R3F raycast continues to the real target. Delete-mode is excepted (hidden walls must stay deletable).

Found by the Bones movable-outlets track (night-5 D4) — the same phantom-click class already affects service-point interaction in prod today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core viewer pointer/selection behavior for walls; scope is narrow with an explicit delete-mode exception and translucent walls unchanged.
> 
> **Overview**
> Fixes **phantom wall selection** when walls are drawn invisible (X-ray `down`, cutaway, auto interior partitions) but their hidden **collision mesh** still intercepts clicks meant for wall-mounted plugins or items behind them.
> 
> **`WallCutout`** now sets `userData.wallHidden` on each wall mesh when it is hidden and not in **translucent** mode (translucent walls stay interactive). The **wall renderer** wraps `useNodeEvents` so those handlers **no-op** while `wallHidden` is true—no emit and no `stopPropagation`, so R3F can hit the next intersection. **Delete mode** is unchanged: hidden walls still receive events for the delete-invisible hover flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40d7fd92a1b7a23df6c23983a4f1ebe03cec4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->