### PR TITLE
chore: bump plugin-bones — the outside heat pump always ships

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#3022fc0d265548611da2ad68b8c8d5c840607a80",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#73c0812bbd64c1b0ccdf88ef882eb51e5d6139ae",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#3022fc0d265548611da2ad68b8c8d5c840607a80",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#73c0812bbd64c1b0ccdf88ef882eb51e5d6139ae",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -725,7 +725,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#3022fc0", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-3022fc0"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#73c0812", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-73c0812"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Fixes the user report "sometimes the hvac does not add the outside heat pump."

Root cause (2,700-compose sweep): the whole outdoor block (unit/pad/disconnect/whip/line-set) was gated behind detail 400 while the air handler and ducts ship at every LOD — the panel's LOD knob silently removed the heat pump. Also fixed: silent skips on no-exterior-wall footprints and unresolvable heat-pump service nodes.

Contract now gated across 1,500 composes: an air handler always implies ≥1 outdoor unit, or a warning names the reason. Skeptic + examiner APPROVE; baseline byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin only; no local logic, auth, or data-handling changes. Risk is limited to whatever the new plugin-bones commit does at compose time.
> 
> **Overview**
> Pins `@pascal-app/plugin-bones` to `73c0812` so HVAC composes always include the outdoor heat pump (unit, pad, disconnect, whip, line-set) instead of dropping it when LOD is below detail 400.
> 
> Also picks up plugin-side handling for no-exterior-wall footprints and unresolvable heat-pump service nodes, with a compose contract that an air handler implies at least one outdoor unit (or a named warning).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a201393c79a48e9b1ba77cefadc254e3d4a8a0d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->