### PR TITLE
Add /import?src=<url>: a hand-off point for scanning apps

### DIFF
--- a/apps/editor/app/import/import-client.tsx
+++ b/apps/editor/app/import/import-client.tsx
@@ -106,7 +106,9 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
           message:
             response.status === 401 || response.status === 403
               ? 'You need to be signed in to import a scene.'
-              : `Creating the scene failed (${response.status}).`,
+              : response.status === 413
+                ? 'The scene is too large for the scene store.'
+                : `Creating the scene failed (${response.status}).`,
         })
         return
       }

--- a/apps/editor/app/import/import-client.tsx
+++ b/apps/editor/app/import/import-client.tsx
@@ -200,6 +200,20 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
             ))}
           </ul>
         )}
+        {/* The schema error above says "see details below" — these are the
+            details: per-node path and message, same data Load Build shows. */}
+        {result.schemaIssues.length > 0 && (
+          <ul className="mt-2 space-y-1">
+            {result.schemaIssues.map((issue) => (
+              <li
+                className="text-destructive text-xs"
+                key={`${issue.nodeId}:${issue.path}:${issue.message}`}
+              >
+                {issue.nodeId} ({issue.nodeType}) · {issue.path}: {issue.message}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
 
       {phase.createError && <p className="text-destructive text-sm">{phase.createError}</p>}

--- a/apps/editor/app/import/import-client.tsx
+++ b/apps/editor/app/import/import-client.tsx
@@ -77,7 +77,10 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
         update({ kind: 'error', message: 'The file could not be read.' })
         return
       }
-      if (text.length > MAX_IMPORT_BYTES) {
+      // Blob measures BYTES — text.length counts UTF-16 code units, and
+      // a graph full of non-ASCII names could pass here yet still 413
+      // at the store (review feedback).
+      if (new Blob([text]).size > MAX_IMPORT_BYTES) {
         update({ kind: 'error', message: 'The file is too large to import.' })
         return
       }

--- a/apps/editor/app/import/import-client.tsx
+++ b/apps/editor/app/import/import-client.tsx
@@ -7,8 +7,12 @@ import { MAX_IMPORT_BYTES, parseImportSrc } from '@/lib/import-src'
 
 type Phase =
   | { kind: 'fetching' }
-  | { kind: 'review'; result: ValidateBuildJsonResult }
-  | { kind: 'creating' }
+  // createError keeps the review alive after a failed create: the
+  // validated graph stays on screen and Import can simply be retried —
+  // a refresh would re-fetch `src`, and a short-lived scan URL may
+  // already be gone (review feedback).
+  | { kind: 'review'; result: ValidateBuildJsonResult; createError?: string }
+  | { kind: 'creating'; result: ValidateBuildJsonResult }
   | { kind: 'error'; message: string }
 
 /**
@@ -96,7 +100,8 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
     if (phase.kind !== 'review' || !phase.result.parsed) return
     if (creating.current) return
     creating.current = true
-    setPhase({ kind: 'creating' })
+    const review = phase.result
+    setPhase({ kind: 'creating', result: review })
     try {
       const response = await fetch('/api/scenes', {
         method: 'POST',
@@ -108,8 +113,9 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
       })
       if (!response.ok) {
         setPhase({
-          kind: 'error',
-          message:
+          kind: 'review',
+          result: review,
+          createError:
             response.status === 401 || response.status === 403
               ? 'You need to be signed in to import a scene.'
               : response.status === 413
@@ -122,8 +128,10 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
       router.push(`/scene/${meta.id}`)
     } catch (error) {
       setPhase({
-        kind: 'error',
-        message: error instanceof Error ? error.message : 'Creating the scene failed.',
+        kind: 'review',
+        result: review,
+        createError:
+          error instanceof Error ? error.message : 'Creating the scene failed.',
       })
     } finally {
       // Released in every path: after an error the user may retry.
@@ -193,13 +201,16 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
         )}
       </div>
 
+      {phase.createError && (
+        <p className="text-destructive text-sm">{phase.createError}</p>
+      )}
       <button
         className="rounded-md border border-border bg-accent px-4 py-2 font-medium text-sm hover:bg-accent/80 disabled:opacity-50"
         disabled={!result.ok || !result.parsed}
         onClick={handleImport}
         type="button"
       >
-        Import as a new scene
+        {phase.createError ? 'Try again' : 'Import as a new scene'}
       </button>
     </div>
   )

--- a/apps/editor/app/import/import-client.tsx
+++ b/apps/editor/app/import/import-client.tsx
@@ -2,7 +2,7 @@
 
 import { type ValidateBuildJsonResult, validateBuildJson } from '@pascal-app/core'
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { MAX_IMPORT_BYTES, parseImportSrc } from '@/lib/import-src'
 
 type Phase =
@@ -24,6 +24,10 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
   const router = useRouter()
   const [phase, setPhase] = useState<Phase>({ kind: 'fetching' })
   const [sceneName, setSceneName] = useState(name ?? 'Imported scene')
+  // Synchronous re-entry guard: a second tap can fire before React
+  // re-renders into 'creating', and two scenes would be created (review
+  // feedback — especially likely on the mobile hand-off).
+  const creating = useRef(false)
 
   useEffect(() => {
     // A new src restarts the flow: reset to fetching so a stale review
@@ -90,6 +94,8 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
 
   const handleImport = useCallback(async () => {
     if (phase.kind !== 'review' || !phase.result.parsed) return
+    if (creating.current) return
+    creating.current = true
     setPhase({ kind: 'creating' })
     try {
       const response = await fetch('/api/scenes', {
@@ -119,6 +125,9 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
         kind: 'error',
         message: error instanceof Error ? error.message : 'Creating the scene failed.',
       })
+    } finally {
+      // Released in every path: after an error the user may retry.
+      creating.current = false
     }
   }, [phase, router, sceneName])
 

--- a/apps/editor/app/import/import-client.tsx
+++ b/apps/editor/app/import/import-client.tsx
@@ -26,18 +26,27 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
   const [sceneName, setSceneName] = useState(name ?? 'Imported scene')
 
   useEffect(() => {
+    // A new src restarts the flow: reset to fetching so a stale review
+    // (and its Import button) can never act on the previous file, and
+    // ignore every state update from a superseded run — an abort must
+    // not surface as an error either.
+    setPhase({ kind: 'fetching' })
     const parsedSrc = parseImportSrc(src)
     if (!parsedSrc.ok) {
       setPhase({ kind: 'error', message: parsedSrc.reason })
       return
     }
+    let cancelled = false
     const controller = new AbortController()
+    const update = (next: Phase) => {
+      if (!cancelled) setPhase(next)
+    }
     ;(async () => {
       let response: Response
       try {
         response = await fetch(parsedSrc.url, { signal: controller.signal })
       } catch {
-        setPhase({
+        update({
           kind: 'error',
           message:
             'The file could not be fetched. The server hosting it must allow cross-origin requests (CORS).',
@@ -45,29 +54,38 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
         return
       }
       if (!response.ok) {
-        setPhase({ kind: 'error', message: `The file could not be fetched (${response.status}).` })
+        update({ kind: 'error', message: `The file could not be fetched (${response.status}).` })
         return
       }
       const declared = Number(response.headers.get('content-length') ?? 0)
       if (declared > MAX_IMPORT_BYTES) {
-        setPhase({ kind: 'error', message: 'The file is too large to import.' })
+        update({ kind: 'error', message: 'The file is too large to import.' })
         return
       }
-      const text = await response.text()
+      let text: string
+      try {
+        text = await response.text()
+      } catch {
+        update({ kind: 'error', message: 'The file could not be read.' })
+        return
+      }
       if (text.length > MAX_IMPORT_BYTES) {
-        setPhase({ kind: 'error', message: 'The file is too large to import.' })
+        update({ kind: 'error', message: 'The file is too large to import.' })
         return
       }
       let parsed: unknown
       try {
         parsed = JSON.parse(text)
       } catch {
-        setPhase({ kind: 'error', message: 'The file could not be parsed as JSON.' })
+        update({ kind: 'error', message: 'The file could not be parsed as JSON.' })
         return
       }
-      setPhase({ kind: 'review', result: validateBuildJson(parsed) })
+      update({ kind: 'review', result: validateBuildJson(parsed) })
     })()
-    return () => controller.abort()
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
   }, [src])
 
   const handleImport = useCallback(async () => {

--- a/apps/editor/app/import/import-client.tsx
+++ b/apps/editor/app/import/import-client.tsx
@@ -34,11 +34,10 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
   const creating = useRef(false)
 
   useEffect(() => {
-    // A new src restarts the flow: reset to fetching so a stale review
-    // (and its Import button) can never act on the previous file, and
-    // ignore every state update from a superseded run — an abort must
-    // not surface as an error either.
-    setPhase({ kind: 'fetching' })
+    // A new src remounts the component (the page keys it by src), so
+    // state can never leak between files. Within one mount, ignore
+    // every state update from a superseded run — an abort must not
+    // surface as an error either.
     const parsedSrc = parseImportSrc(src)
     if (!parsedSrc.ok) {
       setPhase({ kind: 'error', message: parsedSrc.reason })
@@ -133,8 +132,7 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
       setPhase({
         kind: 'review',
         result: review,
-        createError:
-          error instanceof Error ? error.message : 'Creating the scene failed.',
+        createError: error instanceof Error ? error.message : 'Creating the scene failed.',
       })
     } finally {
       // Released in every path: after an error the user may retry.
@@ -204,9 +202,7 @@ export function ImportClient({ src, name }: { src: string | null; name: string |
         )}
       </div>
 
-      {phase.createError && (
-        <p className="text-destructive text-sm">{phase.createError}</p>
-      )}
+      {phase.createError && <p className="text-destructive text-sm">{phase.createError}</p>}
       <button
         className="rounded-md border border-border bg-accent px-4 py-2 font-medium text-sm hover:bg-accent/80 disabled:opacity-50"
         disabled={!result.ok || !result.parsed}

--- a/apps/editor/app/import/import-client.tsx
+++ b/apps/editor/app/import/import-client.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { type ValidateBuildJsonResult, validateBuildJson } from '@pascal-app/core'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import { MAX_IMPORT_BYTES, parseImportSrc } from '@/lib/import-src'
+
+type Phase =
+  | { kind: 'fetching' }
+  | { kind: 'review'; result: ValidateBuildJsonResult }
+  | { kind: 'creating' }
+  | { kind: 'error'; message: string }
+
+/**
+ * Client half of `/import?src=<url>`: fetches the build JSON in the
+ * visitor's browser (same trust model as dropping a file on Load Build —
+ * the target must allow CORS), runs the same `validateBuildJson`
+ * pre-flight as Load Build, shows what would be imported, and only on an
+ * explicit click creates the scene through the regular `POST /api/scenes`
+ * route — so auth, origin checks and graph validation all apply
+ * unchanged.
+ */
+export function ImportClient({ src, name }: { src: string | null; name: string | null }) {
+  const router = useRouter()
+  const [phase, setPhase] = useState<Phase>({ kind: 'fetching' })
+  const [sceneName, setSceneName] = useState(name ?? 'Imported scene')
+
+  useEffect(() => {
+    const parsedSrc = parseImportSrc(src)
+    if (!parsedSrc.ok) {
+      setPhase({ kind: 'error', message: parsedSrc.reason })
+      return
+    }
+    const controller = new AbortController()
+    ;(async () => {
+      let response: Response
+      try {
+        response = await fetch(parsedSrc.url, { signal: controller.signal })
+      } catch {
+        setPhase({
+          kind: 'error',
+          message:
+            'The file could not be fetched. The server hosting it must allow cross-origin requests (CORS).',
+        })
+        return
+      }
+      if (!response.ok) {
+        setPhase({ kind: 'error', message: `The file could not be fetched (${response.status}).` })
+        return
+      }
+      const declared = Number(response.headers.get('content-length') ?? 0)
+      if (declared > MAX_IMPORT_BYTES) {
+        setPhase({ kind: 'error', message: 'The file is too large to import.' })
+        return
+      }
+      const text = await response.text()
+      if (text.length > MAX_IMPORT_BYTES) {
+        setPhase({ kind: 'error', message: 'The file is too large to import.' })
+        return
+      }
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(text)
+      } catch {
+        setPhase({ kind: 'error', message: 'The file could not be parsed as JSON.' })
+        return
+      }
+      setPhase({ kind: 'review', result: validateBuildJson(parsed) })
+    })()
+    return () => controller.abort()
+  }, [src])
+
+  const handleImport = useCallback(async () => {
+    if (phase.kind !== 'review' || !phase.result.parsed) return
+    setPhase({ kind: 'creating' })
+    try {
+      const response = await fetch('/api/scenes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: sceneName || 'Imported scene',
+          graph: phase.result.parsed,
+        }),
+      })
+      if (!response.ok) {
+        setPhase({
+          kind: 'error',
+          message:
+            response.status === 401 || response.status === 403
+              ? 'You need to be signed in to import a scene.'
+              : `Creating the scene failed (${response.status}).`,
+        })
+        return
+      }
+      const meta = (await response.json()) as { id: string }
+      router.push(`/scene/${meta.id}`)
+    } catch (error) {
+      setPhase({
+        kind: 'error',
+        message: error instanceof Error ? error.message : 'Creating the scene failed.',
+      })
+    }
+  }, [phase, router, sceneName])
+
+  if (phase.kind === 'fetching') {
+    return <p className="text-muted-foreground text-sm">Fetching the scene…</p>
+  }
+  if (phase.kind === 'creating') {
+    return <p className="text-muted-foreground text-sm">Creating the scene…</p>
+  }
+  if (phase.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-border/60 bg-background p-6">
+        <p className="text-destructive text-sm">{phase.message}</p>
+      </div>
+    )
+  }
+
+  const { result } = phase
+  const typeEntries = Object.entries(result.stats.byType).sort((a, b) => b[1] - a[1])
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-border/60 bg-background p-6">
+        <label className="mb-1 block font-medium text-muted-foreground text-xs uppercase">
+          Scene name
+        </label>
+        <input
+          className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+          onChange={(event) => setSceneName(event.target.value)}
+          value={sceneName}
+        />
+
+        <p className="mt-4 mb-1 font-medium text-muted-foreground text-xs uppercase">Contents</p>
+        <p className="text-sm">
+          {result.stats.total} node{result.stats.total === 1 ? '' : 's'}
+          {result.stats.floorAreaM2 > 0
+            ? ` · ${Math.round(result.stats.floorAreaM2)} m² of floor`
+            : ''}
+        </p>
+        {typeEntries.length > 0 && (
+          <p className="mt-1 text-muted-foreground text-xs">
+            {typeEntries.map(([type, count]) => `${count} ${type}`).join(' · ')}
+          </p>
+        )}
+
+        {result.errors.length > 0 && (
+          <ul className="mt-4 space-y-1">
+            {result.errors.map((issue) => (
+              <li className="text-destructive text-xs" key={`${issue.code}:${issue.message}`}>
+                {issue.message}
+              </li>
+            ))}
+          </ul>
+        )}
+        {result.warnings.length > 0 && (
+          <ul className="mt-2 space-y-1">
+            {result.warnings.map((issue) => (
+              <li className="text-muted-foreground text-xs" key={`${issue.code}:${issue.message}`}>
+                {issue.message}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        className="rounded-md border border-border bg-accent px-4 py-2 font-medium text-sm hover:bg-accent/80 disabled:opacity-50"
+        disabled={!result.ok || !result.parsed}
+        onClick={handleImport}
+        type="button"
+      >
+        Import as a new scene
+      </button>
+    </div>
+  )
+}

--- a/apps/editor/app/import/page.tsx
+++ b/apps/editor/app/import/page.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+import { ImportClient } from './import-client'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * `/import?src=<https-url>[&name=<scene name>]` — the hand-off point for
+ * scanning apps and other external tools: they host a build JSON at a
+ * URL (CORS-enabled) and open this page; the visitor reviews what the
+ * file contains and imports it as a new scene of their own.
+ */
+export default async function ImportPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ src?: string; name?: string }>
+}) {
+  const params = await searchParams
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-10 border-border border-b bg-background/95 backdrop-blur">
+        <div className="container mx-auto flex items-center justify-between gap-4 px-6 py-4">
+          <nav className="flex items-center gap-4 text-sm">
+            <Link
+              className="text-muted-foreground transition-colors hover:text-foreground"
+              href="/"
+            >
+              Home
+            </Link>
+            <span className="text-muted-foreground">/</span>
+            <span className="font-medium text-foreground">Import</span>
+          </nav>
+        </div>
+      </header>
+
+      <main className="container mx-auto max-w-2xl px-6 py-12">
+        <h1 className="mb-2 font-bold text-3xl">Import a scene</h1>
+        <p className="mb-8 text-muted-foreground text-sm">
+          Review the file before it becomes a scene. Nothing is created until you confirm.
+        </p>
+        <ImportClient name={params.name ?? null} src={params.src ?? null} />
+      </main>
+    </div>
+  )
+}

