### PR TITLE
Bump plugin-bones to 43fbf41 (condenser honesty fast-follow)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#1cac1bbca054a8ae5b497f47bcca532da0f605b6",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#43fbf418b7f024f2207fe3d40d92dbe2341a8381",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#1cac1bbca054a8ae5b497f47bcca532da0f605b6",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#43fbf418b7f024f2207fe3d40d92dbe2341a8381",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -739,7 +739,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#1cac1bb", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-1cac1bb"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#43fbf41", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-43fbf41"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Warnings-only fast-follow to the day-9 batch (zero geometry/render changes — baseline byte-identical): a level whose X-ray can't derive HVAC/plumbing now says why ('no indoor zones on this level — draw zones here or X-ray the storey that has them' and siblings); a heat-pump point dragged indoors or >25ft (NEC 210.63) from every wall warns instead of silently drawing there; upper-storey condensers state their floor-elevation mounting. Root of the user report: an X-rayed level with no indoor zones looked alive (framing/electrical render) while HVAC silently skipped. Plugin 1610 tests, 2 adversarial rounds, mutation-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin only; warnings-only plugin behavior with no geometry, render, or auth/data-path changes in this repo.
> 
> **Overview**
> Pins `@pascal-app/plugin-bones` to `43fbf41` so HVAC/X-ray and condenser placement explain themselves instead of failing silently.
> 
> X-ray on a level with no indoor zones now says why HVAC/plumbing was skipped. Heat-pump points indoors or more than 25ft from a wall (NEC 210.63) warn instead of drawing quietly. Upper-storey condensers note floor-elevation mounting. Geometry and render output are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a481dd40bcc2a11fbc20e2958e87e65e60c283da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->