### PR TITLE
test(editor): stable row hook for the scene material list

### DIFF
--- a/packages/editor/src/components/ui/controls/scene-material-list.tsx
+++ b/packages/editor/src/components/ui/controls/scene-material-list.tsx
@@ -141,6 +141,7 @@ function SceneMaterialRow({
       className={`rounded-md border border-border/60 bg-background/40 p-2 ${
         isActive ? 'ring-1 ring-primary ring-inset' : ''
       }`}
+      data-testid={`scene-material-row-${id}`}
     >
       <div className="flex items-center gap-2">
         <span


### PR DESCRIPTION
One-line `data-testid` (`scene-material-row-<id>`) on the material row container. The paint-rail rework left the row's name/color inputs without accessible names, so private-editor's e2e specs (two of them PR-gate specs, currently red for every PR over there) need a stable hook. Merging this + the follow-up private PR (spec updates + pin bump) restores the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single DOM attribute for testing; no logic, auth, or data-path changes.
> 
> **Overview**
> Adds a **`data-testid`** of `scene-material-row-<id>` on each scene material list row container so e2e tests can target rows reliably after the paint-rail UI rework left name/color inputs without stable accessible names.
> 
> This is a test-hook-only change with no runtime behavior impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b5788184fedc646c9681424e5bcfd426f7f95f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->