### PR TITLE
fix(core): slab-sourced wall drafts are never coerced to a ground base

### DIFF
--- a/packages/core/src/hooks/spatial-grid/support-host-patch.ts
+++ b/packages/core/src/hooks/spatial-grid/support-host-patch.ts
@@ -443,6 +443,9 @@ export function resolveWallConstruction(
   let resolvedNodes = nodes
   let sourceSupportUpdate: WallConstructionResolution['sourceSupportUpdate'] = null
   const constructionSourceNodeId = options?.constructionSourceNodeId
+  const constructionSourceIsSlab = constructionSourceNodeId
+    ? nodes[constructionSourceNodeId]?.type === 'slab'
+    : false
   if (constructionSourceNodeId) {
     const sourceNode = nodes[constructionSourceNodeId]
     const currentSupport =
@@ -475,13 +478,14 @@ export function resolveWallConstruction(
       !options.flatConstructionBase
         ? undefined
         : options
-    const preferredSupportSlabId =
-      wallOptions?.flatConstructionBase === true
-        ? GROUND_SUPPORT_ID
-        : (wallOptions?.preferredSupportSlabId ??
-          (wallOptions?.constructionElevation != null && terrainBase != null
-            ? GROUND_SUPPORT_ID
-            : null))
+    const flatConstructionBase =
+      wallOptions?.flatConstructionBase === true && !constructionSourceIsSlab
+    const preferredSupportSlabId = flatConstructionBase
+      ? GROUND_SUPPORT_ID
+      : (wallOptions?.preferredSupportSlabId ??
+        (wallOptions?.constructionElevation != null && terrainBase != null
+          ? GROUND_SUPPORT_ID
+          : null))
     const supportPatch = resolveWallSupportSlabPatch(wallWithParent, resolvedNodes, {
       maxElevation: wallOptions?.supportCap ?? null,
       preferredSlabId: preferredSupportSlabId,
@@ -496,8 +500,7 @@ export function resolveWallConstruction(
       wallOptions?.supportCap ?? null,
     )
     const groundDraft =
-      preferredSupportSlabId === GROUND_SUPPORT_ID &&
-      (terrainBase != null || wallOptions?.flatConstructionBase === true)
+      preferredSupportSlabId === GROUND_SUPPORT_ID && (terrainBase != null || flatConstructionBase)
     const supportOffset =
       groundDraft && wallOptions?.constructionElevation != null
         ? wallOptions.constructionElevation - sourceSupport.elevation

--- a/packages/editor/src/components/tools/wall/wall-drafting.test.ts
+++ b/packages/editor/src/components/tools/wall/wall-drafting.test.ts
@@ -423,6 +423,136 @@ describe('createWallOnCurrentLevel', () => {
     expect(created?.supportSlabId).not.toBe(GROUND_SUPPORT_ID)
   })
 
+  test('a fresh-scene wall started on a slab node-top elects that slab plane-bound', () => {
+    const slab = SlabNode.parse({
+      id: 'slab_fresh_floor',
+      parentId: LEVEL_ID,
+      polygon: [
+        [-1, -1],
+        [5, -1],
+        [5, 5],
+        [-1, 5],
+      ],
+      elevation: 0.05,
+      thickness: 0.05,
+    })
+    seedLevel([], [slab])
+    spatialGridManager.clear()
+    spatialGridManager.handleNodeCreated(slab as AnyNode, LEVEL_ID)
+
+    const created = createWallOnCurrentLevel([2, 2], [3, 2], {
+      supportCap: 0.05,
+      preferredSupportSlabId: null,
+      constructionElevation: 0.05,
+      constructionHeight: 2.5,
+      constructionSourceNodeId: slab.id,
+      flatConstructionBase: true,
+    })
+
+    expect(created).not.toBeNull()
+    expect(created?.supportSlabId).toBeUndefined()
+    expect(created?.height).toBeUndefined()
+    expect(created?.supportOffset).toBeUndefined()
+    const support = spatialGridManager.getSlabSupportForWall(
+      LEVEL_ID,
+      created!.start,
+      created!.end,
+      created!.curveOffset,
+      created!.thickness,
+      created!.supportSlabId,
+    )
+    expect(support.electedSlabId).toBe(slab.id)
+    expect(support.elevation).toBeCloseTo(0.05)
+  })
+
+  test('a direct slab source does not pin a cross-slab wall away from the higher majority support', () => {
+    const sourceSlab = SlabNode.parse({
+      id: 'slab_source_low',
+      parentId: LEVEL_ID,
+      polygon: [
+        [-0.1, -1],
+        [0.1, -1],
+        [0.1, 1],
+        [-0.1, 1],
+      ],
+      elevation: 0.1,
+      thickness: 0.05,
+    })
+    const majoritySlab = SlabNode.parse({
+      id: 'slab_majority_high',
+      parentId: LEVEL_ID,
+      polygon: [
+        [0.1, -1],
+        [4.1, -1],
+        [4.1, 1],
+        [0.1, 1],
+      ],
+      elevation: 0.6,
+      thickness: 0.1,
+    })
+    seedLevel([], [sourceSlab, majoritySlab])
+    spatialGridManager.clear()
+    spatialGridManager.handleNodeCreated(sourceSlab as AnyNode, LEVEL_ID)
+    spatialGridManager.handleNodeCreated(majoritySlab as AnyNode, LEVEL_ID)
+
+    const created = createWallOnCurrentLevel([0, 0], [4, 0], {
+      supportCap: 0.6,
+      preferredSupportSlabId: null,
+      constructionElevation: 0.1,
+      constructionHeight: 2.5,
+      constructionSourceNodeId: sourceSlab.id,
+      flatConstructionBase: true,
+    })
+
+    expect(created?.supportSlabId).toBe(majoritySlab.id)
+    expect(created?.height).toBeUndefined()
+    expect(created?.supportOffset).toBeUndefined()
+  })
+
+  test('a grazing direct slab source does not override the commit elevation cap', () => {
+    const sourceSlab = SlabNode.parse({
+      id: 'slab_source_high',
+      parentId: LEVEL_ID,
+      polygon: [
+        [-0.1, -1],
+        [0.1, -1],
+        [0.1, 1],
+        [-0.1, 1],
+      ],
+      elevation: 0.6,
+      thickness: 0.1,
+    })
+    const cappedSlab = SlabNode.parse({
+      id: 'slab_capped_low',
+      parentId: LEVEL_ID,
+      polygon: [
+        [-0.1, -1],
+        [4.1, -1],
+        [4.1, 1],
+        [-0.1, 1],
+      ],
+      elevation: 0.1,
+      thickness: 0.05,
+    })
+    seedLevel([], [sourceSlab, cappedSlab])
+    spatialGridManager.clear()
+    spatialGridManager.handleNodeCreated(sourceSlab as AnyNode, LEVEL_ID)
+    spatialGridManager.handleNodeCreated(cappedSlab as AnyNode, LEVEL_ID)
+
+    const created = createWallOnCurrentLevel([0, 0], [4, 0], {
+      supportCap: 0.1,
+      preferredSupportSlabId: null,
+      constructionElevation: 0.6,
+      constructionHeight: 2.5,
+      constructionSourceNodeId: sourceSlab.id,
+      flatConstructionBase: true,
+    })
+
+    expect(created?.supportSlabId).toBe(cappedSlab.id)
+    expect(created?.height).toBeUndefined()
+    expect(created?.supportOffset).toBeUndefined()
+  })
+
   test('a non-ground draft never freezes the ghost height, even at a raised plane', () => {
     const created = createWallOnCurrentLevel([2, 2], [3, 2], {
       supportCap: 1.2,


### PR DESCRIPTION
Fixes #699 — walls drawn on a slab in **fresh scenes** committed terrain-hosted (`height` = level height, `supportOffset` = slab elevation, `supportSlabId: "ground"`) while rendering correctly on the slab. Mechanism and scene-structure discriminator are in the issue.

## The fix (deliberately narrow)

`resolveWallConstruction`: a `constructionSourceNodeId` that resolves to a **slab** suppresses the `flatConstructionBase` ground coercion — nothing more. Normal capped support election then finds the underlying slab; caller-supplied `preferredSupportSlabId` semantics are untouched; genuine terrain drafts (no slab source) keep their by-design explicit height/offset stamping (#630 rule).

A first iteration also fed the source slab into `preferredSlabId`; the independent review pass caught that this would pin the first-click slab across cross-slab walls (overriding per-commit re-election and the elevation cap, and diverging from the 2D path). The narrowed version ships with tests for exactly those shapes.

## Evidence

- **Unit, red-first**: fresh-scene shape failed on unpatched code (`Expected "slab_fresh_floor" / Received "ground"`); the two review-derived tests (cross-slab majority wins; grazing source not pinned) failed on the broad first patch and pass on the narrowed one. Focused suites 35/35, full `turbo test` 13/13.
- **Acceptance e2e** (private-editor, fresh org-moved project — the exact bug shape): `wall-plane-bound` un-fixme'd passes 2× (28.0s / 22.4s). It ships `test.fixme`'d over there and gets un-fixme'd in the submodule-bump PR after this merges.
- **Adjacent e2e**: wall-hover-outline and undo-redo-graph green on the rebuilt packages.
- Caller trace: `resolveWallConstruction` has one production caller (wall-drafting), reached from the 3D wall tool and the floorplan panel; column/fence/stair flows don't pass these options. The floorplan path has no equivalent coercion (parity checked per `wiki/architecture/tools.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wall support-host persistence, which can change committed geometry, but the change is a small, well-tested guard in one resolver.
> 
> **Overview**
> Walls started on a **slab** in `resolveWallConstruction` no longer get `flatConstructionBase` treated as a ground host. That was committing fresh-scene slab drafts as terrain-hosted (`GROUND_SUPPORT_ID` plus stamped height/offset) even though they rendered on the slab.
> 
> The source slab is only used to suppress that coercion. Support still re-elects under the existing cap, so a first-click slab is not pinned across a longer wall. Genuine terrain drafts without a slab source keep explicit height/offset stamping.
> 
> Tests cover the fresh-scene slab case, majority support on a cross-slab span, and a grazing source that must not override the elevation cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec838824a041ee2c517b6c958557a4d2693feaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->