### PR TITLE
fix: stop node tops lifting floor placements, and keep batched walls pickable

### DIFF
--- a/packages/editor/src/components/tools/shared/pointer-support-cap.test.ts
+++ b/packages/editor/src/components/tools/shared/pointer-support-cap.test.ts
@@ -14,6 +14,7 @@ import {
 import { useViewer } from '@pascal-app/viewer'
 import { BoxGeometry, Mesh, MeshBasicMaterial, PerspectiveCamera } from 'three'
 import { z } from 'zod'
+import useInteractionScope from '../../../store/use-interaction-scope'
 import { createWallOnCurrentLevel } from '../wall/wall-drafting'
 import { resolvePointerSupportSurface } from './pointer-support-cap'
 
@@ -38,6 +39,7 @@ describe('resolvePointerSupportSurface node tops', () => {
   beforeEach(() => {
     spatialGridManager.clear()
     sceneRegistry.clear()
+    useInteractionScope.getState().end()
     useViewer.setState({
       selection: {
         buildingId: null,
@@ -108,24 +110,54 @@ describe('resolvePointerSupportSurface node tops', () => {
     camera.position.set(0, 5, 0)
     camera.updateMatrixWorld(true)
 
-    const support = resolvePointerSupportSurface(camera, [0, 0, 0])
+    const support = resolvePointerSupportSurface(camera, [0, 0, 0], {
+      includeNodeTopSurfaces: true,
+    })
 
     expect(support?.sourceNodeId).toBe(PLATFORM_ID)
     expect(support?.elevation).toBeCloseTo(2)
     expect(support?.worldPoint).toEqual([0, 2, 0])
   })
 
-  test('keeps the ground result when node-top surfaces are explicitly disabled', () => {
+  test('keeps the ground result unless node-top surfaces are asked for', () => {
     addPluginPlatform()
 
     const camera = new PerspectiveCamera()
     camera.position.set(0, 5, 0)
     camera.updateMatrixWorld(true)
 
-    const support = resolvePointerSupportSurface(camera, [0, 0, 0], {
-      includeNodeTopSurfaces: false,
+    // The default. A floor placement aims THROUGH whatever upward-facing
+    // geometry sits between the camera and the floor — a room's ceiling, the
+    // top of the wall the ray passes over — so only the tools that build on a
+    // surface opt in.
+    for (const options of [undefined, { includeNodeTopSurfaces: false }]) {
+      const support = resolvePointerSupportSurface(camera, [0, 0, 0], options)
+      expect(support?.sourceNodeId).toBeNull()
+      expect(support?.elevation).toBe(0)
+    }
+  })
+
+  test('never elects the node the active interaction is placing or moving', () => {
+    addPluginPlatform()
+    useInteractionScope.getState().begin({
+      kind: 'placing',
+      node: useScene.getState().nodes[PLATFORM_ID]!,
+      nodeId: PLATFORM_ID,
+      nodeType: PLATFORM_KIND,
+      view: '3d',
+      pressDrag: false,
+      driver: 'registry-tool',
     })
 
+    const camera = new PerspectiveCamera()
+    camera.position.set(0, 5, 0)
+    camera.updateMatrixWorld(true)
+
+    const support = resolvePointerSupportSurface(camera, [0, 0, 0], {
+      includeNodeTopSurfaces: true,
+    })
+
+    // Its own top would raise it by its own height on every pointer move.
     expect(support?.sourceNodeId).toBeNull()
     expect(support?.elevation).toBe(0)
   })

--- a/packages/editor/src/components/tools/shared/pointer-support-cap.ts
+++ b/packages/editor/src/components/tools/shared/pointer-support-cap.ts
@@ -12,6 +12,8 @@ import {
 import { useViewer } from '@pascal-app/viewer'
 import { type Camera, Matrix3, type Object3D, Raycaster, Vector3 } from 'three'
 import { resolveTerrainGroundHit } from '../../../lib/ground-surface'
+import { scopeNodeId } from '../../../lib/interaction/scope'
+import useInteractionScope from '../../../store/use-interaction-scope'
 
 const originScratch = new Vector3()
 const hitScratch = new Vector3()
@@ -150,22 +152,34 @@ export function resolvePointerSupportSurface(
     localPoint = [pointScratch.x, pointScratch.y, pointScratch.z]
   }
 
-  const nodeTopSurfaceKinds =
-    options?.includeNodeTopSurfaces === false
-      ? []
-      : Array.from(nodeRegistry.entries())
-          .filter(([, definition]) => definition.capabilities.surfaces?.top !== undefined)
-          .map(([kind]) => kind)
+  // Node tops are opt-in. A ray aimed at a floor crosses every upward-facing
+  // face above that floor first — a room's ceiling, the top of the wall it
+  // passes over — so electing "the nearest node top along the ray" silently
+  // lifts anything placed inside a finished room. Only the tools that build ON
+  // a surface (wall / column / fence / stair / block) mean that, and they say
+  // so. Everything else places against the floor the pointer indicates.
+  const nodeTopSurfaceKinds = options?.includeNodeTopSurfaces
+    ? Array.from(nodeRegistry.entries())
+        .filter(([, definition]) => definition.capabilities.surfaces?.top !== undefined)
+        .map(([kind]) => kind)
+    : []
   if (nodeTopSurfaceKinds.some((kind) => (sceneRegistry.byType[kind]?.size ?? 0) > 0)) {
     nodeTopRaycaster.set(worldRayOrigin, worldRayDirection.clone().normalize())
     const nodes = useScene.getState().nodes
     const registeredOwners = new Map(
       [...sceneRegistry.nodes.entries()].map(([nodeId, object]) => [object, nodeId as AnyNodeId]),
     )
-    const belongsToActiveLevel = (nodeId: AnyNodeId) => {
+    // The node the active interaction is placing/moving cannot be a surface for
+    // itself: its mesh rides the cursor, so electing its own top would raise it
+    // by its own height on every pointer move. Tools neuter the dragged mesh's
+    // `raycast` for their own pointer routing, but that is each tool's private
+    // convention — the election owns the invariant.
+    const interactingNodeId = scopeNodeId(useInteractionScope.getState().scope)
+    const isEligibleCandidate = (nodeId: AnyNodeId) => {
       let current = nodes[nodeId]
       const visited = new Set<AnyNodeId>()
       while (current && !visited.has(current.id)) {
+        if (current.id === interactingNodeId) return false
         if (current.id === levelId) return true
         visited.add(current.id)
         current = current.parentId ? nodes[current.parentId as AnyNodeId] : undefined
@@ -189,7 +203,7 @@ export function resolvePointerSupportSurface(
         const nodeId = rawId as AnyNodeId
         const node = nodes[nodeId]
         const object = sceneRegistry.nodes.get(nodeId)
-        if (!(node?.visible && object?.visible && belongsToActiveLevel(nodeId))) continue
+        if (!(node?.visible && object?.visible && isEligibleCandidate(nodeId))) continue
         if (
           node.type === 'item' &&
           (!canHostOnTop(node) || isLowProfileItemSurface(node as ItemNode))

--- a/packages/editor/src/components/tools/stair/stair-tool.tsx
+++ b/packages/editor/src/components/tools/stair/stair-tool.tsx
@@ -438,7 +438,9 @@ export const StairTool: React.FC = () => {
     }
 
     const resolveStairPosition = (event: MoveTriggerEvent): [number, number, number] | null => {
-      const pointed = resolvePointerSupportSurface(cameraRef.current, event.position)
+      const pointed = resolvePointerSupportSurface(cameraRef.current, event.position, {
+        includeNodeTopSurfaces: true,
+      })
       supportSurfaceRef.current = pointed
       const fallbackPosition =
         'node' in event ? lastCanonicalPositionRef.current : event.localPosition

--- a/packages/nodes/src/block/tool.tsx
+++ b/packages/nodes/src/block/tool.tsx
@@ -81,7 +81,9 @@ const BlockTool = () => {
     const pointedSurfaceFor = (event: GridEvent | FloorPlacementClickTriggerEvent) =>
       typeof HTMLCanvasElement !== 'undefined' &&
       event.nativeEvent?.target instanceof HTMLCanvasElement
-        ? resolvePointerSupportSurface(cameraRef.current, event.position)
+        ? resolvePointerSupportSurface(cameraRef.current, event.position, {
+            includeNodeTopSurfaces: true,
+          })
         : null
 
     const resolvePlacement = (

--- a/packages/nodes/src/column/tool.tsx
+++ b/packages/nodes/src/column/tool.tsx
@@ -96,7 +96,9 @@ const ColumnTool = () => {
     const pointedSurfaceFor = (event: FloorPlacementClickTriggerEvent) =>
       typeof HTMLCanvasElement !== 'undefined' &&
       event.nativeEvent?.target instanceof HTMLCanvasElement
-        ? resolvePointerSupportSurface(cameraRef.current, event.position)
+        ? resolvePointerSupportSurface(cameraRef.current, event.position, {
+            includeNodeTopSurfaces: true,
+          })
         : null
 
     const resolveColumnPlacement = (

--- a/packages/nodes/src/fence/tool.tsx
+++ b/packages/nodes/src/fence/tool.tsx
@@ -74,7 +74,7 @@ const surfacePointScratch = new Vector3()
 // them; those keep the uncapped max election and leave the grid plane alone.
 function pointedSurfaceFor(camera: Camera, event: GridEvent) {
   return event.nativeEvent?.target instanceof HTMLCanvasElement
-    ? resolvePointerSupportSurface(camera, event.position)
+    ? resolvePointerSupportSurface(camera, event.position, { includeNodeTopSurfaces: true })
     : null
 }
 /** Figma-style alignment-snap threshold (meters), matching the move tools. */

--- a/packages/viewer/src/components/viewer/index.tsx
+++ b/packages/viewer/src/components/viewer/index.tsx
@@ -33,6 +33,7 @@ import { SceneRenderer } from '../renderers/scene-renderer'
 import FrameLimiter from './frame-limiter'
 import { Lights } from './lights'
 import { PerfMonitor } from './perf-monitor'
+import { PointerRaycastLayers } from './pointer-raycast-layers'
 import PostProcessing, { DEFAULT_HOVER_STYLES, type HoverStyles } from './post-processing'
 import { RegisteredSystems } from './registered-systems'
 import { SceneBvh } from './scene-bvh'
@@ -574,6 +575,7 @@ const Viewer = forwardRef<ViewerHandle, ViewerProps>(function Viewer(
     >
       <FrameLimiter fps={maxFps} paused={renderPaused} />
       <ViewerCamera />
+      <PointerRaycastLayers />
       <GPUDeviceWatcher />
       <ToneMappingExposure />
       <SceneReadyTracker

--- a/packages/viewer/src/components/viewer/pointer-raycast-layers.tsx
+++ b/packages/viewer/src/components/viewer/pointer-raycast-layers.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useThree } from '@react-three/fiber'
+import { useLayoutEffect } from 'react'
+import { BATCHED_LAYER } from '../../lib/layers'
+
+/**
+ * Lets R3F's pointer raycaster see geometry a collective batch draws.
+ *
+ * R3F picks with one shared raycaster whose default mask is `SCENE_LAYER`
+ * alone. A wall sewn into its level's merged mesh is moved off that layer
+ * (`hideBatchedWall`) while staying in the graph with its pointer handlers
+ * intact — so without this the wall answers no hover, paint or click the
+ * moment it joins a batch, and a floor's walls go dead a fraction of a second
+ * after the last edit settles.
+ *
+ * Additive rather than `setSurfaceRaycastLayers`: that helper resets the mask
+ * for the private raycasters callers build per query, and this one is shared.
+ */
+export const PointerRaycastLayers = () => {
+  const raycaster = useThree((state) => state.raycaster)
+
+  useLayoutEffect(() => {
+    const mask = raycaster.layers.mask
+    raycaster.layers.enable(BATCHED_LAYER)
+    return () => {
+      raycaster.layers.mask = mask
+    }
+  }, [raycaster])
+
+  return null
+}

--- a/packages/viewer/src/lib/scene-visibility.test.ts
+++ b/packages/viewer/src/lib/scene-visibility.test.ts
@@ -2,7 +2,13 @@
 // depend on @types/bun so the import type is unresolved at compile time.
 import { describe, expect, test } from 'bun:test'
 import * as THREE from 'three'
-import { BATCHED_LAYER, OVERLAY_LAYER, SCENE_LAYER, SHADOW_ONLY_LAYER } from './layers'
+import {
+  BATCHED_LAYER,
+  OVERLAY_LAYER,
+  SCENE_LAYER,
+  SHADOW_ONLY_LAYER,
+  setSurfaceRaycastLayers,
+} from './layers'
 import { hideFromScene, showInScene } from './scene-visibility'
 
 function sceneObject(): THREE.Object3D {
@@ -114,5 +120,28 @@ describe('scene visibility', () => {
     showInScene(obj, 'isolated')
     expect(obj.layers.mask).toBe(original)
     expect(obj.layers.isEnabled(SCENE_LAYER)).toBe(false)
+  })
+
+  // A batched wall keeps its pointer handlers, so whatever raycaster drives
+  // hover / paint / click has to reach it or the wall goes dead the moment its
+  // level is sewn. `PointerRaycastLayers` enables the bit on R3F's shared
+  // raycaster; `setSurfaceRaycastLayers` does it for private ones.
+  test('a batched object answers only a raycaster that opted into the layer', () => {
+    const obj = sceneObject()
+    hideFromScene(obj, 'batched')
+
+    const defaultLayers = new THREE.Layers()
+    expect(obj.layers.test(defaultLayers)).toBe(false)
+
+    const surfaceLayers = new THREE.Layers()
+    setSurfaceRaycastLayers(surfaceLayers)
+    expect(obj.layers.test(surfaceLayers)).toBe(true)
+
+    const sharedLayers = new THREE.Layers()
+    sharedLayers.enable(BATCHED_LAYER)
+    expect(obj.layers.test(sharedLayers)).toBe(true)
+
+    showInScene(obj, 'batched')
+    expect(obj.layers.test(defaultLayers)).toBe(true)
   })
 })


### PR DESCRIPTION
Two regressions that landed in main on 2026-08-18, both reproduced by hand in the community editor before and after the fix.

## 1. Items and presets pushed up the Y axis (#638)

`pointer-support-cap.ts` flipped node-top election from opt-in to opt-out — `options?.includeNodeTopSurfaces === false` became the only way out, so every caller that passed nothing started electing node tops. The same PR gave `item` a `capabilities.surfaces.top`, widening the candidate set from `['wall','item','column']` to wall, slab, ceiling, cabinet, column, item, shelf and block.

A ray aimed at a floor crosses every upward-facing face above that floor first. In a finished room that is the ceiling: placing an item at the centre of a ceilinged room elects the ceiling's top face (nearest hit, `normal.y ≈ 1`) and `resolveFrozenFloorPlacementPatch` freezes it into the draft's authored Y, so the item sits at ceiling height instead of on the floor. Verified against the real function — elects `elevation: 2.7, sourceNodeId: ceiling` where the previous behaviour returned `0`. Walls the ray passes over do the same in a narrower band.

Restores the opt-in, keeping #638's registry-driven kind discovery (the list is still derived from `capabilities.surfaces.top`, not hardcoded). Only the tools that build **on** a surface ask for it: wall (already did), column, fence, stair, block. Item placement, registry move/presets and slab drafting go back to placing against the floor the pointer indicates.

Also excludes the node the active interaction is placing or moving. Its mesh rides the cursor, so electing its own top would raise it by its own height on every pointer move. Both tools happen to neuter the dragged mesh's `raycast` today, but that is each tool's private convention and async-mounted item children are only covered on the next frame — the election owns the invariant now.

## 2. Wall hover outline and paint preview dead (#608)

#608 sews a level's walls into one mesh once they settle (8+ walls, 180 ms quiet) and moves each sewn wall off `SCENE_LAYER` onto `BATCHED_LAYER` via `hideBatchedWall`, so it costs no draw call while staying in the graph **with its R3F pointer handlers attached**.

R3F picks with one shared raycaster whose default mask is `SCENE_LAYER` alone, so a batched wall stops being hit: no `wall:enter` (no hover outline, no paint preview), no `wall:move`, no `wall:click`. Selection is the circular case — a selected wall leaves the batch, but the click that would select it never lands. #608 saw this for measurement and added `setSurfaceRaycastLayers` for the raycasters that module builds; the shared event raycaster was never opted in.

`PointerRaycastLayers` enables the bit on it. Additive rather than `setSurfaceRaycastLayers`, which resets the mask — right for the private per-query raycasters it was written for, wrong for the one every pointer event goes through.

## Testing

- Full suite: 4100 pass, 0 new failures. The 11 `door floor clearance` / `DrawingSheetNode` failures are pre-existing and order-dependent — they fail identically on `6cfff809` without this branch.
- `check-types` green, biome clean.
- New coverage: the opt-in default and the interacting-node exclusion in `pointer-support-cap.test.ts`; the batched-layer raycast invariant in `scene-visibility.test.ts`.
- Manual A/B in the community editor: both bugs reproduced on `6cfff809`, both gone on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pointer placement and shared viewer raycasting; behavior is localized with explicit opt-in and tests, but wrong defaults would affect all floor placement and wall interaction.
> 
> **Overview**
> Fixes two editor regressions: **floor placements snapping to ceilings** and **batched walls losing pointer interaction**.
> 
> **Pointer support (`resolvePointerSupportSurface`)** — Node-top election is **opt-in** again via `includeNodeTopSurfaces: true` (default off), so item/preset/slab placement uses the floor under the cursor instead of the nearest upward face along the ray. Structural tools that build on surfaces (stair, block, column, fence) pass the flag explicitly. The resolver also **skips the node under active place/move** (`useInteractionScope`) so a preview cannot lift itself on its own top.
> 
> **Viewer picking** — New **`PointerRaycastLayers`** additively enables `BATCHED_LAYER` on React Three Fiber’s shared raycaster so walls moved off `SCENE_LAYER` when merged into a level batch still receive hover, paint, and click.
> 
> Tests cover the default/off behavior, interacting-node exclusion, and batched-layer raycast matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2eb6b676feccd6db6f9afd62bb6173a108a7e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->