### PR TITLE
Bump plugin-bones to 5679260 (LGS machine UX + Canadian jurisdictions)

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.2",
-    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#9f86f120da4697bd62174eeba16660f674faa313",
+    "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#5679260261ee1c733656ff6dfb99e30bb24b58a7",
     "@mint/pascal-plugin": "github:mintdotgg/mint-pascal-plugin#902c546dbaece6b31455c0dc394afe6b9cd136fe",
     "@number-flow/react": "^0.6.0",
     "@pascal-app/core": "*",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@pascal-app/editor": "*",
         "@pascal-app/mcp": "*",
         "@pascal-app/nodes": "*",
-        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#9f86f120da4697bd62174eeba16660f674faa313",
+        "@pascal-app/plugin-bones": "github:pascalorg/plugin-bones#5679260261ee1c733656ff6dfb99e30bb24b58a7",
         "@pascal-app/plugin-streetscape": "github:sudhir9297/streetscape-pascal-plugin#1c04ec9ccb3fa8124ec56dfc1026567cbbc51aef",
         "@pascal-app/plugin-trees": "github:pascalorg/plugin-trees#56d978cd9b409b716207b3f3d269455d3cd6f067",
         "@pascal-app/viewer": "*",
@@ -783,7 +783,7 @@
 
     "@pascal-app/nodes": ["@pascal-app/nodes@workspace:packages/nodes"],
 
-    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#9f86f12", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-9f86f12"],
+    "@pascal-app/plugin-bones": ["@pascal-app/plugin-bones@github:pascalorg/plugin-bones#5679260", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "pascalorg-plugin-bones-5679260"],
 
     "@pascal-app/plugin-streetscape": ["@pascal-app/plugin-streetscape@github:sudhir9297/streetscape-pascal-plugin#1c04ec9", { "peerDependencies": { "@pascal-app/core": ">=0.9.1 <1", "@pascal-app/editor": ">=0.9.1 <1", "@pascal-app/viewer": ">=0.9.1 <1", "@react-three/fiber": "^9", "react": "^18 || ^19", "three": "^0.185", "zod": "^4", "zustand": "^5" } }, "sudhir9297-streetscape-pascal-plugin-1c04ec9"],
 


### PR DESCRIPTION
Community plugin pin bump.

- **LGS Phase 2 (machine selection)**: the wall card's construction control gains a Steel segment; the panel gains one Framing row (Lumber|Steel) with a progressive-disclosure machine select (FRAMECAD/Howick/Scottsdale/Pinnacle from the cited catalog). Selecting a machine brands member labels and emits honest per-class can't-roll warnings — it never approves a profile and never changes geometry at LOD 300+. Verified with pixel-level clutter proofs (zero differing pixels outside the panel).
- **16 Canadian jurisdictions** (community PR #1 by @JonathanNus, adopted via cherry-pick with authorship preserved): all provinces + territories + NBC-2020 fallback, cited climatic data with documented unit conversions, permafrost warnings, and a non-IRC confession warning that also fixes a dormant gap (IRC citations printed unconditionally on non-IRC jurisdictions — WI/VT now confess too).

Plugin suite: 1946 tests, 0 fail; tsc clean. Every change adversarially verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin only with no local source edits; risk is limited to regressions or UX changes inside the external plugin-bones package.
> 
> **Overview**
> Pins **`@pascal-app/plugin-bones`** in the editor app (and **`bun.lock`**) from commit `9f86f12` to **`5679260`**, with no other monorepo code changes.
> 
> The new plugin revision adds **LGS Phase 2** UX (steel framing segment, machine picker, per-class roll warnings without changing LOD 300+ geometry) and expands **Canadian jurisdiction** support (provinces/territories, NBC-2020 fallback, climatic/permafrost warnings, and IRC citation handling fixes).
> 
> Editor behavior for bones comes from the existing **`bonesPlugin` / `bonesHostPanel`** bootstrap wiring; reviewers only need to validate the updated community plugin after install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc4934116b7b232df30c8e5f874110a22486f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->