### PR TITLE
fix(nodes/wall): let a hovered wall out of its batch so it can outline

### DIFF
--- a/packages/nodes/src/wall/wall-batch-system.test.ts
+++ b/packages/nodes/src/wall/wall-batch-system.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import { sceneRegistry, useScene } from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
 import { BufferGeometry, Float32BufferAttribute, Mesh, MeshBasicMaterial } from 'three'
-import { collectWallBatchCandidates } from './wall-batch-system'
+import { collectTintedWalls, collectWallBatchCandidates } from './wall-batch-system'
 
 const registeredIds: string[] = []
 
@@ -14,6 +15,7 @@ afterEach(() => {
     sceneRegistry.nodes.delete(id)
   }
   useScene.setState({ nodes: {}, rootNodeIds: [] } as never)
+  useViewer.setState({ hoverHighlightMode: 'default', hoveredId: null } as never)
 })
 
 function registerWall(id: string) {
@@ -43,5 +45,28 @@ describe('collectWallBatchCandidates', () => {
     const candidates = [...collectWallBatchCandidates('level', tinted).values()].flat()
 
     expect(candidates.map((candidate) => candidate.nodeId)).toEqual(wallIds.slice(8))
+  })
+})
+
+describe('collectTintedWalls', () => {
+  // Regression: hover feedback for a wall is an outline, and the outline node
+  // renders through the main camera — which never sees a sewn wall. A hovered
+  // wall has to leave its batch or hovering it lights up nothing, in select
+  // mode and in paint mode alike.
+  const wallIds = new Set(['wall_a', 'wall_b'])
+
+  test.each(['default', 'paint-ready', 'paint-disabled', 'delete'])(
+    'a %s hover takes the wall out of its batch',
+    (hoverHighlightMode) => {
+      useViewer.setState({ hoverHighlightMode, hoveredId: 'wall_a' } as never)
+
+      expect([...collectTintedWalls(wallIds)]).toEqual(['wall_a'])
+    },
+  )
+
+  test('a hover over a non-wall node tints nothing', () => {
+    useViewer.setState({ hoverHighlightMode: 'default', hoveredId: 'slab_a' } as never)
+
+    expect([...collectTintedWalls(wallIds)]).toEqual([])
   })
 })

