### PR TITLE
chore: bump plugin-bones to 22d9e7ae — night-5: movable outlets LIVE

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#041041dab1366ecd59bf3c74d0dd47a243cc6845",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#22d9e7ae6807126d3f485ae4c3d538280137a43a",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#041041dab1366ecd59bf3c74d0dd47a243cc6845",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#22d9e7ae6807126d3f485ae4c3d538280137a43a",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#041041d", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-041041d"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#22d9e7a", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-22d9e7a"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Pin bump only. Night-5 batch:

- **Movable outlets go LIVE** (flag defaults ON): every derived receptacle/switch is hoverable and drags like a door — code-aware snapping, wires re-route, exact single-undo per gesture. The night-4 corruption class is root-caused and dead: the drag frame's onCommit cascade re-flagged the parent wall mid-commit and woke space-detection (three undo entries per drag); commits are now one tracked write. Ships alongside #683 (pointer-transparent hidden walls) which fixes the dead-click walls.
- **Tee-junction guards**: parallel-wall false tees filtered (a regression class that silently ate 0.57m of framing per end), width-aware oblique retreats in all three tee consumers, junction-honesty warnings for near-parallel contacts and inset-swallowed runs.
- **Blueprint examiner round 4 fixes**: the circuit legend never truncates (second column past 22 rows), condensers print 'CU' not 'AH', GEN's color walk no longer wraps into the lighting band (family floor 10 → 22 RGB, gated).

Loop-verified: skeptic + examiner rounds on the track-C fixes, pilot-run root-cause rounds on outlets, full-stack visual running at this exact sha + editor main (both host fixes) before the community bump. 878 plugin tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium because the bump pulls substantial electrical/framing and interaction logic from an external plugin SHA, even though this PR is only a pin update.
> 
> **Overview**
> **Dependency-only change:** `@pascal-app/plugin-bones` moves from `041041d` to **`22d9e7a`** in `apps/editor/package.json`, with the matching lockfile entry in `bun.lock`. No application source in this repo is modified.
> 
> That plugin revision (per the PR notes) turns on **movable outlets** by default, fixes drag **undo** so each gesture is a single tracked write, adds **tee-junction** guards and junction-honesty warnings, and ships **blueprint examiner** fixes (circuit legend layout, condenser label, GEN color banding). Behavior lands entirely inside the pinned plugin build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb14722b94b2071d83c29db9073882fbb2d4f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->