### PR TITLE
Level pill: no ground-floor delete; hide compass in studio

### DIFF
--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -5092,6 +5092,9 @@ export function FloorplanPanel({
     if (building?.type !== 'building') return false
     return building.children.some((cid) => state.nodes[cid]?.type === 'level')
   })
+  // The studio workspace (renders / materials / item builder) is a clean
+  // stage — editor viewport chrome, compass included, stays out of it.
+  const isStudioWorkspace = useEditor((s) => s.workspaceMode === 'studio')
   const elevators = useScene(
     useShallow((state) => {
       const building = currentBuildingId ? state.nodes[currentBuildingId] : null
@@ -11136,7 +11139,8 @@ export function FloorplanPanel({
         <FloorplanRegistryActionMenu />
         <FloorplanGroupActionMenu />
 
-        {(levelNode?.type === 'level' || hasAmbientBuildingLevel) &&
+        {!isStudioWorkspace &&
+          (levelNode?.type === 'level' || hasAmbientBuildingLevel) &&
           (compassHost ? (
             createPortal(
               <FloorplanCompassButton

--- a/packages/editor/src/components/ui/floating-level-selector.tsx
+++ b/packages/editor/src/components/ui/floating-level-selector.tsx
@@ -150,6 +150,9 @@ function LevelRow({
   const storeyHeight = getStoredLevelHeight(level)
   // toFixed(2) + strip one trailing zero: "2.50" → "2.5", "2.75" stays.
   const storeyHeightLabel = `${toDisplay(storeyHeight).toFixed(2).replace(/0$/, '')} ${displayUnit}`
+  // Same rule as the site panel and command palette: the ordinal-0 ground
+  // floor is the vertical model's zero anchor and must never be deletable.
+  const canDeleteLevel = level.level !== 0
 
   // Clean preset values per display system; imperial stores exact meters
   // for whole-foot storey heights.
@@ -304,11 +307,13 @@ function LevelRow({
                 </button>
               )}
               <button
-                className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-muted-foreground text-xs transition-colors hover:bg-white/10 hover:text-red-400"
+                className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-muted-foreground text-xs transition-colors enabled:hover:bg-white/10 enabled:hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={!canDeleteLevel}
                 onClick={(e) => {
                   e.stopPropagation()
                   onRequestDelete()
                 }}
+                title={canDeleteLevel ? 'Delete level' : 'The ground level cannot be deleted'}
                 type="button"
               >
                 <Trash2 className="h-3 w-3" />


### PR DESCRIPTION
Replaces #722 (auto-closed when its stacked base branch was deleted by the #721 merge; now rebased onto main).

## What

- **Floating level selector**: the kebab menu offered "Delete level" for the ordinal-0 ground floor — the vertical model's zero anchor — while the site panel and command palette already guard it. Now disabled with the same rule (`level.level !== 0`) and the same explanatory title as the site panel.
- **Compass in studio**: the floorplan compass is portaled into the viewer area (so it survives the 2D panel being `display:none`), which also let it paint above the studio stage overlays — it showed in the gallery/materials/item-builder tabs. Now gated on the edit workspace, same pattern as `HelperManager`.

## Verification

Playwright probe against the running community app: Ground Floor's Delete item renders disabled with the tooltip; compass hidden after switching to Studio; compass returns in Edit.

## Note for reviewers

There is **no store-layer guard** for ground-floor deletion — `deleteNode` / `deleteLevelWithFallbackSelection` / MCP `delete-node` all delete it unconditionally; every guard is UI-level (site panel, command palette, now the pill). A core-level guard may be worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrRkPvd6AogVAbt3PNeLAw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only guards and visibility gating with no changes to delete APIs or scene store behavior.
> 
> **Overview**
> **Studio workspace** no longer shows the floorplan compass overlay. The compass render is gated on not being in `studio` workspace mode, matching how other editor chrome (e.g. helpers) stays off the renders/materials/item-builder stage.
> 
> **Floating level selector** now applies the same ground-floor rule as the site panel and command palette: **Delete level** is disabled when `level.level === 0`, with a tooltip explaining the ground level cannot be deleted. Styling reflects the disabled state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ecae465415c38d99ed3baf9c6a81e189bb6a8b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->