### PR TITLE
Bump plugin-bones to 5c2650e (heat pump first-class object)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#d1c3c8be23a0686acf9e54b5599e69ae9734e84f",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#5c2650e262e31156ebddef3b72e240675b841534",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#d1c3c8be23a0686acf9e54b5599e69ae9734e84f",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#5c2650e262e31156ebddef3b72e240675b841534",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -739,7 +739,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#d1c3c8b", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-d1c3c8b"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#5c2650e", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-5c2650e"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Hover the outdoor unit → it highlights; click → selects its service point; ⌘-drag → the engine recomputes pad, disconnect, whip, line-set and wiring live; undo restores. The AC block renders at its true proportions (uniform scale — the one-axis squeeze is gone) with a code-honest 24" face-clearance standoff and true-size pad. Both pick proxies now write zero pixels while staying raycastable. Loop-verified (2 rounds) + browser-verified (2 rounds, zero console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> External plugin pin only, but it changes 3D selection, drag, and geometry for HVAC objects in the editor. Behavior depends entirely on the unreviewed GitHub commit.
> 
> **Overview**
> Bumps `@pascal-app/plugin-bones` in the editor from `d1c3c8b` to `5c2650e` (lockfile updated to match).
> 
> The new plugin pin treats the outdoor heat-pump unit as a first-class object: hover highlights it, click selects its service point, and ⌘-drag live-recomputes pad, disconnect, whip, line-set, and wiring (undo restores). AC rendering uses uniform scale, a 24" face-clearance standoff, and a true-size pad; pick proxies stay raycastable without drawing pixels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac51f37907ec301cca1d5d8cf7b7a425a7158a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->