### PR TITLE
fix(mcp): report skipped persistence instead of silently dropping live sync

### DIFF
--- a/packages/mcp/src/tools/apply-patch.ts
+++ b/packages/mcp/src/tools/apply-patch.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import type { Patch as BridgePatch } from '../bridge/scene-bridge'
 import type { SceneOperations } from '../operations'
 import { ErrorCode, throwMcpError } from './errors'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { PatchSchema } from './schemas'
 
 export const applyPatchInput = {
@@ -15,6 +15,7 @@ export const applyPatchOutput = {
   appliedOps: z.number(),
   deletedIds: z.array(z.string()),
   createdIds: z.array(z.string()),
+  ...liveSyncOutput,
 }
 
 export function registerApplyPatch(server: McpServer, bridge: SceneOperations): void {
@@ -52,11 +53,12 @@ export function registerApplyPatch(server: McpServer, bridge: SceneOperations): 
 
       try {
         const result = bridge.applyPatch(bridgePatches)
-        await publishLiveSceneSnapshot(bridge, 'apply_patch')
+        const persistence = await publishLiveSceneSnapshot(bridge, 'apply_patch')
         const payload = {
           appliedOps: result.appliedOps,
           deletedIds: result.deletedIds as unknown as string[],
           createdIds: result.createdIds as unknown as string[],
+          ...persistencePayload(persistence),
         }
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(payload) }],

--- a/packages/mcp/src/tools/construction-tools.ts
+++ b/packages/mcp/src/tools/construction-tools.ts
@@ -14,7 +14,7 @@ import {
 } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { measurement } from './measurement'
 import { NodeIdSchema, Vec2Schema, Vec3Schema } from './schemas'
 
@@ -60,6 +60,7 @@ export const createStoryShellOutput = {
   slabId: z.string().nullable(),
   ceilingId: z.string().nullable(),
   createdIds: z.array(z.string()),
+  ...liveSyncOutput,
 }
 
 export const createRoofInput = {
@@ -96,6 +97,7 @@ export const createRoofOutput = {
   createdRoofLevelId: z.string().nullable(),
   roofId: z.string(),
   roofSegmentId: z.string(),
+  ...liveSyncOutput,
 }
 
 export const createStairBetweenLevelsInput = {
@@ -139,6 +141,7 @@ export const createStairBetweenLevelsOutput = {
   destinationSlabId: z.string().nullable(),
   sourceCeilingId: z.string().nullable(),
   openingPolygon: z.array(Vec2Schema),
+  ...liveSyncOutput,
 }
 
 function textResult<T extends Record<string, unknown>>(payload: T) {
@@ -332,13 +335,14 @@ export function registerConstructionTools(server: McpServer, bridge: SceneOperat
       }
 
       const result = bridge.applyPatch(patches)
-      await publishLiveSceneSnapshot(bridge, 'create_story_shell')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'create_story_shell')
       return textResult({
         levelId,
         wallIds,
         slabId,
         ceilingId,
         createdIds: result.createdIds as string[],
+        ...persistencePayload(persistence),
       })
     },
   )
@@ -436,13 +440,14 @@ export function registerConstructionTools(server: McpServer, bridge: SceneOperat
         { op: 'create', node: roof, parentId: targetRoofLevelId },
         { op: 'create', node: segment, parentId: roof.id as AnyNodeId },
       ])
-      await publishLiveSceneSnapshot(bridge, 'create_roof')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'create_roof')
       return textResult({
         referenceLevelId: levelId,
         roofLevelId: targetRoofLevelId,
         createdRoofLevelId,
         roofId: roof.id,
         roofSegmentId: segment.id,
+        ...persistencePayload(persistence),
       })
     },
   )
@@ -567,13 +572,14 @@ export function registerConstructionTools(server: McpServer, bridge: SceneOperat
       }
 
       bridge.applyPatch(patches)
-      await publishLiveSceneSnapshot(bridge, 'create_stair_between_levels')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'create_stair_between_levels')
       return textResult({
         stairId: stair.id,
         stairSegmentId: segment.id,
         destinationSlabId: destinationSlab?.id ?? null,
         sourceCeilingId: sourceCeiling?.id ?? null,
         openingPolygon,
+        ...persistencePayload(persistence),
       })
     },
   )

