### PR TITLE
Bump plugin-bones to 9f86f12 (HP polish + LGS steel walls)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#c05c13e00956d9c1525fab5493a8cd9f3ac9c134",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#9f86f120da4697bd62174eeba16660f674faa313",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#c05c13e00956d9c1525fab5493a8cd9f3ac9c134",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#9f86f120da4697bd62174eeba16660f674faa313",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -783,7 +783,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#c05c13e", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-c05c13e"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#9f86f12", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-9f86f12"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Community plugin pin bump.

- **HP unit polish**: equipment-gray schematic tint, wall-square assembly, world-XZ-grid snapped auto placement (least-standoff-first, 24" face clearance floor mathematically proven never violated), R-key/gizmo rotation with host rotation-quantum parity, off-grid honesty flag that survives the auto-seed lifecycle. 3 adversarial rounds → skeptic + examiner + visual all approve.
- **LGS Phase 1**: light-gauge steel walls at LOD-400 per IRC R603 behind the per-wall `lgs` override — C-studs/tracks (track mil == stud mil), R603.7 opening structure, R603.3.3 strap bracing with never-silent CMU-junction warnings, S240 punchout metadata. No R603 table cell invented — conservative picks state their basis on every label. Existing scenes byte-identical (baseline recapture cmp-proven). 4 adversarial rounds → approve.

Plugin suite: 1883 tests, 0 fail; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin only in the editor app; no monorepo code changes, though the new plugin version may alter 3D/editor behavior for bones-related workflows.
> 
> **Overview**
> Pins **`@pascal-app/plugin-bones`** in the editor app from `c05c13e` to **`9f86f120`** and refreshes **`bun.lock`**. No local source changes—behavior updates come entirely from the new plugin revision (described upstream as **HP unit polish** and **LGS Phase 1** light-gauge steel wall modeling behind per-wall overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59b46423ff1c54288e0d0129f3501aae7204e315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->