### PR TITLE
Bump plugin-bones to 1cac1bb (day-9 feedback batch)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#92d84d7b5aae3b8fa0f167343fec1f878088cefa",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#1cac1bbca054a8ae5b497f47bcca532da0f605b6",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#92d84d7b5aae3b8fa0f167343fec1f878088cefa",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#1cac1bbca054a8ae5b497f47bcca532da0f605b6",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -739,7 +739,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#92d84d7", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-92d84d7"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#1cac1bb", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-1cac1bb"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Four loop-verified fixes from this morning's user feedback:

- **Starter-template heat pump** — the exterior-wall election failed on slab-less zoned scenes (the starter template), leaving the condenser as a flagged fallback stub hidden in the garden fence. Root cause fixed at the election (indoor-zone polygons stand in as floor coverage when no slab exists) + a new 'outdoor' room category so HVAC never serves open air; the unit now stands outside with its NEC 440.14 disconnect and wall-routed line-set, sized from conditioned area only. 22 pinned gates on the actual template compose, 5 adversarial rounds.
- **Sidebar declutter** — warnings fold into a collapsed drawer with repeated classes grouped; flags collapsed by default.
- **Basement → Subfloor** — label rename (schema value unchanged, no migration).
- **Selected-wall open cut** — clicking a wall no longer closes both drywall faces over its wiring; the wall stays open toward the camera while its engineering card is up.

Plugin suite 1591 green, tsc clean. Pre-ship visual round: SHIP 4/4 + regression clean, zero console errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only pin, but it changes HVAC placement and wall-cut behavior in the editor plugin. Regression risk is moderate if the external SHA is wrong or incomplete.
> 
> **Overview**
> Pins `@pascal-app/plugin-bones` to `1cac1bb` so the editor picks up a batch of plugin-side UX and placement fixes.
> 
> The new pin places the starter-template heat pump outdoors (using indoor-zone polygons when there is no slab, plus an outdoor room category so HVAC is not served into open air), folds sidebar warnings into a collapsed grouped drawer, relabels Basement to Subfloor without a schema migration, and keeps a selected wall open toward the camera instead of closing both drywall faces over wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c00d219b0de9f01bbc457eeeab0fd4a03bddb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->