--- a/packages/mcp/src/tools/create-level.ts
+++ b/packages/mcp/src/tools/create-level.ts
@@ -5,7 +5,7 @@ import { LevelNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
 import { ErrorCode, throwMcpError } from './errors'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { measurement } from './measurement'
 import { NodeIdSchema } from './schemas'
 
@@ -24,6 +24,7 @@ export const createLevelInput = {
 
 export const createLevelOutput = {
   levelId: z.string(),
+  ...liveSyncOutput,
 }
 
 export function registerCreateLevel(server: McpServer, bridge: SceneOperations): void {
@@ -65,8 +66,8 @@ export function registerCreateLevel(server: McpServer, bridge: SceneOperations):
       })
 
       const id = bridge.createNode(levelNode, buildingId as AnyNodeId)
-      await publishLiveSceneSnapshot(bridge, 'create_level')
-      const payload = { levelId: id as string }
+      const persistence = await publishLiveSceneSnapshot(bridge, 'create_level')
+      const payload = { levelId: id as string, ...persistencePayload(persistence) }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
         structuredContent: payload,

--- a/packages/mcp/src/tools/create-wall.ts
+++ b/packages/mcp/src/tools/create-wall.ts
@@ -4,7 +4,7 @@ import { WallNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
 import { ErrorCode, throwMcpError } from './errors'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { measurement } from './measurement'
 import { NodeIdSchema, Vec2Schema } from './schemas'
 
@@ -21,6 +21,7 @@ export const createWallInput = {
 
 export const createWallOutput = {
   wallId: z.string(),
+  ...liveSyncOutput,
 }
 
 export function registerCreateWall(server: McpServer, bridge: SceneOperations): void {
@@ -63,8 +64,8 @@ export function registerCreateWall(server: McpServer, bridge: SceneOperations): 
         ...(height !== undefined ? { height } : {}),
       })
       const id = bridge.createNode(wall, levelId as AnyNodeId)
-      await publishLiveSceneSnapshot(bridge, 'create_wall')
-      const payload = { wallId: id as string }
+      const persistence = await publishLiveSceneSnapshot(bridge, 'create_wall')
+      const payload = { wallId: id as string, ...persistencePayload(persistence) }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
         structuredContent: payload,

--- a/packages/mcp/src/tools/cut-opening.ts
+++ b/packages/mcp/src/tools/cut-opening.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import type { SceneOperations } from '../operations'
 import { ErrorCode, throwMcpError } from './errors'
 import { wallLength, wallLocalXFromT } from './geometry'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { measurement } from './measurement'
 import { NodeIdSchema } from './schemas'
 
@@ -19,6 +19,7 @@ export const cutOpeningInput = {
 
 export const cutOpeningOutput = {
   openingId: z.string(),
+  ...liveSyncOutput,
 }
 
 export function registerCutOpening(server: McpServer, bridge: SceneOperations): void {
@@ -69,9 +70,9 @@ export function registerCutOpening(server: McpServer, bridge: SceneOperations): 
               position: [base.position[0], 0.9 + height / 2, 0],
             })
       const id = bridge.createNode(opening, wallId as AnyNodeId)
-      await publishLiveSceneSnapshot(bridge, 'cut_opening')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'cut_opening')
 
-      const payload = { openingId: id as string }
+      const payload = { openingId: id as string, ...persistencePayload(persistence) }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
         structuredContent: payload,

--- a/packages/mcp/src/tools/delete-node.ts
+++ b/packages/mcp/src/tools/delete-node.ts
@@ -3,7 +3,7 @@ import type { AnyNodeId } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
 import { ErrorCode, throwMcpError } from './errors'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { NodeIdSchema } from './schemas'
 
 export const deleteNodeInput = {
@@ -13,6 +13,7 @@ export const deleteNodeInput = {
 
 export const deleteNodeOutput = {
   deletedIds: z.array(z.string()),
+  ...liveSyncOutput,
 }
 
 export function registerDeleteNode(server: McpServer, bridge: SceneOperations): void {
@@ -32,8 +33,8 @@ export function registerDeleteNode(server: McpServer, bridge: SceneOperations): 
       }
       try {
         const removed = bridge.deleteNode(id as AnyNodeId, cascade ?? false)
-        await publishLiveSceneSnapshot(bridge, 'delete_node')
-        const payload = { deletedIds: removed }
+        const persistence = await publishLiveSceneSnapshot(bridge, 'delete_node')
+        const payload = { deletedIds: removed, ...persistencePayload(persistence) }
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
           structuredContent: payload,

--- a/packages/mcp/src/tools/duplicate-level.ts
+++ b/packages/mcp/src/tools/duplicate-level.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import type { Patch as BridgePatch } from '../bridge/scene-bridge'
 import type { SceneOperations } from '../operations'
 import { ErrorCode, throwMcpError } from './errors'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { NodeIdSchema } from './schemas'
 
 export const duplicateLevelInput = {
@@ -15,6 +15,7 @@ export const duplicateLevelInput = {
 export const duplicateLevelOutput = {
   newLevelId: z.string(),
   newNodeIds: z.array(z.string()),
+  ...liveSyncOutput,
 }
 
 export function registerDuplicateLevel(server: McpServer, bridge: SceneOperations): void {
@@ -59,11 +60,12 @@ export function registerDuplicateLevel(server: McpServer, bridge: SceneOperation
       })
 
       const result = bridge.applyPatch(patches)
-      await publishLiveSceneSnapshot(bridge, 'duplicate_level')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'duplicate_level')
 
       const payload = {
         newLevelId: newLevelId as string,
         newNodeIds: result.createdIds as unknown as string[],
+        ...persistencePayload(persistence),
       }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload) }],

--- a/packages/mcp/src/tools/live-sync.test.ts
+++ b/packages/mcp/src/tools/live-sync.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { SceneBridge } from '../bridge/scene-bridge'
+import { createSceneOperations, type SceneOperations } from '../operations'
+import type { SceneStore } from '../storage/types'
+import { registerCreateWall } from './create-wall'
+import { publishLiveSceneSnapshot } from './live-sync'
+import {
+  createTestSceneOperations,
+  InMemorySceneStore,
+  parseToolText,
+  type StoredTextContent,
+} from './scene-lifecycle/test-utils'
+
+function createBridge(): SceneBridge {
+  const bridge = new SceneBridge()
+  bridge.setScene({}, [])
+  bridge.loadDefault()
+  return bridge
+}
+
+/** InMemorySceneStore stripped of its scene-event methods. */
+function withoutSceneEvents(base: InMemorySceneStore): SceneStore {
+  return {
+    backend: base.backend,
+    save: (opts) => base.save(opts),
+    load: (id) => base.load(id),
+    list: (opts) => base.list(opts),
+    delete: (id, opts) => base.delete(id, opts),
+    rename: (id, newName, opts) => base.rename(id, newName, opts),
+  }
+}
+
+async function connectCreateWall(operations: SceneOperations): Promise<Client> {
+  const server = new McpServer({ name: 'test', version: '0.0.0' })
+  registerCreateWall(server, operations)
+  const [srvT, cliT] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'test-client', version: '0.0.0' })
+  await Promise.all([server.connect(srvT), client.connect(cliT)])
+  return client
+}
+
+async function callCreateWall(
+  client: Client,
+  bridge: SceneBridge,
+): Promise<Record<string, unknown>> {
+  const level = Object.values(bridge.getNodes()).find((n) => n.type === 'level')!
+  const result = await client.callTool({
+    name: 'create_wall',
+    arguments: { levelId: level.id, start: [0, 0], end: [4, 0] },
+  })
+  expect(result.isError).toBeFalsy()
+  return parseToolText(result.content as StoredTextContent[])
+}
+
+describe('live sync persistence reporting', () => {
+  test('warns unbound when no active scene is bound', async () => {
+    const bridge = createBridge()
+    const { store, operations } = createTestSceneOperations({ bridge })
+    const client = await connectCreateWall(operations)
+
+    const parsed = await callCreateWall(client, bridge)
+    const persistence = parsed.persistence as { status: string; warning: string }
+    expect(persistence.status).toBe('unbound')
+    expect(typeof persistence.warning).toBe('string')
+    expect(persistence.warning.length).toBeGreaterThan(0)
+    expect(await store.listSceneEvents('scene_1')).toEqual([])
+  })
+
+  test('omits persistence and appends an event when publish succeeds', async () => {
+    const bridge = createBridge()
+    const { store, operations } = createTestSceneOperations({ bridge })
+    const meta = await store.save({ name: 'Live Scene', graph: operations.exportSceneGraph() })
+    operations.setActiveScene(meta)
+    const client = await connectCreateWall(operations)
+
+    const parsed = await callCreateWall(client, bridge)
+    expect(parsed.persistence).toBeUndefined()
+    const events = await store.listSceneEvents(meta.id)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.kind).toBe('create_wall')
+    const saved = await store.load(meta.id)
+    expect(saved!.version).toBe(meta.version + 1)
+    expect(saved!.graph.nodes[parsed.wallId as string]).toBeDefined()
+  })
+
+  test('warns events_unsupported when the store lacks scene events', async () => {
+    const bridge = createBridge()
+    const base = new InMemorySceneStore()
+    const operations = createSceneOperations({ bridge, store: withoutSceneEvents(base) })
+    const meta = await base.save({ name: 'Live Scene', graph: operations.exportSceneGraph() })
+    operations.setActiveScene(meta)
+    const client = await connectCreateWall(operations)
+
+    const parsed = await callCreateWall(client, bridge)
+    const persistence = parsed.persistence as { status: string; warning: string }
+    expect(persistence.status).toBe('events_unsupported')
+    expect(typeof persistence.warning).toBe('string')
+  })
+})
+
+describe('publishLiveSceneSnapshot', () => {
+  test('returns unbound without an active scene', async () => {
+    const { operations } = createTestSceneOperations({ bridge: createBridge() })
+    expect(await publishLiveSceneSnapshot(operations, 'test')).toBe('unbound')
+  })
+
+  test('returns events_unsupported when the store lacks scene events', async () => {
+    const base = new InMemorySceneStore()
+    const operations = createSceneOperations({
+      bridge: createBridge(),
+      store: withoutSceneEvents(base),
+    })
+    const meta = await base.save({ name: 'Live Scene', graph: operations.exportSceneGraph() })
+    operations.setActiveScene(meta)
+    expect(await publishLiveSceneSnapshot(operations, 'test')).toBe('events_unsupported')
+  })
+
+  test('returns published when bound to an event-capable store', async () => {
+    const { store, operations } = createTestSceneOperations({ bridge: createBridge() })
+    const meta = await store.save({ name: 'Live Scene', graph: operations.exportSceneGraph() })
+    operations.setActiveScene(meta)
+    expect(await publishLiveSceneSnapshot(operations, 'test')).toBe('published')
+    expect(await store.listSceneEvents(meta.id)).toHaveLength(1)
+  })
+})

