### PR TITLE
Fix order-dependent pointer-support flake: registry leaks across test files

### DIFF
--- a/packages/core/src/registry/registry.test.ts
+++ b/packages/core/src/registry/registry.test.ts
@@ -105,6 +105,35 @@ describe('nodeRegistry', () => {
     registerNode(b)
     expect(nodeRegistry.schemas()).toEqual([a.schema, b.schema])
   })
+
+  test('_snapshot() restores definitions and plugin bookkeeping', async () => {
+    const kept = makeDefinition('kept')
+    registerNode(kept)
+    await loadPlugin({
+      id: 'test:kept-plugin',
+      apiVersion: 1,
+      nodes: [makeDefinition('kept-plugin-kind')],
+    } as Plugin)
+
+    const restore = nodeRegistry._snapshot()
+
+    // Mutate every kind of registry state a test can leak: a throwaway
+    // definition, a full reset, and a plugin load with its kind bookkeeping.
+    registerNode(makeDefinition('leaked'))
+    nodeRegistry._reset()
+    await loadPlugin({
+      id: 'test:leaked-plugin',
+      apiVersion: 1,
+      nodes: [makeDefinition('leaked-plugin-kind')],
+    } as Plugin)
+
+    restore()
+
+    expect(Array.from(nodeRegistry.entries(), ([k]) => k)).toEqual(['kept', 'kept-plugin-kind'])
+    expect(nodeRegistry.get('kept')).toBe(kept)
+    expect(getNodePluginId('kept-plugin-kind')).toBe('test:kept-plugin')
+    expect(getNodePluginId('leaked-plugin-kind')).toBeUndefined()
+  })
 })
 
 describe('isPresettable', () => {

--- a/packages/core/src/registry/registry.ts
+++ b/packages/core/src/registry/registry.ts
@@ -131,11 +131,37 @@ class NodeRegistryImpl implements NodeRegistry {
     inspectorExtensionsByKind.clear()
     notifyRegistryChanged()
   }
+
+  // Test-only — captures the registry (definitions + plugin bookkeeping) and
+  // returns a restore function. The registry is a module singleton and bun
+  // runs a package's test files sequentially in ONE process, so a test that
+  // registers a throwaway kind (or `_reset()`s) without restoring leaks that
+  // state into every later test FILE — and file order varies by platform
+  // (macOS vs CI Linux), which turns the leak into an order-dependent flake.
+  // Wrap registry mutations in `const restore = nodeRegistry._snapshot()`
+  // + `restore()` in `afterEach`/`finally`.
+  _snapshot(): () => void {
+    const defs = new Map(this.defs)
+    const pluginIds = new Map(pluginIdsByKind)
+    const extensions = new Map(
+      Array.from(inspectorExtensionsByKind, ([kind, list]) => [kind, [...list]] as const),
+    )
+    return () => {
+      this.defs.clear()
+      for (const [kind, def] of defs) this.defs.set(kind, def)
+      pluginIdsByKind.clear()
+      for (const [kind, id] of pluginIds) pluginIdsByKind.set(kind, id)
+      inspectorExtensionsByKind.clear()
+      for (const [kind, list] of extensions) inspectorExtensionsByKind.set(kind, [...list])
+      notifyRegistryChanged()
+    }
+  }
 }
 
 export const nodeRegistry: NodeRegistry & {
   _register: (def: AnyNodeDefinition) => void
   _reset: () => void
+  _snapshot: () => () => void
 } = new NodeRegistryImpl()
 
 export function registerNode(def: AnyNodeDefinition): void {

--- a/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.test.ts
+++ b/packages/editor/src/components/editor-2d/renderers/floorplan-registry-layer.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import type {
   AnyNode,
   AnyNodeId,
@@ -447,11 +447,19 @@ describe('floorplan annotation overlay routing', () => {
 })
 
 describe('computeAffectedSiblingIds', () => {
+  // The cabinet fixture definitions have no `capabilities` — leaking them
+  // past this describe crashes any later test FILE that enumerates the
+  // registry (night-8 CI: pointer-support-cap.test.ts, run 32580694134).
+  let restoreRegistry: () => void
+
   beforeEach(() => {
+    restoreRegistry = nodeRegistry._snapshot()
     nodeRegistry._reset()
     registerCabinetFloorplanDefinition('cabinet')
     registerCabinetFloorplanDefinition('cabinet-module')
   })
+
+  afterEach(() => restoreRegistry())
 
   test('propagates cabinet live overrides through the cabinet family', () => {
     const run = cabinetRun('cabinet_run', ['cabinet-module_main', 'cabinet-module_corner'])
@@ -545,6 +553,16 @@ describe('collectFloorplanDependencyNodes', () => {
 })
 
 describe('collectFloorplanLinkedLevelNodes', () => {
+  // Same containment as computeAffectedSiblingIds above: the fixture
+  // definition has no `capabilities`, so it must not outlive this describe.
+  let restoreRegistry: () => void
+
+  beforeEach(() => {
+    restoreRegistry = nodeRegistry._snapshot()
+  })
+
+  afterEach(() => restoreRegistry())
+
   test('projects a node onto a linked destination level with its real children', () => {
     nodeRegistry._reset()
     registerNode({

--- a/packages/editor/src/components/tools/shared/pointer-support-cap.test.ts
+++ b/packages/editor/src/components/tools/shared/pointer-support-cap.test.ts
@@ -241,4 +241,39 @@ describe('resolvePointerSupportSurface node tops', () => {
       wallSupport.baseSegments.every((segment) => Math.abs(segment.elevation - 2) < 1e-6),
     ).toBe(true)
   })
+
+  test('tolerates a registered definition without capabilities', () => {
+    // Gates the pollution class behind the night-8 CI flake (run
+    // 32580694134): `capabilities` is typed required, but a minimal plugin
+    // definition (or a leaked test fixture) can ship without it at runtime.
+    // The resolver enumerates every registered kind, so one capabilities-less
+    // entry must read as "no top surface" — not crash the election.
+    const restoreRegistry = nodeRegistry._snapshot()
+    try {
+      registerNode({
+        kind: 'plugin-minimal-capless',
+        schemaVersion: 1,
+        schema: z.object({}),
+        category: 'structure',
+        defaults: () => ({}),
+        // No `capabilities` — deliberately.
+      } as unknown as AnyNodeDefinition)
+      addPluginPlatform()
+
+      const camera = new PerspectiveCamera()
+      camera.position.set(0, 5, 0)
+      camera.updateMatrixWorld(true)
+
+      const support = resolvePointerSupportSurface(camera, [0, 0, 0], {
+        includeNodeTopSurfaces: true,
+      })
+
+      // No throw, and the election still works: the capabilities-less kind is
+      // skipped while the platform's declared top is found as usual.
+      expect(support?.sourceNodeId).toBe(PLATFORM_ID)
+      expect(support?.elevation).toBeCloseTo(2)
+    } finally {
+      restoreRegistry()
+    }
+  })
 })

--- a/packages/editor/src/components/tools/shared/pointer-support-cap.ts
+++ b/packages/editor/src/components/tools/shared/pointer-support-cap.ts
@@ -158,9 +158,14 @@ export function resolvePointerSupportSurface(
   // lifts anything placed inside a finished room. Only the tools that build ON
   // a surface (wall / column / fence / stair / block) mean that, and they say
   // so. Everything else places against the floor the pointer indicates.
+  //
+  // `capabilities` is typed required on NodeDefinition, but this enumerates
+  // EVERY registered kind — including plugin bundles that bypass the type at
+  // runtime. A minimal definition without `capabilities` must read as "no top
+  // surface", not crash the resolver (night-8 CI, run 32580694134).
   const nodeTopSurfaceKinds = options?.includeNodeTopSurfaces
     ? Array.from(nodeRegistry.entries())
-        .filter(([, definition]) => definition.capabilities.surfaces?.top !== undefined)
+        .filter(([, definition]) => definition.capabilities?.surfaces?.top !== undefined)
         .map(([kind]) => kind)
     : []
   if (nodeTopSurfaceKinds.some((kind) => (sceneRegistry.byType[kind]?.size ?? 0) > 0)) {

--- a/packages/editor/src/components/tools/wall/wall-drafting.test.ts
+++ b/packages/editor/src/components/tools/wall/wall-drafting.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
   type AnyNode,
   type AnyNodeId,
@@ -143,6 +143,15 @@ function levelWalls(): WallNode[] {
 }
 
 describe('createWallOnCurrentLevel', () => {
+  // Set by tests that mutate the process-wide node registry; restored here
+  // so the mutation can't leak into later test files (order-dependent flakes).
+  let restoreRegistry: (() => void) | undefined
+
+  afterEach(() => {
+    restoreRegistry?.()
+    restoreRegistry = undefined
+  })
+
   beforeEach(() => {
     useViewer.setState({
       selection: {
@@ -314,6 +323,10 @@ describe('createWallOnCurrentLevel', () => {
   })
 
   test('pins an existing construction source before a generated room slab can lift it', () => {
+    // The reset + throwaway `block` registration is scoped to this test —
+    // the registry is a process-wide singleton, so leaking it would leave
+    // later test FILES with a stripped registry (order-dependent flakes).
+    restoreRegistry = nodeRegistry._snapshot()
     nodeRegistry._reset()
     spatialGridManager.clear()
     registerNode({

--- a/packages/editor/src/lib/floorplan/apply-alignment.test.ts
+++ b/packages/editor/src/lib/floorplan/apply-alignment.test.ts
@@ -1,8 +1,23 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { useScene } from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
 import useAlignmentGuides from '../../store/use-alignment-guides'
 import { applyFloorplanAlignment } from './apply-alignment'
 
 describe('applyFloorplanAlignment', () => {
+  beforeEach(() => {
+    // These tests assume no active building (alignment runs on world axes).
+    // The scene/viewer stores are process-wide singletons, so an earlier test
+    // FILE can leak a selected building fixture into them — under bun's
+    // platform-dependent file order that turned into an order-dependent
+    // failure (getActiveBuildingPose reading a fixture building without a
+    // rotation array). Pin the empty-scene context explicitly.
+    useScene.setState({ nodes: {} } as never)
+    useViewer.setState({
+      selection: { buildingId: null, levelId: null, zoneId: null, selectedIds: [] },
+    } as never)
+  })
+
   afterEach(() => {
     useAlignmentGuides.getState().clear()
   })


### PR DESCRIPTION
## The flake

Night-8 private-editor CI ([run 32580694134](https://github.com/pascalorg/private-editor/actions/runs/32580694134)) failed three tests in `packages/editor/src/components/tools/shared/pointer-support-cap.test.ts`:

- `discovers a plugin-declared top surface without a kind-name list`
- `never elects the node the active interaction is placing or moving`
- `uses a plugin-declared top as the wall construction surface`

all with `TypeError: undefined is not an object (evaluating 'definition.capabilities.surfaces')` at `pointer-support-cap.ts:163`. The same tree passed 752/752 locally twice (forced).

## Root cause: order-dependent test pollution

`nodeRegistry` is a module singleton and bun runs a package's test files sequentially in **one process**. `floorplan-registry-layer.test.ts` registers capabilities-less fixture definitions (`cabinet`, `cabinet-module`, `linked-floorplan-test`) after a `nodeRegistry._reset()` and never restores. Bun's test-file order differs between platforms (macOS local vs CI Linux) — when the floorplan file runs **before** `pointer-support-cap.test.ts`, the leaked entries hit the top-surface enumeration:

```ts
.filter(([, definition]) => definition.capabilities.surfaces?.top !== undefined)
```

and only the three tests that pass `includeNodeTopSurfaces: true` crash — exactly the CI signature.

**Reproduced deterministically** on unmodified `main` with `bun test --randomize --seed=1` on the two-file pair: same three tests, same TypeError, same line.

## The fix (both sides + a gate)

1. **Test hygiene** — new test-only `nodeRegistry._snapshot()` (captures definitions + plugin bookkeeping, returns a restore fn). Applied in:
   - `floorplan-registry-layer.test.ts` — both mutation sites now snapshot/restore
   - `wall-drafting.test.ts` — the mid-test `_reset()` no longer strips the registry for later files
2. **Production honesty** — `definition.capabilities?.surfaces?.top`. `capabilities` is typed required, but the resolver enumerates *every* registered kind and a plugin bundle can bypass the type at runtime; a minimal definition must read as "no top surface", not crash the election.
3. **Gate** — a test registers a capabilities-less definition then calls `resolvePointerSupportSurface`: no throw, and the platform's declared top is still elected. Verified failing against the unguarded code, passing with the chain.

Bonus: seed-22 randomized verification surfaced a second latent flake of the same class (`apply-alignment.test.ts` inheriting a leaked building fixture through the scene/viewer store singletons — confirmed pre-existing on unmodified `main`). Pinned its empty-scene context explicitly.

## Verification

- Repro before fix: seeds 1/2/4/6 fail on the two-file pair with the CI signature; green after
- Full editor suite `bun test --randomize` x10 fresh seeds: 753 pass / 0 fail each
- `bunx turbo run test --filter=@pascal-app/editor --force`: 753/753 (752 + new gate test)
- Full repo `bunx turbo run test`: 13/13 tasks green
- `check-types` (editor + core) and Biome on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly test isolation plus optional chaining on a registry enumeration path. Production behavior only changes for malformed/minimal definitions that previously threw.
> 
> **Overview**
> Stops order-dependent CI flakes from tests mutating the process-wide `nodeRegistry` (and scene/viewer stores) without restoring them. Bun runs a package’s tests in one process, so a leaked capabilities-less fixture crashed later `pointer-support-cap` files when file order differed on Linux.
> 
> Adds test-only `nodeRegistry._snapshot()` to capture definitions plus plugin bookkeeping and restore them. Floorplan registry and wall-drafting tests now snapshot/restore around `_reset()` and throwaway registrations.
> 
> `resolvePointerSupportSurface` now uses optional chaining on `capabilities`, so a kind without that field is skipped instead of throwing. A gate test registers a capless definition and still elects the platform top. Alignment tests also pin an empty scene/selection so a leaked building fixture cannot break world-axis alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14eb77a2f27ee18151a6557fc044da32361ba1ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->