### PR TITLE
feat(editor): expose printable STL export

### DIFF
--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/print-export-button.test.ts
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/print-export-button.test.ts
@@ -58,6 +58,33 @@ describe('simple 3D print export', () => {
     expect(prepared).toEqual({ artifact, report })
   })
 
+  test('uses the same safe profile for printable STL files', async () => {
+    const calls: { format?: string; options?: ModelExportOptions }[] = []
+    const stlReport: PrintExportReport = { ...report, format: 'stl' }
+    const artifact = { blob: new Blob(['stl']), filename: 'house.zip', metadata: stlReport }
+    const modelExport: ModelExport = async (format, options) => {
+      calls.push({ format, options })
+      return artifact
+    }
+
+    const prepared = await preparePrintExport(modelExport, false, 'print-stl')
+
+    expect(calls).toEqual([
+      {
+        format: 'print-stl',
+        options: {
+          onlyVisible: false,
+          download: false,
+          printScale: 100,
+          printScope: 'levels',
+          printContent: 'structure',
+          printBase: 'none',
+        },
+      },
+    ])
+    expect(prepared).toEqual({ artifact, report: stlReport })
+  })
+
   test('blocks the download when preflight finds invalid geometry', async () => {
     const blockedReport: PrintExportReport = {
       ...report,

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/print-export-button.test.ts
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/print-export-button.test.ts
@@ -40,7 +40,7 @@ describe('simple 3D print export', () => {
       return artifact
     }
 
-    const prepared = await preparePrintExport(modelExport, true)
+    const prepared = await preparePrintExport(modelExport, true, 'print-3mf')
 
     expect(calls).toEqual([
       {
@@ -103,7 +103,7 @@ describe('simple 3D print export', () => {
       metadata: blockedReport,
     })
 
-    await expect(preparePrintExport(modelExport, true)).rejects.toThrow(
+    await expect(preparePrintExport(modelExport, true, 'print-3mf')).rejects.toThrow(
       'One wall has an open edge.',
     )
   })
@@ -149,7 +149,7 @@ describe('simple 3D print export', () => {
       metadata: blockedBundleReport,
     })
 
-    await expect(preparePrintExport(modelExport, true)).rejects.toThrow(
+    await expect(preparePrintExport(modelExport, true, 'print-3mf')).rejects.toThrow(
       'The upper level has an open edge.',
     )
   })
@@ -160,7 +160,7 @@ describe('simple 3D print export', () => {
       filename: 'house.3mf',
     })
 
-    await expect(preparePrintExport(modelExport, false)).rejects.toThrow(
+    await expect(preparePrintExport(modelExport, false, 'print-3mf')).rejects.toThrow(
       'did not return a valid file',
     )
   })

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/print-export-button.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/print-export-button.tsx
@@ -5,7 +5,11 @@ import {
   isPrintLevelBundleReport,
   type PrintLevelBundleReport,
 } from '../../../../../lib/level-print-export'
-import type { ModelExport, ModelExportArtifact } from '../../../../../lib/model-export'
+import type {
+  ModelExport,
+  ModelExportArtifact,
+  ModelExportFormat,
+} from '../../../../../lib/model-export'
 import {
   isPrintExportReport,
   type PrintExportReport,
@@ -16,6 +20,8 @@ type PreparedPrintExport = {
   artifact: ModelExportArtifact
   report: PrintExportReport | PrintLevelBundleReport
 }
+
+type PrintModelExportFormat = Extract<ModelExportFormat, 'print-3mf' | 'print-stl'>
 
 function downloadArtifact(artifact: ModelExportArtifact) {
   const url = URL.createObjectURL(artifact.blob)
@@ -39,8 +45,9 @@ function firstBlockingMessage(report: PrintExportReport | PrintLevelBundleReport
 export async function preparePrintExport(
   modelExport: ModelExport,
   onlyVisible: boolean,
+  format: PrintModelExportFormat = 'print-3mf',
 ): Promise<PreparedPrintExport> {
-  const artifact = await modelExport('print-3mf', {
+  const artifact = await modelExport(format, {
     onlyVisible,
     download: false,
     printScale: 100,
@@ -71,13 +78,13 @@ export function PrintExportButton({ onlyVisible }: { onlyVisible: boolean }) {
   const [isExporting, setIsExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const handleExport = async () => {
+  const handleExport = async (format: PrintModelExportFormat) => {
     if (!modelExport) return
 
     setIsExporting(true)
     setError(null)
     try {
-      const prepared = await preparePrintExport(modelExport, onlyVisible)
+      const prepared = await preparePrintExport(modelExport, onlyVisible, format)
       downloadArtifact(prepared.artifact)
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : '3D print export failed.')
@@ -92,11 +99,21 @@ export function PrintExportButton({ onlyVisible }: { onlyVisible: boolean }) {
         aria-busy={isExporting}
         className="w-full justify-start gap-2"
         disabled={isExporting || !modelExport}
-        onClick={handleExport}
+        onClick={() => void handleExport('print-3mf')}
         variant="outline"
       >
         <Printer className="size-4" />
-        Export 3D print files
+        Export 3D print 3MF
+      </Button>
+      <Button
+        aria-busy={isExporting}
+        className="w-full justify-start gap-2"
+        disabled={isExporting || !modelExport}
+        onClick={() => void handleExport('print-stl')}
+        variant="outline"
+      >
+        <Printer className="size-4" />
+        Export 3D print STL files
       </Button>
       {error && (
         <div className="flex gap-2 text-destructive text-xs">

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/print-export-button.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/print-export-button.tsx
@@ -45,7 +45,7 @@ function firstBlockingMessage(report: PrintExportReport | PrintLevelBundleReport
 export async function preparePrintExport(
   modelExport: ModelExport,
   onlyVisible: boolean,
-  format: PrintModelExportFormat = 'print-3mf',
+  format: PrintModelExportFormat,
 ): Promise<PreparedPrintExport> {
   const artifact = await modelExport(format, {
     onlyVisible,
@@ -75,13 +75,13 @@ export async function preparePrintExport(
 
 export function PrintExportButton({ onlyVisible }: { onlyVisible: boolean }) {
   const modelExport = useEditor((state) => state.modelExport)
-  const [isExporting, setIsExporting] = useState(false)
+  const [exportingFormat, setExportingFormat] = useState<PrintModelExportFormat | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const handleExport = async (format: PrintModelExportFormat) => {
     if (!modelExport) return
 
-    setIsExporting(true)
+    setExportingFormat(format)
     setError(null)
     try {
       const prepared = await preparePrintExport(modelExport, onlyVisible, format)
@@ -89,14 +89,16 @@ export function PrintExportButton({ onlyVisible }: { onlyVisible: boolean }) {
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : '3D print export failed.')
     } finally {
-      setIsExporting(false)
+      setExportingFormat(null)
     }
   }
+
+  const isExporting = exportingFormat !== null
 
   return (
     <>
       <Button
-        aria-busy={isExporting}
+        aria-busy={exportingFormat === 'print-3mf'}
         className="w-full justify-start gap-2"
         disabled={isExporting || !modelExport}
         onClick={() => void handleExport('print-3mf')}
@@ -106,14 +108,14 @@ export function PrintExportButton({ onlyVisible }: { onlyVisible: boolean }) {
         Export 3D print 3MF
       </Button>
       <Button
-        aria-busy={isExporting}
+        aria-busy={exportingFormat === 'print-stl'}
         className="w-full justify-start gap-2"
         disabled={isExporting || !modelExport}
         onClick={() => void handleExport('print-stl')}
         variant="outline"
       >
         <Printer className="size-4" />
-        Export 3D print STL files
+        Export 3D print STL
       </Button>
       {error && (
         <div className="flex gap-2 text-destructive text-xs">


### PR DESCRIPTION
## What does this PR do?

Exposes printable STL export in the settings panel Export section. Users can now download printable STL files (as a zip) via a dedicated button, using the same safe print profile as the existing 3MF export (`printScale: 100`, `printScope: levels`, `printContent: structure`, `printBase: none`).

Follow-up to [Discussion #331](https://github.com/pascalorg/editor/discussions/331) — exposes the existing internal `print-stl` export path in the Settings UI.

## How to test

1. Run `bun dev` and open http://localhost:3002
2. Open or create a project with printable geometry
3. Open the sidebar → **Export** section
4. Confirm both **Export 3D print 3MF** and **Export 3D print STL files** buttons are visible
5. Click **Export 3D print STL files** — a zip should download
6. Click **Export 3D print 3MF** — still works as before
7. Run `bun --cwd packages/editor run test -- print-export-button`

## Screenshots / screen recording

<img width="306" height="621" alt="Screenshot_20260828_140351" src="https://github.com/user-attachments/assets/05231d23-8ea7-4b72-92ae-2b339bdc411a" />

Screenshot shows the new "Export 3D print STL files" button alongside the existing 3MF export in the Export panel.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only wiring to an existing `print-stl` export path with unchanged preflight and export options; no auth or data-model changes.
> 
> **Overview**
> Adds a second **Export 3D print STL** control next to the existing 3MF button in the settings Export section, so users can download printable STL (zip) from the same UI.
> 
> `preparePrintExport` now takes an explicit `print-3mf` or `print-stl` format instead of always calling `print-3mf`; both paths still use the same fixed safe print options (scale, levels scope, structure content, no base). Export loading state tracks which format is running so one export disables both buttons and sets per-button `aria-busy`. Tests pass the format argument and assert STL uses the same profile as 3MF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e67e701cce589141329841f0c3b588e453248d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->