--- a/packages/mcp/src/tools/live-sync.ts
+++ b/packages/mcp/src/tools/live-sync.ts
@@ -1,5 +1,6 @@
 import type { SceneGraph } from '@pascal-app/core/clone-scene-graph'
 import { syncAutoStairOpenings } from '@pascal-app/core/stair-openings'
+import { z } from 'zod'
 import type { SceneOperations } from '../operations'
 import { SceneVersionConflictError } from '../storage/types'
 import { ErrorCode, throwMcpError } from './errors'
@@ -17,19 +18,58 @@ export function syncDerivedStairOpenings(operations: SceneOperations): number {
   return updates.length
 }
 
+export type LiveSyncStatus = 'published' | 'unbound' | 'events_unsupported'
+
+type LiveSyncSkip = Exclude<LiveSyncStatus, 'published'>
+
+/**
+ * Output-schema fragment for every tool that mutates the scene. Spread into
+ * the tool's `outputSchema` so `persistencePayload` fields survive the SDK's
+ * structured-content validation.
+ */
+export const liveSyncOutput = {
+  persistence: z
+    .object({
+      status: z.enum(['unbound', 'events_unsupported']),
+      warning: z.string(),
+    })
+    .optional(),
+}
+
+const LIVE_SYNC_WARNINGS: Record<LiveSyncSkip, string> = {
+  unbound:
+    'The change was applied to the in-memory session only: no active scene is bound, so nothing was persisted and no live event reached subscribers. Bind a scene with save_scene or load_scene to persist changes.',
+  events_unsupported:
+    'The change was applied to the in-memory session only: the attached scene store does not support live scene events, so nothing was persisted.',
+}
+
+/**
+ * Payload fragment matching `liveSyncOutput`: empty after a successful
+ * publish, a `persistence` warning when the mutation stayed in-memory.
+ */
+export function persistencePayload(status: LiveSyncStatus): {
+  persistence?: { status: LiveSyncSkip; warning: string }
+} {
+  if (status === 'published') return {}
+  return { persistence: { status, warning: LIVE_SYNC_WARNINGS[status] } }
+}
+
 /**
  * Persist the bridge's current graph to the active scene and append a live
- * event for browser subscribers. No-ops when the MCP session is not currently
- * bound to a saved scene.
+ * event for browser subscribers. Skips persistence — reporting why — when the
+ * MCP session is not currently bound to a saved scene or the store cannot
+ * append scene events; callers surface that through `persistencePayload` so
+ * the skip is never silent (#725).
  */
 export async function publishLiveSceneSnapshot(
   operations: SceneOperations,
   kind: string,
-): Promise<void> {
+): Promise<LiveSyncStatus> {
   syncDerivedStairOpenings(operations)
 
   const active = operations.getActiveScene()
-  if (!(active && operations.canAppendSceneEvents)) return
+  if (!active) return 'unbound'
+  if (!operations.canAppendSceneEvents) return 'events_unsupported'
 
   const graph = operations.exportSceneGraph()
 
@@ -63,6 +103,7 @@ export async function publishLiveSceneSnapshot(
     const message = error instanceof Error ? error.message : String(error)
     throwMcpError(ErrorCode.InternalError, `live_sync_failed: ${message}`)
   }
+  return 'published'
 }
 
 export async function appendLiveSceneEvent(

--- a/packages/mcp/src/tools/place-item.ts
+++ b/packages/mcp/src/tools/place-item.ts
@@ -6,7 +6,7 @@ import type { SceneOperations } from '../operations'
 import { findCatalogItem } from './asset-catalog'
 import { ErrorCode, throwMcpError } from './errors'
 import { projectWorldPointToWallLocalX, wallLength } from './geometry'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { measurement } from './measurement'
 import { NodeIdSchema, Vec3Schema } from './schemas'
 
@@ -20,6 +20,7 @@ export const placeItemInput = {
 export const placeItemOutput = {
   itemId: z.string(),
   status: z.string().optional(),
+  ...liveSyncOutput,
 }
 
 export function registerPlaceItem(server: McpServer, bridge: SceneOperations): void {
@@ -97,10 +98,11 @@ export function registerPlaceItem(server: McpServer, bridge: SceneOperations): v
         ...wallExtras,
       })
       const id = bridge.createNode(item, parentId as AnyNodeId)
-      await publishLiveSceneSnapshot(bridge, 'place_item')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'place_item')
       const payload = {
         itemId: id as string,
         status: catalogAsset ? 'ok' : 'catalog_unavailable',
+        ...persistencePayload(persistence),
       }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload) }],

