### PR TITLE
Carry scene materials through Load Build

### DIFF
--- a/packages/core/src/validation/validate-build-json.test.ts
+++ b/packages/core/src/validation/validate-build-json.test.ts
@@ -126,3 +126,48 @@ describe('validateBuildJson with registered plugin kinds', () => {
     expect(result.schemaIssues[0]?.nodeType).toBe('trees:tree')
   })
 })
+
+describe('scene materials', () => {
+  const minimalGraph = () => ({
+    nodes: {
+      building_1: { id: 'building_1', type: 'building', children: ['level_1'] },
+      level_1: { id: 'level_1', type: 'level', children: [] },
+    },
+    rootNodeIds: ['building_1'],
+  })
+
+  test('carries valid materials through to parsed', () => {
+    const result = validateBuildJson({
+      ...minimalGraph(),
+      materials: {
+        mat_a: {
+          id: 'mat_a',
+          name: 'Measured cabinet',
+          material: { properties: { color: '#595c5a' } },
+        },
+      },
+    })
+    expect(result.ok).toBe(true)
+    expect(result.parsed?.materials?.mat_a?.name).toBe('Measured cabinet')
+  })
+
+  test('skips invalid material entries with a warning, keeps the rest', () => {
+    const result = validateBuildJson({
+      ...minimalGraph(),
+      materials: {
+        mat_ok: { id: 'mat_ok', name: 'Fine', material: {} },
+        mat_bad: { name: 42 },
+      },
+    })
+    expect(result.ok).toBe(true)
+    expect(Object.keys(result.parsed?.materials ?? {})).toEqual(['mat_ok'])
+    expect(result.warnings.some((w) => w.code === 'invalid_materials')).toBe(true)
+  })
+
+  test('warns when materials is not an object', () => {
+    const result = validateBuildJson({ ...minimalGraph(), materials: 'nope' })
+    expect(result.ok).toBe(true)
+    expect(result.parsed?.materials).toBeUndefined()
+    expect(result.warnings.some((w) => w.code === 'invalid_materials')).toBe(true)
+  })
+})

--- a/packages/core/src/validation/validate-build-json.test.ts
+++ b/packages/core/src/validation/validate-build-json.test.ts
@@ -161,7 +161,10 @@ describe('scene materials', () => {
     })
     expect(result.ok).toBe(true)
     expect(Object.keys(result.parsed?.materials ?? {})).toEqual(['mat_ok'])
