### PR TITLE
Let a host tour point at the snapping chips

### DIFF
--- a/packages/editor/src/components/ui/helpers/contextual-helper-panel.tsx
+++ b/packages/editor/src/components/ui/helpers/contextual-helper-panel.tsx
@@ -90,6 +90,7 @@ function ShortcutSequence({
 function ChipRow({
   ariaLabel,
   disabled = false,
+  guideTarget,
   icon,
   label,
   onClick,
@@ -98,6 +99,11 @@ function ChipRow({
 }: {
   ariaLabel?: string
   disabled?: boolean
+  /**
+   * A static hook for a host app's first-run tour to point at, written to
+   * `data-guide-target`. Nothing here reads it.
+   */
+  guideTarget?: string
   icon?: string
   label: string
   onClick?: () => void
@@ -130,6 +136,7 @@ function ChipRow({
         'pointer-events-auto cursor-pointer items-center rounded-md text-left transition-colors hover:bg-muted/60',
         disabled && 'opacity-45 saturate-0',
       )}
+      data-guide-target={guideTarget}
       onClick={onClick}
       type="button"
     >
@@ -181,6 +188,7 @@ function SnappingChips({ context }: { context: SnapContext }) {
     <>
       <ChipRow
         ariaLabel={`Snapping: ${SNAPPING_MODE_LABELS[snappingMode]}`}
+        guideTarget="snap-mode"
         icon={SNAPPING_MODE_ICONS[snappingMode]}
         label={`Snapping: ${SNAPPING_MODE_LABELS[snappingMode]}`}
         onClick={() => {
@@ -193,6 +201,7 @@ function SnappingChips({ context }: { context: SnapContext }) {
       {gridActive ? (
         <ChipRow
           ariaLabel={`Grid step: ${gridSnapStep.toFixed(2)} m`}
+          guideTarget="snap-grid-step"
           label={`Grid: ${gridSnapStep.toFixed(2)} m`}
           onClick={() => {
             setGridSnapStep(nextGridSnapStep(gridSnapStep))


### PR DESCRIPTION
One static `data-guide-target` on each of the helper panel's two snapping chips — `snap-mode` on the Shift/mode chip and `snap-grid-step` on the Ctrl/grid-step chip — through an optional `guideTarget` prop on `ChipRow`. Same shape as the Select button, the level "+" and the material picker (#728): nothing in the package reads it.

The community getting-started guide's window step used to name the keys in its small print and say the chips were "on the right of the screen", which first-time users read as decoration. With a hook on the chip the guide can ring the actual control and ask for the grid step to be shrunk as a beat.

Consumer: pascalorg/private-editor `fix/getting-started-copy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfcEhXQKCFz216c2Y11Wah

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional DOM attributes on two UI chips with no behavior or snapping logic changes.
> 
> **Overview**
> Adds an optional **`guideTarget`** prop on **`ChipRow`** that sets **`data-guide-target`** on clickable chip buttons, matching the existing host-tour hooks on mode select, level controls, and the material picker.
> 
> **Snapping** chips in the contextual helper panel now expose **`snap-mode`** (Shift / mode cycle) and **`snap-grid-step`** (Ctrl / grid step when grid snapping is active) so a consumer getting-started tour can highlight the real controls instead of describing them in copy alone. The editor package does not read these attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f924b6d6f834b15c7ed65d68ece0a77ed325447c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->