--- a/packages/mcp/src/tools/redo.ts
+++ b/packages/mcp/src/tools/redo.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 
 export const redoInput = {
   steps: z.number().int().positive().optional(),
@@ -9,6 +9,7 @@ export const redoInput = {
 
 export const redoOutput = {
   redone: z.number(),
+  ...liveSyncOutput,
 }
 
 export function registerRedo(server: McpServer, bridge: SceneOperations): void {
@@ -23,8 +24,9 @@ export function registerRedo(server: McpServer, bridge: SceneOperations): void {
     },
     async ({ steps }) => {
       const redone = bridge.redo(steps ?? 1)
-      if (redone > 0) await publishLiveSceneSnapshot(bridge, 'redo')
-      const payload = { redone }
+      const persistence =
+        redone > 0 ? await publishLiveSceneSnapshot(bridge, 'redo') : ('published' as const)
+      const payload = { redone, ...persistencePayload(persistence) }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
         structuredContent: payload,

--- a/packages/mcp/src/tools/room-tools.ts
+++ b/packages/mcp/src/tools/room-tools.ts
@@ -22,7 +22,12 @@ import {
   itemPlanAabb,
   type PlanAabb,
 } from './layout-clearance'
-import { publishLiveSceneSnapshot } from './live-sync'
+import {
+  type LiveSyncStatus,
+  liveSyncOutput,
+  persistencePayload,
+  publishLiveSceneSnapshot,
+} from './live-sync'
 import { measurement } from './measurement'
 import { NodeIdSchema, Vec2Schema } from './schemas'
 
@@ -69,6 +74,7 @@ export const createRoomOutput = {
   ceilingId: z.string(),
   wallIds: z.array(z.string()),
   areaSqMeters: z.number(),
+  ...liveSyncOutput,
 }
 
 export const addDoorInput = {
@@ -89,6 +95,7 @@ export const addDoorOutput = {
   wallLength: z.number(),
   clamped: z.boolean(),
   coordinateSystem: z.literal('wall-local-meters'),
+  ...liveSyncOutput,
 }
 
 export const addWindowInput = {
@@ -112,6 +119,7 @@ export const addWindowOutput = {
   clamped: z.boolean(),
   coordinateSystem: z.literal('wall-local-meters'),
   sillHeight: z.number(),
+  ...liveSyncOutput,
 }
 
 export const furnishRoomInput = {
@@ -126,6 +134,7 @@ export const furnishRoomOutput = {
   placed: z.number(),
   itemIds: z.array(z.string()),
   skipped: z.array(z.string()),
+  ...liveSyncOutput,
 }
 
 type Placement = {
@@ -460,7 +469,7 @@ export function registerCreateRoom(server: McpServer, bridge: SceneOperations): 
           parentId: levelId as AnyNodeId,
         })),
       ])
-      await publishLiveSceneSnapshot(bridge, 'create_room')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'create_room')
 
       return textResult({
         zoneId: zone.id,
@@ -468,6 +477,7 @@ export function registerCreateRoom(server: McpServer, bridge: SceneOperations): 
         ceilingId: ceiling.id,
         wallIds: walls.map((wall) => wall.id),
         areaSqMeters: Math.round(polygonArea(points) * 100) / 100,
+        ...persistencePayload(persistence),
       })
     },
   )
