### PR TITLE
chore: bump plugin-bones to ecadea5 (night-7 batch)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#85238a8eb4e221cc1f779f47fb8aa8ef6922627c",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#3022fc0d265548611da2ad68b8c8d5c840607a80",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#85238a8eb4e221cc1f779f47fb8aa8ef6922627c",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#3022fc0d265548611da2ad68b8c8d5c840607a80",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#85238a8", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-85238a8"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#3022fc0", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-3022fc0"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Night-7 plugin batch, loop-verified (~15 adversarial rounds; every merge individually gated; pre-ship 3D visual round APPROVE with instance-level numeric evidence):

- **F1 line-set**: real routed pair condenser→air handler (shared route, rolled risers, 3.5cm cross-trade lateral off the plumbing plane, composed crossing flags, exact miter corners).
- **F3 drainage**: buried sloped DWV tree per fixture → one labeled sewer exit; frost sleeves per actual concrete crossing; upper-storey honesty; MEP flow arrows/ticks/marker with full de-collision.
- **B17 slab truth** (wave-2 blocker): slab field + vapor retarder members and rows; first-principles pour math; true-thickness side-view strokes.
- **B19 return-air truth** (wave-2 blocker): AH placement out of the garage (M1602.2(1)); real return trunk with supply keep-out; true duct sections in takeoff; soffit doorway crossings slide or flag.
- MEP glyph layer: joint text/pipe/equipment obstacle model, honest crowded-drops.

1054 tests at the pin; baseline byte-stable. Pairs with #697 (nearest-first selection) already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Host-app change is only a dependency pin, but it ships substantial external plugin logic for routing, drainage, slabs, and HVAC that can change generated 3D/MEP output.
> 
> **Overview**
> Bumps `@pascal-app/plugin-bones` from `85238a8` to `3022fc0` in the editor app (and lockfile). No host-app code changes.
> 
> The new pin is intended to bring in the night-7 plugin batch: routed condenser→AHU line-sets, sloped DWV drainage, slab/vapor-retarder truth, return-air/AH placement rules, and denser MEP glyph collision handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69967e52dbe017cca880a9b09a57b709aa2b61a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->