### PR TITLE
Level pill: no ground-floor delete; hide compass in studio

### DIFF
--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -5092,6 +5092,9 @@ export function FloorplanPanel({
     if (building?.type !== 'building') return false
     return building.children.some((cid) => state.nodes[cid]?.type === 'level')
   })
+  // The studio workspace (renders / materials / item builder) is a clean
+  // stage — editor viewport chrome, compass included, stays out of it.
+  const isStudioWorkspace = useEditor((s) => s.workspaceMode === 'studio')
   const elevators = useScene(
     useShallow((state) => {
       const building = currentBuildingId ? state.nodes[currentBuildingId] : null
@@ -11136,7 +11139,8 @@ export function FloorplanPanel({
         <FloorplanRegistryActionMenu />
         <FloorplanGroupActionMenu />
 
-        {(levelNode?.type === 'level' || hasAmbientBuildingLevel) &&
+        {!isStudioWorkspace &&
+          (levelNode?.type === 'level' || hasAmbientBuildingLevel) &&
           (compassHost ? (
             createPortal(
               <FloorplanCompassButton

--- a/packages/editor/src/components/ui/floating-level-selector.tsx
+++ b/packages/editor/src/components/ui/floating-level-selector.tsx
@@ -150,6 +150,9 @@ function LevelRow({
   const storeyHeight = getStoredLevelHeight(level)
   // toFixed(2) + strip one trailing zero: "2.50" → "2.5", "2.75" stays.
   const storeyHeightLabel = `${toDisplay(storeyHeight).toFixed(2).replace(/0$/, '')} ${displayUnit}`
+  // Same rule as the site panel and command palette: the ordinal-0 ground
+  // floor is the vertical model's zero anchor and must never be deletable.
+  const canDeleteLevel = level.level !== 0
 
   // Clean preset values per display system; imperial stores exact meters
   // for whole-foot storey heights.
@@ -304,11 +307,13 @@ function LevelRow({
                 </button>
               )}
               <button
-                className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-muted-foreground text-xs transition-colors hover:bg-white/10 hover:text-red-400"
+                className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-muted-foreground text-xs transition-colors enabled:hover:bg-white/10 enabled:hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={!canDeleteLevel}
                 onClick={(e) => {
                   e.stopPropagation()
                   onRequestDelete()
                 }}
+                title={canDeleteLevel ? 'Delete level' : 'The ground level cannot be deleted'}
                 type="button"
               >
                 <Trash2 className="h-3 w-3" />


### PR DESCRIPTION
Stacked on #721 — retarget to `main` after it merges.

## What

- **Floating level selector**: the kebab menu offered "Delete level" for the ordinal-0 ground floor — the vertical model's zero anchor — while the site panel and command palette already guard it. Now disabled with the same rule (`level.level !== 0`) and the same explanatory title as the site panel.
- **Compass in studio**: the floorplan compass is portaled into the viewer area (so it survives the 2D panel being `display:none`), which also let it paint above the studio stage overlays — it showed in the gallery/materials/item-builder tabs. Now gated on the edit workspace, same pattern as `HelperManager`.

## Verification

Playwright probe against the running community app: Ground Floor's Delete item renders disabled with the tooltip; compass hidden after switching to Studio; compass returns in Edit.

## Note for reviewers

There is **no store-layer guard** for ground-floor deletion — `deleteNode` / `deleteLevelWithFallbackSelection` / MCP `delete-node` all delete it unconditionally; every guard is UI-level (site panel, command palette, now the pill). A core-level guard may be worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrRkPvd6AogVAbt3PNeLAw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only guards in two components; no changes to delete or scene APIs, though ground-floor deletion remains possible outside these UI paths.
> 
> **Overview**
> Aligns two floorplan UI edges with existing rules elsewhere in the editor.
> 
> The **floating level selector** kebab menu now **disables Delete level** when the level ordinal is **0** (ground floor), with the same disabled styling and tooltip as the site panel — previously only the site panel and command palette blocked deleting the vertical model’s zero anchor.
> 
> The **floorplan compass** is now shown only in the **edit** workspace (`!isStudioWorkspace`), matching `HelperManager`, so it no longer appears over studio tabs (gallery, materials, item builder) after being portaled into the viewer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b23ee8229cdbde0e7085eb6c8f73eff6ea4bd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->