@@ -504,7 +514,7 @@ export function registerAddDoor(server: McpServer, bridge: SceneOperations): voi
         ...(swingDirection ? { swingDirection } : {}),
       })
       const id = bridge.createNode(door, wallId as AnyNodeId)
-      await publishLiveSceneSnapshot(bridge, 'add_door')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'add_door')
       return textResult({
         doorId: id,
         localX,
@@ -513,6 +523,7 @@ export function registerAddDoor(server: McpServer, bridge: SceneOperations): voi
         wallLength: length,
         clamped: Math.abs(localX - wallT * length) > 1e-9,
         coordinateSystem: 'wall-local-meters',
+        ...persistencePayload(persistence),
       })
     },
   )
@@ -547,7 +558,7 @@ export function registerAddWindow(server: McpServer, bridge: SceneOperations): v
         height,
       })
       const id = bridge.createNode(windowNode, wallId as AnyNodeId)
-      await publishLiveSceneSnapshot(bridge, 'add_window')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'add_window')
       return textResult({
         windowId: id,
         localX,
@@ -557,6 +568,7 @@ export function registerAddWindow(server: McpServer, bridge: SceneOperations): v
         clamped: Math.abs(localX - wallT * length) > 1e-9,
         coordinateSystem: 'wall-local-meters',
         sillHeight,
+        ...persistencePayload(persistence),
       })
     },
   )
