### PR TITLE
Bump plugin-bones to 4a527ec (heat-pump package)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#43fbf418b7f024f2207fe3d40d92dbe2341a8381",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#4a527ecba1135ed8c85ef4de98ebf63bfb2e4da8",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#43fbf418b7f024f2207fe3d40d92dbe2341a8381",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#4a527ecba1135ed8c85ef4de98ebf63bfb2e4da8",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -739,7 +739,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#43fbf41", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-43fbf41"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#4a527ec", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-4a527ec"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
The complete heat-pump fast-follow, all loop-verified + visually re-checked (SHIP 5/5): scene-aware condenser election (auto placement validates as genuinely outdoors — fixes units landing inside rooms on scenes with floor-coverage quirks), the condenser renders as the AC block asset with its tonnage label, and engine-rendered service kinds drop their placeholder bodies in X-ray (the sign remains the select/move handle — verified end to end). Plugin 1646 tests at the pinned sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only pin, but it changes 3D placement and rendering of heat-pump equipment in the editor, so visual/behavior regressions are possible without local code review of the plugin.
> 
> **Overview**
> Pins `@pascal-app/plugin-bones` to `4a527ec` so the editor picks up the heat-pump fast-follow.
> 
> That plugin revision adds scene-aware condenser placement (units must land outdoors), renders the condenser as the AC block with a tonnage label, and drops placeholder bodies for engine-rendered service kinds in X-ray while keeping the sign as the select/move handle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd95918da4c0413d63dea37e823931d48aab3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->