--- a/apps/editor/app/import/page.tsx
+++ b/apps/editor/app/import/page.tsx
@@ -38,7 +38,9 @@ export default async function ImportPage({
         <p className="mb-8 text-muted-foreground text-sm">
           Review the file before it becomes a scene. Nothing is created until you confirm.
         </p>
-        <ImportClient name={params.name ?? null} src={params.src ?? null} />
+        {/* Keyed by src: a new file is a new flow — state (scene name,
+            phase) must never leak from the previous one. */}
+        <ImportClient key={params.src} name={params.name ?? null} src={params.src ?? null} />
       </main>
     </div>
   )

--- a/apps/editor/lib/import-src.test.ts
+++ b/apps/editor/lib/import-src.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'bun:test'
 import { parseImportSrc } from './import-src'
 
 describe('parseImportSrc', () => {

--- a/apps/editor/lib/import-src.test.ts
+++ b/apps/editor/lib/import-src.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { parseImportSrc } from './import-src'
+
+describe('parseImportSrc', () => {
+  it('accepts plain https URLs', () => {
+    const result = parseImportSrc('https://example.com/scan/pascal.json')
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts http for localhost during development', () => {
+    expect(parseImportSrc('http://localhost:8080/scene.json').ok).toBe(true)
+    expect(parseImportSrc('http://127.0.0.1/scene.json').ok).toBe(true)
+  })
+
+  it('rejects http for non-local hosts', () => {
+    expect(parseImportSrc('http://example.com/scene.json').ok).toBe(false)
+  })
+
+  it('rejects non-http schemes', () => {
+    expect(parseImportSrc('javascript:alert(1)').ok).toBe(false)
+    expect(parseImportSrc('file:///etc/passwd').ok).toBe(false)
+    expect(parseImportSrc('ftp://example.com/x.json').ok).toBe(false)
+  })
+
+  it('rejects embedded credentials', () => {
+    expect(parseImportSrc('https://user:pass@example.com/x.json').ok).toBe(false)
+  })
+
+  it('rejects relative and malformed values', () => {
+    expect(parseImportSrc('/scene.json').ok).toBe(false)
+    expect(parseImportSrc('').ok).toBe(false)
+    expect(parseImportSrc(undefined).ok).toBe(false)
+  })
+})

--- a/apps/editor/lib/import-src.ts
+++ b/apps/editor/lib/import-src.ts
@@ -1,0 +1,39 @@
+/**
+ * Validation for the `src` parameter of the `/import` page: the URL a
+ * scanning app (or any external tool) hands us to import a build JSON
+ * from. The fetch itself happens client-side in the visitor's browser —
+ * same trust model as dropping a file on Load Build — so the checks here
+ * are about not being tricked into requesting something that is not a
+ * plain https resource, not about SSRF (no server ever fetches it).
+ */
+
+/** Hard cap on the fetched document; matches generous hand-made scenes. */
+export const MAX_IMPORT_BYTES = 25 * 1024 * 1024
+
+export type ImportSrcResult = { ok: true; url: URL } | { ok: false; reason: string }
+
+/**
+ * Accepts only absolute `https:` URLs without embedded credentials.
+ * `http:` is allowed for localhost only, so a scan app on the same
+ * machine can hand over a file during development.
+ */
+export function parseImportSrc(raw: string | null | undefined): ImportSrcResult {
+  if (!raw) {
+    return { ok: false, reason: 'Missing `src` parameter.' }
+  }
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    return { ok: false, reason: 'The `src` parameter is not an absolute URL.' }
+  }
+  if (url.username || url.password) {
+    return { ok: false, reason: 'Credentials in the `src` URL are not allowed.' }
+  }
+  const isLocalhost =
+    url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]'
+  if (url.protocol === 'https:' || (url.protocol === 'http:' && isLocalhost)) {
+    return { ok: true, url }
+  }
+  return { ok: false, reason: 'Only https URLs can be imported.' }
+}

--- a/apps/editor/lib/import-src.ts
+++ b/apps/editor/lib/import-src.ts
@@ -7,8 +7,12 @@
  * plain https resource, not about SSRF (no server ever fetches it).
  */
 
-/** Hard cap on the fetched document; matches generous hand-made scenes. */
-export const MAX_IMPORT_BYTES = 25 * 1024 * 1024
+/**
+ * Hard cap on the fetched document. Matches the scene store's own limit
+ * (`DEFAULT_MAX_SCENE_BYTES` in the sqlite scene store, 10 MB): a file
+ * that passes review must not then fail `POST /api/scenes` with a 413.
+ */
+export const MAX_IMPORT_BYTES = 10 * 1024 * 1024
 
 export type ImportSrcResult = { ok: true; url: URL } | { ok: false; reason: string }
 


### PR DESCRIPTION
## What

A new `/import?src=<https-url>[&name=<scene name>]` page: an external tool — in our case an iOS LiDAR scanning app — hosts a build JSON at a URL and opens this page; the visitor reviews what the file contains and imports it as a new scene with one click.

Until now the only way to get a generated scene into the editor was dragging a file onto Load Build, which does not exist on mobile. With this page, any scan app can end its export flow with "Open in Pascal Editor".

## How it works

- The fetch happens **client-side in the visitor's browser** — the same trust model as dropping a file on Load Build. The host must allow CORS; no server ever fetches the URL, so there is no SSRF surface.
- The file runs through the same `validateBuildJson` pre-flight as Load Build, and the page shows the node counts, floor area, warnings and errors before anything happens.
- Only an explicit click creates the scene, through the regular `POST /api/scenes` route — so auth, origin checks and `apiGraphSchema` validation (including the AssetUrl allowlist) all apply unchanged.
- `src` accepts https only (http for localhost during development), rejects embedded credentials, and caps the document at 25 MB. URL validation lives in `lib/import-src.ts` with unit tests.

## Tested

- `bun test lib`: 41 pass (6 new)
- `bun run check-types`, `biome check`: clean
- End to end against a real scan: a RoomPlan-captured apartment (31 walls, 27 items, slab, scene materials) served from a CORS-enabled URL → review page → one click → scene opens in the editor with furniture and per-item slot materials rendering correctly.

## Why we built it

We build A3 Atlas Scanner, an iOS field tool that captures homes with RoomPlan and already exports your `{nodes, rootNodeIds, materials}` graph (catalog items scaled to measured dimensions, measured colors as scene materials, IFC alongside). This page is the missing link that turns every scan into a one-tap Pascal scene. Happy to adjust anything to fit the project's conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New entry point for creating scenes from arbitrary HTTPS URLs, but creation still goes through existing authenticated `/api/scenes` validation; primary risk is user-supplied remote JSON in the browser, not server SSRF.
> 
> **Overview**
> Adds **`/import?src=<url>[&name=…]`** so scanning apps and other tools can open the editor with a hosted build JSON instead of relying on desktop **Load Build** drag-and-drop (not available on mobile).
> 
> The browser **fetches and parses** the file client-side (CORS required; no server-side fetch), validates it with **`validateBuildJson`** like Load Build, shows stats/errors/warnings and an editable scene name, and only on confirm **POSTs to `/api/scenes`** then navigates to the new scene. Failed creates stay on the review screen with **Try again**; fetch/create paths enforce **10 MB** (byte-accurate via `Blob`), abort on unmount, and a ref guard against double-submit.
> 
> **`parseImportSrc`** in `lib/import-src.ts` restricts `src` to absolute **https** ( **http** only on localhost), blocks credentials and dangerous schemes, with **unit tests**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2917aee845e21d95755d96ba4712840e3bebed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->