### PR TITLE
fix(editor): keep manifold-3d out of consumer bundler graphs

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -515,6 +515,8 @@ export {
   editorHostPanelRegistry,
   registerEditorHostPanel,
 } from './lib/plugin-panels'
+export { configureManifoldRuntime } from './lib/print-shell-compiler-manifold-worker'
+export type { ManifoldRuntimeOptions } from './lib/print-shell-compiler-protocol'
 export {
   createQuickMeasurementPointerScheduler,
   quickMeasurementContext,

--- a/packages/editor/src/lib/print-shell-compiler-manifold-core.ts
+++ b/packages/editor/src/lib/print-shell-compiler-manifold-core.ts
@@ -1,6 +1,10 @@
-import ManifoldModule, { type Manifold as ManifoldSolid, type ManifoldToplevel } from 'manifold-3d'
+import type { Manifold as ManifoldSolid, ManifoldToplevel } from 'manifold-3d'
 import type { PrintShellCompileDiagnostic } from './print-shell-compiler-baseline'
-import type { ManifoldCompileOutput, ManifoldMeshData } from './print-shell-compiler-protocol'
+import type {
+  ManifoldCompileOutput,
+  ManifoldMeshData,
+  ManifoldRuntimeOptions,
+} from './print-shell-compiler-protocol'
 
 let modulePromise: Promise<ManifoldToplevel> | null = null
 const MANIFOLD_OUTPUT_WELD_EPSILON_METERS = 2e-5
@@ -8,14 +12,59 @@ const COLLINEAR_SEAM_CROSS_LENGTH_SQ = 1e-20
 
 type Triangle = [number, number, number]
 
-async function getManifoldModule(wasmUrl?: string): Promise<ManifoldToplevel> {
-  modulePromise ??= ManifoldModule(wasmUrl ? { locateFile: () => wasmUrl } : undefined).then(
-    (module) => {
+type ManifoldFactory = (config?: {
+  locateFile?: (path: string) => string
+}) => Promise<ManifoldToplevel>
+
+// manifold-3d's emscripten glue awaits import('node:module') behind a Node
+// check. The branch never executes in a browser, but webpack refuses to
+// *build* a graph that can reach it, so a static specifier here poisons every
+// external bundler that compiles this package's source (#715). The factory is
+// therefore loaded through an import() no bundler can trace: the bare
+// specifier resolves wherever node-style resolution exists at runtime (bun
+// tests, dev servers, bundlers that inline it anyway), and the version-pinned
+// CDN copy covers bundled browser builds that left the specifier unresolved —
+// emscripten then locates manifold.wasm relative to the glue's own URL. Hosts
+// that can't reach the CDN (offline, CSP) pass their own URLs through
+// configureManifoldRuntime.
+const MANIFOLD_VERSION = '3.5.1'
+const FALLBACK_MODULE_URL = `https://cdn.jsdelivr.net/npm/manifold-3d@${MANIFOLD_VERSION}/manifold.js`
+
+function importUntraced(specifier: string): Promise<{ default: ManifoldFactory }> {
+  return import(/* webpackIgnore: true */ /* @vite-ignore */ specifier)
+}
+
+async function loadManifoldFactory(moduleUrl?: string): Promise<ManifoldFactory> {
+  const specifiers = moduleUrl ? [moduleUrl] : ['manifold-3d', FALLBACK_MODULE_URL]
+  let lastError: unknown
+  for (const specifier of specifiers) {
+    try {
+      return (await importUntraced(specifier)).default
+    } catch (error) {
+      lastError = error
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('Failed to load manifold-3d.')
+}
+
+async function getManifoldModule(runtime?: ManifoldRuntimeOptions): Promise<ManifoldToplevel> {
+  modulePromise ??= loadManifoldFactory(runtime?.moduleUrl)
+    .then((factory) => {
+      const wasmUrl = runtime?.wasmUrl
+      return factory(wasmUrl ? { locateFile: () => wasmUrl } : undefined)
+    })
+    .then((module) => {
       module.setup()
       return module
-    },
-  )
-  return modulePromise
+    })
+  try {
+    return await modulePromise
+  } catch (error) {
+    // A transient load failure (offline, blocked CDN) must not poison every
+    // later compile attempt with the cached rejection.
+    modulePromise = null
+    throw error
+  }
 }
 
 function manifoldMesh(
@@ -211,7 +260,7 @@ function elapsed(startedAt: number): number {
 
 export async function compileManifoldMeshData(
   meshes: ManifoldMeshData[],
-  wasmUrl?: string,
+  runtime?: ManifoldRuntimeOptions,
 ): Promise<ManifoldCompileOutput> {
   const startedAt = performance.now()
   const sourceNodeIds = Array.from(new Set(meshes.map((mesh) => mesh.nodeId))).sort()
@@ -238,7 +287,7 @@ export async function compileManifoldMeshData(
   }
 
   try {
-    const module = await getManifoldModule(wasmUrl)
+    const module = await getManifoldModule(runtime)
     for (const mesh of meshes) {
       try {
         solids.push(new module.Manifold(manifoldMesh(module, mesh)))

--- a/packages/editor/src/lib/print-shell-compiler-manifold-worker.ts
+++ b/packages/editor/src/lib/print-shell-compiler-manifold-worker.ts
@@ -16,11 +16,24 @@ import {
 import type {
   ManifoldCompileOutput,
   ManifoldMeshData,
+  ManifoldRuntimeOptions,
   ManifoldWorkerRequest,
   ManifoldWorkerResponse,
 } from './print-shell-compiler-protocol'
 
 const WORKER_TIMEOUT_MS = 60_000
+
+let manifoldRuntime: ManifoldRuntimeOptions | undefined
+
+/**
+ * Overrides where the print-export worker loads the manifold-3d module and
+ * wasm from. See the loader in print-shell-compiler-manifold-core.ts for the
+ * default resolution order; hosts with restrictive networks should call this
+ * with self-hosted asset URLs before the first print export.
+ */
+export function configureManifoldRuntime(options: ManifoldRuntimeOptions | undefined): void {
+  manifoldRuntime = options
+}
 
 export type ManifoldCompileRunner = (meshes: ManifoldMeshData[]) => Promise<ManifoldCompileOutput>
 
@@ -76,7 +89,7 @@ export const runManifoldWorker: ManifoldCompileRunner = (meshes) => {
   const activeWorker = getWorker()
   const id = nextRequestId
   nextRequestId += 1
-  const request: ManifoldWorkerRequest = { id, meshes }
+  const request: ManifoldWorkerRequest = { id, meshes, runtime: manifoldRuntime }
   const transfer = meshes.flatMap((mesh) => [
     mesh.positions.buffer as ArrayBuffer,
     mesh.indices.buffer as ArrayBuffer,

--- a/packages/editor/src/lib/print-shell-compiler-manifold.worker.ts
+++ b/packages/editor/src/lib/print-shell-compiler-manifold.worker.ts
@@ -10,7 +10,7 @@ const workerScope = self as unknown as {
 }
 
 workerScope.addEventListener('message', async (event) => {
-  const output = await compileManifoldMeshData(event.data.meshes)
+  const output = await compileManifoldMeshData(event.data.meshes, event.data.runtime)
   const response: ManifoldWorkerResponse = { id: event.data.id, ...output }
   const transfer: Transferable[] = []
   if (response.status === 'compiled') {

--- a/packages/editor/src/lib/print-shell-compiler-protocol.ts
+++ b/packages/editor/src/lib/print-shell-compiler-protocol.ts
@@ -22,9 +22,17 @@ export type ManifoldCompileOutput =
       durationMs: number
     }
 
+export type ManifoldRuntimeOptions = {
+  /** URL of the manifold-3d emscripten glue module. Defaults to the pinned CDN copy. */
+  moduleUrl?: string
+  /** URL of manifold.wasm. Defaults to resolving relative to the glue module. */
+  wasmUrl?: string
+}
+
 export type ManifoldWorkerRequest = {
   id: number
   meshes: ManifoldMeshData[]
+  runtime?: ManifoldRuntimeOptions
 }
 
 export type ManifoldWorkerResponse = ManifoldCompileOutput & { id: number }


### PR DESCRIPTION
## What does this PR do?

Fixes #715. External webpack consumers of `@pascal-app/editor` fail at build time because `manifold-3d`'s emscripten glue awaits `import('node:module')` behind a Node-only check — the branch never executes in a browser, but webpack refuses to build a graph that can reach it. `export-manager.tsx` statically imports the manifold worker wrapper and `ExportManager` renders unconditionally from the editor root, so the poison was in every consumer's graph whether or not they used print export.

The fix keeps the worker chunk bundler-built but removes every traceable `manifold-3d` specifier from it:

- `print-shell-compiler-manifold-core.ts` keeps only a **type** import from `manifold-3d`; the runtime factory loads through an `import()` no bundler follows (`webpackIgnore` + `@vite-ignore`), trying the bare specifier first (bun tests, dev servers, bundlers that inlined it anyway) and falling back to a version-pinned jsDelivr copy for bundled browser builds. Emscripten locates `manifold.wasm` relative to the glue's own URL, so the CDN path self-resolves the wasm.
- New `configureManifoldRuntime({ moduleUrl, wasmUrl })` (exported from the package entry) lets offline or CSP-restricted hosts point both URLs at self-hosted assets before the first print export.
- The worker protocol carries the runtime options; the in-process test runner path is unchanged (`compileManifoldMeshData`'s second parameter went from `wasmUrl?: string` to `runtime?: ManifoldRuntimeOptions`; no caller passed it).
- A failed load (offline, blocked CDN) no longer poisons later compile attempts — the cached module promise resets on rejection.

## How to test

1. `bun test packages/editor/src/lib/print-golden-house.test.ts packages/editor/src/lib/print-shell-compiler-baseline.test.ts` — the in-process runner now reaches manifold through the bare-specifier branch of the untraced import.
2. In the app: Settings → Export 3D print files still produces a preflight + artifact (worker path, bare specifier resolved by the bundler dev server or CDN fallback).
3. External repro from #715: bundle a Next 15/webpack app that imports `@pascal-app/editor` — the build no longer errors on `node:module`; the worker chunk contains no `manifold-3d` module.

## Screenshots / screen recording

N/A — non-visual packaging/loading change.

## Checklist

- [ ] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Print export now depends on runtime dynamic loading (CDN fallback or host-configured URLs); misconfiguration or network blocks could break Manifold compilation without affecting unrelated editor features.
> 
> **Overview**
> Fixes **#715** by stopping webpack/Next apps that import `@pascal-app/editor` from failing on `manifold-3d`’s unreachable `node:module` import in the emscripten glue.
> 
> **`print-shell-compiler-manifold-core.ts`** now uses a **type-only** `manifold-3d` import and loads the runtime factory via a **dynamic `import()`** annotated with `webpackIgnore` / `@vite-ignore`, so consumer bundlers no longer trace `manifold-3d`. Resolution tries the bare `manifold-3d` specifier first, then a **version-pinned jsDelivr** glue URL; WASM follows the glue URL unless overridden. Failed loads **clear the cached module promise** so a later export can retry.
> 
> Hosts with **CSP or offline** constraints can call the new public **`configureManifoldRuntime({ moduleUrl, wasmUrl })`** (re-exported from the package entry) before the first print export. The **worker request** carries those options; **`compileManifoldMeshData`** takes optional **`ManifoldRuntimeOptions`** instead of a lone `wasmUrl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58edd0c059991fbebdf597c878d06d53ab79edb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->