### PR TITLE
chore: bump plugin-bones to 85238a8e (night-6 batch)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#22d9e7ae6807126d3f485ae4c3d538280137a43a",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#85238a8eb4e221cc1f779f47fb8aa8ef6922627c",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#22d9e7ae6807126d3f485ae4c3d538280137a43a",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#85238a8eb4e221cc1f779f47fb8aa8ef6922627c",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#22d9e7a", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-22d9e7a"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#85238a8", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-85238a8"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Night-6 plugin batch, loop-verified (examiner ship-stamp + skeptic rounds + full-stack visual QA at this exact pin on :3002):

- **Live framing recompute during drags** — the X-ray's framing follows door/window gestures (~10Hz trailing throttle over the host's live node overrides) instead of freezing until drop. Pairs with #689/#694 host fixes.
- Subfloor deck members (LOD-400 B3) + floor-sheet legibility (deck as translucent under-layer, labeled).
- Header truth (B1): composed flags print verbatim at any length; flag block paginates; engineered headers book as supplier SKUs.
- Takeoff one-row-per-material (B4) + climate-zone insulation/vapor labels revived in all 51 jurisdictions.
- PT sole plates on slab, R317.1 (B5) with a 52-code expected-diff manifest.
- Roof span discipline (B2), storey-relative elevation lifts, blocking full-extent cull tests, LOD stamp honesty.

950 tests green at the pin; baseline byte-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only pin of a core editor plugin; behavior of framing, takeoff, and code output can change without local source review.
> 
> **Overview**
> Bumps the editor’s `@pascal-app/plugin-bones` Git pin from `22d9e7a` to `85238a8` (lockfile updated to match).
> 
> The new pin is intended to bring live X-ray framing during door/window drags, plus framing/takeoff/code-sheet improvements (subfloor deck, header flags, one-row-per-material takeoff, PT sole plates, roof span discipline). No host-app code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5cd376f845329b39f58dcf79b07daae71c980c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->