--- a/packages/nodes/src/wall/wall-batch-system.test.ts
+++ b/packages/nodes/src/wall/wall-batch-system.test.ts
@@ -55,14 +55,16 @@ describe('collectTintedWalls', () => {
   // mode and in paint mode alike.
   const wallIds = new Set(['wall_a', 'wall_b'])
 
-  test.each(['default', 'paint-ready', 'paint-disabled', 'delete'])(
-    'a %s hover takes the wall out of its batch',
-    (hoverHighlightMode) => {
-      useViewer.setState({ hoverHighlightMode, hoveredId: 'wall_a' } as never)
+  test.each([
+    'default',
+    'paint-ready',
+    'paint-disabled',
+    'delete',
+  ])('a %s hover takes the wall out of its batch', (hoverHighlightMode) => {
+    useViewer.setState({ hoverHighlightMode, hoveredId: 'wall_a' } as never)
 
-      expect([...collectTintedWalls(wallIds)]).toEqual(['wall_a'])
-    },
-  )
+    expect([...collectTintedWalls(wallIds)]).toEqual(['wall_a'])
+  })
 
   test('a hover over a non-wall node tints nothing', () => {
     useViewer.setState({ hoverHighlightMode: 'default', hoveredId: 'slab_a' } as never)

--- a/packages/nodes/src/wall/wall-batch-system.tsx
+++ b/packages/nodes/src/wall/wall-batch-system.tsx
@@ -182,21 +182,29 @@ export function canBatchWalls(wallMode: WallMode, isolationActive: boolean): boo
 }
 
 /**
- * Walls the cutaway pass is currently tinting — a selection or a delete hover.
+ * Walls the viewer is currently lighting up — a selection, or any hover.
  *
- * It paints them by swapping the materials on the wall's own mesh, which the
- * merged mesh does not follow, so a lit wall goes back to drawing itself. There
- * are only ever a handful, and a handful of extra draw calls is what the tint
- * costs.
+ * A selection or delete hover paints the wall by swapping the materials on its
+ * own mesh, which the merged mesh does not follow. Every other hover draws an
+ * outline instead, and that needs the same thing for a different reason: the
+ * outline node renders `outliner.hoveredObjects` through the main camera, which
+ * enables no batched layer, so a sewn wall reaches neither mask pass and
+ * hovering it lights up nothing at all — in select mode, and in paint mode
+ * where the outline is the only signal for which surface the next click lands
+ * on.
+ *
+ * Both wants are the same one: a lit wall goes back to drawing its own
+ * geometry. Only ever a handful are lit at once, and a handful of extra draw
+ * calls is what lighting them costs.
  */
-function collectTintedWalls(wallIds: ReadonlySet<string>): Set<string> {
+export function collectTintedWalls(wallIds: ReadonlySet<string>): Set<string> {
   const viewer = useViewer.getState()
   const tinted = new Set<string>()
 
   for (const id of viewer.selection.selectedIds) if (wallIds.has(id)) tinted.add(id)
   for (const id of viewer.previewSelectedIds) if (wallIds.has(id)) tinted.add(id)
 
-  const hovered = viewer.hoverHighlightMode === 'delete' ? viewer.hoveredId : null
+  const hovered = viewer.hoveredId
   if (hovered && wallIds.has(hovered)) tinted.add(hovered)
 
   return tinted


### PR DESCRIPTION
Hovering a wall on a finished floor lights up nothing — no hover outline in select mode, and in paint mode no preview of the surface the next click will paint. Selection looks fine, which is what makes it confusing.

## Why

Hover feedback for a wall is an outline and nothing else. `SelectionMaterialSync` skips walls outright, and the cutaway pass tints only a selection or a delete hover — so `default`, `paint-ready` and `paint-disabled` all reduce to `outliner.hoveredObjects` plus a colour.

`MergedOutlineNode` draws that mask with `renderer.render(scene, camera)` on the main camera, which enables no `BATCHED_LAYER`. Once #608 sews a level's walls (wall mode `up`, 8+ walls, 180ms quiet) every wall on the floor is on that layer alone, so it reaches neither the depth pass nor a mask pass.

Selection escapes this only because `collectTintedWalls` already pulls a selected wall back out of the batch: the click lands, the wall starts drawing itself, and the outline appears. Hover had no such release.

Worth noting for anyone tracing this from #686: wall picking was never affected. The pointer handlers live on the `collision-mesh` child, which batching never moves off `SCENE_LAYER`, and R3F raycasts each interaction object directly — so clicks always landed. Only the *feedback* was missing.

## Fix

Release on any hover, not just a delete one. Same mechanism, one more reason: selection and delete tint through materials the merged mesh never reads, a plain hover outlines through a camera that never sees it, and both are answered by the wall drawing its own geometry while it is lit. One wall is lit at a time, so the cost is the one extra draw call the delete path already accepted.

## Verification

12-wall single-level project in the community editor, headless Chromium against a local dev server:

| Wall mode | hover outline before | after |
|---|---|---|
| `Full height` (batching on) | none | outlines, select + paint + erase |
| `Cutaway` (batching stands down) | outlines | unchanged |

`bun test src` in `packages/nodes`: 1052 pass. Regression test added over `collectTintedWalls` for all four hover modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to wall batch exclusion logic with regression tests; no auth, data, or API impact.
> 
> **Overview**
> **Fixes missing hover outlines on batched walls** when wall mode is `up` and a level’s walls are merged into the batch mesh.
> 
> `collectTintedWalls` now treats **any** hovered wall ID like a lit wall (not only delete-mode hovers), so the batch system **releases** that wall to draw its own geometry again. That matches how selection already worked and is required for default/paint hovers, where feedback is an outline rendered through the main camera—which does not see walls on the batched layer.
> 
> The function is **exported** for tests. New regression tests cover all four `hoverHighlightMode` values plus hovers on non-wall nodes (no release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e555cf69691ce1fb0bac2eca992c943d06dd47ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->