-    expect(result.warnings.some((w) => w.code === 'invalid_materials')).toBe(true)
+    const warning = result.warnings.find((w) => w.code === 'invalid_materials')
+    expect(warning).toBeDefined()
+    // The skipped ids are named so a hand-edited file can be repaired.
+    expect(warning?.message).toContain('mat_bad')
   })
 
   test('warns when materials is not an object', () => {

--- a/packages/core/src/validation/validate-build-json.ts
+++ b/packages/core/src/validation/validate-build-json.ts
@@ -1,4 +1,5 @@
 import { nodeRegistry } from '../registry'
+import { SceneMaterial } from '../schema/scene-material'
 import { AnyNode, type AnyNodeType } from '../schema/types'
 import { healSceneNodes } from '../utils/heal-scene-graph'
 
@@ -24,6 +25,8 @@ export type ParsedBuildJson = {
   nodes: Record<string, unknown>
   rootNodeIds: string[]
   installedPlugins?: string[]
+  /** Scene materials referenced by node `slots` (`scene:<id>`). */
+  materials?: Record<string, SceneMaterial>
 }
 
 export type SchemaIssue = {
@@ -111,6 +114,7 @@ export function validateBuildJson(input: unknown): ValidateBuildJsonResult {
   const nodesRaw = input.nodes
   const rootNodeIdsRaw = input.rootNodeIds
   const installedPluginsRaw = input.installedPlugins
+  const materialsRaw = input.materials
 
   if (!isPlainObject(nodesRaw)) {
     errors.push({
@@ -157,6 +161,46 @@ export function validateBuildJson(input: unknown): ValidateBuildJsonResult {
       severity: 'warning',
       code: 'invalid_installed_plugins',
       message: 'Ignored invalid "installedPlugins" — expected an array of plugin IDs.',
+    })
+  }
+
+  // Scene materials ride along with the graph: nodes reference them by
+  // `scene:<id>` slot refs, so dropping the table here silently strips
+  // every custom finish from the imported scene. Invalid entries are
+  // skipped one by one — a bad material must not take the import down.
+  //
+  // DELIBERATE: `safeParse().data` NORMALIZES — defaults are injected
+  // and unknown keys dropped. That is the opposite of the API boundary
+  // (`apiGraphSchema` preserves unknown fields on purpose), and it is
+  // chosen here because import feeds the live scene store, which only
+  // understands schema-shaped materials; a hand-edited file with a
+  // half-formed material should land as something the renderer can
+  // draw, not round-trip garbage.
+  let materials: Record<string, SceneMaterial> | undefined
+  if (isPlainObject(materialsRaw)) {
+    let skipped = 0
+    const kept: Record<string, SceneMaterial> = {}
+    for (const [id, value] of Object.entries(materialsRaw)) {
+      const result = SceneMaterial.safeParse(value)
+      if (result.success) {
+        kept[id] = result.data
+      } else {
+        skipped += 1
+      }
+    }
+    if (Object.keys(kept).length > 0) materials = kept
+    if (skipped > 0) {
+      warnings.push({
+        severity: 'warning',
+        code: 'invalid_materials',
+        message: `Ignored ${skipped} invalid scene material${skipped === 1 ? '' : 's'}.`,
+      })
+    }
+  } else if (materialsRaw !== undefined) {
+    warnings.push({
+      severity: 'warning',
+      code: 'invalid_materials',
+      message: 'Ignored invalid "materials" — expected an object of id → material.',
     })
   }
 
@@ -373,6 +417,7 @@ export function validateBuildJson(input: unknown): ValidateBuildJsonResult {
           nodes,
           rootNodeIds,
           ...(installedPlugins ? { installedPlugins } : {}),
+          ...(materials ? { materials } : {}),
         }
       : null,
     stats,

--- a/packages/core/src/validation/validate-build-json.ts
+++ b/packages/core/src/validation/validate-build-json.ts
@@ -178,22 +178,26 @@ export function validateBuildJson(input: unknown): ValidateBuildJsonResult {
   // draw, not round-trip garbage.
   let materials: Record<string, SceneMaterial> | undefined
   if (isPlainObject(materialsRaw)) {
-    let skipped = 0
+    const skippedIds: string[] = []
     const kept: Record<string, SceneMaterial> = {}
     for (const [id, value] of Object.entries(materialsRaw)) {
       const result = SceneMaterial.safeParse(value)
       if (result.success) {
         kept[id] = result.data
       } else {
-        skipped += 1
+        skippedIds.push(id)
       }
     }
     if (Object.keys(kept).length > 0) materials = kept
-    if (skipped > 0) {
+    if (skippedIds.length > 0) {
+      // Name the ids: the audience is hand-edited files, and a count
+      // alone leaves nothing to repair by.
       warnings.push({
         severity: 'warning',
         code: 'invalid_materials',
-        message: `Ignored ${skipped} invalid scene material${skipped === 1 ? '' : 's'}.`,
+        message: `Ignored ${skippedIds.length} invalid scene material${
+          skippedIds.length === 1 ? '' : 's'
+        }: ${skippedIds.join(', ')}.`,
       })
     }
   } else if (materialsRaw !== undefined) {

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
@@ -2,6 +2,7 @@ import {
   clearSceneHistory,
   emitter,
   useScene,
+  type ParsedBuildJson,
   validateBuildJson,
 } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
@@ -287,16 +288,16 @@ export function SettingsPanel({
     e.target.value = ''
   }
 
-  const handleConfirmImport = (parsed: {
-    nodes: Record<string, unknown>
-    rootNodeIds: string[]
-    installedPlugins?: string[]
-  }) => {
+  const handleConfirmImport = (parsed: ParsedBuildJson) => {
     const currentScene = useScene.getState()
     setScene(
       parsed.nodes as Parameters<typeof setScene>[0],
       parsed.rootNodeIds as Parameters<typeof setScene>[1],
       {
+        // Without this, every `scene:<id>` slot ref in the imported file
+        // pointed at a material that no longer existed — custom finishes
+        // silently reverted to defaults on import.
+        materials: parsed.materials,
         installedPlugins: parsed.installedPlugins ?? currentScene.installedPlugins,
         hasExplicitPluginInstallState:
           parsed.installedPlugins !== undefined || currentScene.hasExplicitPluginInstallState,

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
@@ -192,6 +192,7 @@ export function SettingsPanel({
   const nodes = useScene((state) => state.nodes)
   const rootNodeIds = useScene((state) => state.rootNodeIds)
   const installedPlugins = useScene((state) => state.installedPlugins)
+  const materials = useScene((state) => state.materials)
   const setScene = useScene((state) => state.setScene)
   const clearScene = useScene((state) => state.clearScene)
   const resetSelection = useViewer((state) => state.resetSelection)
@@ -232,7 +233,10 @@ export function SettingsPanel({
   const isLocalProject = false // Props-based; only show cloud sections when projectId provided
 
   const handleSaveBuild = () => {
-    const sceneData = { nodes, rootNodeIds, installedPlugins }
+    // Materials ride along: nodes reference them by `scene:<id>` slot
+    // refs, so a save without the table produces a file whose custom
+    // finishes revert to defaults on the very Load Build path below.
+    const sceneData = { nodes, rootNodeIds, installedPlugins, materials }
     const json = JSON.stringify(sceneData, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url = URL.createObjectURL(blob)


### PR DESCRIPTION
Split out of #720 as requested in the review — the materials fix on its own, so it doesn't wait on the import-page discussion.

## The bug

`validateBuildJson` drops the top-level `materials` table: every `scene:<id>` slot ref in an imported file points at a material that no longer exists, so custom finishes silently revert to defaults on Load Build. Confirmed against main: `handleConfirmImport` passes only `installedPlugins` to `setScene`, whose `extra.materials` support already exists.

## The fix

- `ParsedBuildJson` gains `materials?: Record<string, SceneMaterial>`; entries are validated one by one (`SceneMaterial.safeParse`), invalid ones skipped with a warning so a bad material never takes the import down.
- **Normalization is a deliberate, documented choice** (per the review): `safeParse().data` injects defaults and drops unknown keys — the opposite of `apiGraphSchema`'s preserve-unknowns stance — because import feeds the live scene store, which only understands schema-shaped materials. The in-line comment states this and why.
- `handleConfirmImport` now takes `ParsedBuildJson` directly (no widened record + cast) and hands `parsed.materials` to `setScene`.
- Tests are `bun:test` (`bun test src/validation`: 8 pass); `tsc --noEmit` and `biome check` clean; no lockfile changes.

The review's other points (vitest→bun:test in the page test, byte-accurate size cap, capture-protocol seam) are being addressed on #720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to build JSON validation and editor save/import; invalid materials are warned and skipped without blocking import.
> 
> **Overview**
> **Load Build** no longer drops the top-level `materials` table, which fixes custom finishes silently reverting when nodes reference `scene:<id>` slot refs.
> 
> `validateBuildJson` now accepts optional `materials`, validates each entry with `SceneMaterial.safeParse` (normalized output for the scene store), skips bad entries with `invalid_materials` warnings that name the ids, and includes valid materials on `ParsedBuildJson`. The editor **Save Build** export includes scene `materials`, and **Load Build** passes `parsed.materials` into `setScene` on confirm. Tests cover valid carry-through, partial invalid entries, and non-object `materials`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2996a1190dadb9b7e31e084463758598827afc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->