### PR TITLE
Bump plugin-bones to d1c3c8b (night-10 dawn batch)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#4a527ecba1135ed8c85ef4de98ebf63bfb2e4da8",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#d1c3c8be23a0686acf9e54b5599e69ae9734e84f",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#4a527ecba1135ed8c85ef4de98ebf63bfb2e4da8",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#d1c3c8be23a0686acf9e54b5599e69ae9734e84f",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -739,7 +739,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#4a527ec", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-4a527ec"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#d1c3c8b", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-d1c3c8b"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Eight adversarially-verified merges. Highlights: HVAC tonnage now sized per IRC M1401.3 → Manual J/S from the actual envelope + climate (humid-zone latent allowance, multi-unit splits); the duct-junction two-color z-fight verified gone at the reported camera (0/1.6M differing pixels across provocation orbits); structural hardware finally keyed on the sheets; outdoor zones stopped faking indoor electrical. Dawn visual round: SHIP 6/6, zero console errors across 20 sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> External plugin pin only, but bones drives building systems (HVAC, electrical, structure) so regressions can affect generated models and sheets. Peer deps are unchanged.
> 
> **Overview**
> Bumps the editor’s `@pascal-app/plugin-bones` pin from `4a527ec` to `d1c3c8b` (lockfile updated to match).
> 
> The new plugin build is described as bringing envelope/climate-based HVAC tonnage (IRC M1401.3 / Manual J–S), a duct-junction z-fight fix, structural hardware keyed on sheets, and outdoor zones no longer treated as indoor electrical. No app code changes besides the dependency pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ce5997015f18cc5ad4f6017d29b5ac17a703fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->