### PR TITLE
test(nodes): CI-sized timeout for the every-angle corner-joint sweep

### DIFF
--- a/packages/nodes/src/lean-to-extension/roof-corner.test.ts
+++ b/packages/nodes/src/lean-to-extension/roof-corner.test.ts
@@ -786,7 +786,9 @@ describe('lean-to corner joint', () => {
       gutterA.dispose()
       gutterB.dispose()
     }
-  })
+    // The full-angle sweep runs ~6s on CI's 2-core x64 runners — over bun's
+    // default 5s per-test budget (2-3s locally on Apple Silicon).
+  }, 30_000)
 
   test('rejects corners immediately outside the supported 30 to 150 degree range', () => {
     for (const angle of [20, 29.99, 150.01, 160]) {


### PR DESCRIPTION
The \`roof-corner.test.ts\` full-angle sweep ("keeps the complete roof, gutter, beam, and shared-post joint continuous at every supported angle") runs ~5.7s on a 2-core x64 CI runner — past bun's default 5s per-test budget. It runs 2-3s locally on Apple Silicon, which is why it never failed a dev machine.

Surfaced by pascalorg/private-editor#381 (the #692 submodule bump) — the first CI lane to ever execute this suite (#651 merged before any test lane existed for it). Not a correctness failure: the sweep passes everywhere given time; this gives it a 30s budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout bump with no production or correctness changes.
> 
> **Overview**
> Gives the full-angle lean-to corner-joint sweep in `roof-corner.test.ts` a **30s** budget so it no longer times out on slower CI runners.
> 
> The test itself is unchanged; bun’s default 5s per-test limit was too tight for the ~6s sweep on 2-core x64 CI (it finishes in 2–3s locally).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 709a93717ed8b4631bb1538f122ba70ce7692a01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->