@@ -663,6 +675,7 @@ export function registerFurnishRoom(server: McpServer, bridge: SceneOperations):
         )
       }
 
+      let persistence: LiveSyncStatus = 'published'
       if (items.length > 0) {
         bridge.applyPatch(
           items.map((item) => ({
@@ -671,13 +684,14 @@ export function registerFurnishRoom(server: McpServer, bridge: SceneOperations):
             parentId: room.levelId as AnyNodeId,
           })),
         )
-        await publishLiveSceneSnapshot(bridge, 'furnish_room')
+        persistence = await publishLiveSceneSnapshot(bridge, 'furnish_room')
       }
 
       return textResult({
         placed: items.length,
         itemIds: items.map((item) => item.id),
         skipped,
+        ...persistencePayload(persistence),
       })
     },
   )

--- a/packages/mcp/src/tools/scene-lifecycle/test-utils.ts
+++ b/packages/mcp/src/tools/scene-lifecycle/test-utils.ts
@@ -3,6 +3,9 @@ import { createSceneOperations, type SceneOperations } from '../../operations'
 import {
   type ProjectCreateOptions,
   type ProjectStatus,
+  type SceneEvent,
+  type SceneEventAppendOptions,
+  type SceneEventListOptions,
   type SceneListOptions,
   type SceneMeta,
   type SceneMutateOptions,
@@ -54,8 +57,10 @@ export class InMemorySceneStore implements SceneStore {
       updatedAt: string
     }
   >()
+  private readonly events: SceneEvent[] = []
   private idCounter = 0
   private projectCounter = 0
+  private eventCounter = 0
 
   async createProject(opts: ProjectCreateOptions): Promise<ProjectStatus> {
     const id = opts.id ?? `project_${++this.projectCounter}`
@@ -190,6 +195,29 @@ export class InMemorySceneStore implements SceneStore {
     this.data.set(id, updated)
     this.touchProject(id, newName, updated.updatedAt)
     return this.toMeta(updated)
+  }
+
+  async appendSceneEvent(opts: SceneEventAppendOptions): Promise<SceneEvent> {
+    const event: SceneEvent = {
+      eventId: ++this.eventCounter,
+      sceneId: opts.sceneId,
+      version: opts.version,
+      kind: opts.kind,
+      createdAt: new Date().toISOString(),
+      graph: opts.graph,
+    }
+    this.events.push(event)
+    return event
+  }
+
+  async listSceneEvents(sceneId: string, opts?: SceneEventListOptions): Promise<SceneEvent[]> {
+    let events = this.events.filter((event) => event.sceneId === sceneId)
+    const afterEventId = opts?.afterEventId
+    if (afterEventId !== undefined) {
+      events = events.filter((event) => event.eventId > afterEventId)
+    }
+    if (opts?.limit !== undefined) events = events.slice(0, opts.limit)
+    return events
   }
 
   private touchProject(id: string, name: string, updatedAt: string): void {

--- a/packages/mcp/src/tools/set-zone.ts
+++ b/packages/mcp/src/tools/set-zone.ts
@@ -4,7 +4,7 @@ import { ZoneNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
 import { ErrorCode, throwMcpError } from './errors'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { NodeIdSchema, Vec2Schema } from './schemas'
 
 export const setZoneInput = {
@@ -16,6 +16,7 @@ export const setZoneInput = {
 
 export const setZoneOutput = {
   zoneId: z.string(),
+  ...liveSyncOutput,
 }
 
 export function registerSetZone(server: McpServer, bridge: SceneOperations): void {
@@ -57,9 +58,9 @@ export function registerSetZone(server: McpServer, bridge: SceneOperations): voi
         metadata: properties ?? {},
       })
       const id = bridge.createNode(zone, levelId as AnyNodeId)
-      await publishLiveSceneSnapshot(bridge, 'set_zone')
+      const persistence = await publishLiveSceneSnapshot(bridge, 'set_zone')
 
-      const payload = { zoneId: id as string }
+      const payload = { zoneId: id as string, ...persistencePayload(persistence) }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
         structuredContent: payload,

--- a/packages/mcp/src/tools/undo.ts
+++ b/packages/mcp/src/tools/undo.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
-import { publishLiveSceneSnapshot } from './live-sync'
+import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 
 export const undoInput = {
   steps: z.number().int().positive().optional(),
@@ -9,6 +9,7 @@ export const undoInput = {
 
 export const undoOutput = {
   undone: z.number(),
+  ...liveSyncOutput,
 }
 
 export function registerUndo(server: McpServer, bridge: SceneOperations): void {
@@ -23,8 +24,9 @@ export function registerUndo(server: McpServer, bridge: SceneOperations): void {
     },
     async ({ steps }) => {
       const undone = bridge.undo(steps ?? 1)
-      if (undone > 0) await publishLiveSceneSnapshot(bridge, 'undo')
-      const payload = { undone }
+      const persistence =
+        undone > 0 ? await publishLiveSceneSnapshot(bridge, 'undo') : ('published' as const)
+      const payload = { undone, ...persistencePayload(persistence) }
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
         structuredContent: payload,


### PR DESCRIPTION
## What does this PR do?

Fixes #725. When a store was attached but no scene was bound (or the store couldn't append scene events), `publishLiveSceneSnapshot` returned silently: the mutation applied to the in-memory session, but nothing persisted, no live event reached subscribers, and nothing told the caller — the failure mode that sent #561's investigation into the wrong layer.

Design decision (the question #561 left open): **neither throw nor lazily bind.** A typed `no_active_scene` throw breaks the README `--stdio` quick start on the first `create_wall`; lazy draft binding creates persistent artifacts the user never asked for, on stores that may require project context. Instead the skip becomes *visible*:

- `publishLiveSceneSnapshot` now returns `'published' | 'unbound' | 'events_unsupported'` (built on the existing `canAppendSceneEvents` seam).
- Every mutating tool (17 sites: `apply_patch`, `create_wall`, `create_room`, `add_door`, `add_window`, `furnish_room`, `cut_opening`, `create_story_shell`, `create_roof`, `create_stair_between_levels`, `create_level`, `duplicate_level`, `place_item`, `delete_node`, `set_zone`, `undo`, `redo`) spreads a `persistence: { status, warning }` field into its result when the change stayed in-memory — declared in each tool's `outputSchema` via a shared `liveSyncOutput` fragment so the SDK's structured-content validation keeps it. The warning tells the caller to bind a scene with `save_scene` or `load_scene`.
- `undo`/`redo`/`furnish_room` keep their conditional publish: no mutation → no warning.
- `InMemorySceneStore` (test-utils) now implements `appendSceneEvent`/`listSceneEvents`, which #725 called out as the missing test seam.

## How to test

1. `bun test packages/mcp/src/tools/live-sync.test.ts` — six tests: unbound / published / events-unsupported, each through a real `InMemoryTransport` client-server pair, plus the three statuses at the unit level.
2. `bun test packages/mcp/src/tools` — full tool suite (190 tests) passes.
3. Manually: `pascal-mcp --stdio`, call `create_wall` without opening a scene — the result now carries `persistence.status: "unbound"` with the guidance string instead of silently not persisting.

## Screenshots / screen recording

N/A — MCP server change, no UI.

## Checklist

- [ ] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every mutating MCP tool response shape and persistence behavior; callers may rely on the new optional `persistence` field, but successful paths stay backward compatible.
> 
> **Overview**
> **MCP scene mutations no longer fail silently when live sync cannot persist.** `publishLiveSceneSnapshot` returns `'published' | 'unbound' | 'events_unsupported'` instead of no-oping without feedback when there is no bound scene or the store cannot append scene events.
> 
> All mutating tools wire this through shared `liveSyncOutput` (output schema) and `persistencePayload`: successful publishes add nothing; skipped sync adds optional `persistence: { status, warning }` with guidance to bind via `save_scene` / `load_scene`. `undo`, `redo`, and `furnish_room` only publish (and warn) when they actually change the graph.
> 
> Tests cover the three statuses via `create_wall` over in-memory transport and extend `InMemorySceneStore` with `appendSceneEvent` / `listSceneEvents` for the live-sync path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bd49f3be0435ddb1fc67309aa6b1ecd56bbca9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->