### PR TITLE
fix(editor): correct wall editing and roof controls

### DIFF
--- a/.agents/skills/open-pr2/SKILL.md
+++ b/.agents/skills/open-pr2/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: open-pr2
+description: Open or update a pull request on pascalorg/editor with a plain-language issue-and-fix description based on the full branch diff. Use only when the user explicitly asks for OpenPR2 or /open-pr2.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *) Bash(bun *) Read
+---
+
+# OpenPR2
+
+Open or update a pull request against `pascalorg/editor` from the current branch. Keep the repository's PR template, but write the body like one developer explaining the change to another.
+
+## 1. Pre-flight
+
+Inspect the working tree and the whole branch before writing anything:
+
+```bash
+git status
+git branch --show-current
+git log --oneline main..HEAD
+git diff --stat main...HEAD
+git diff --name-status main...HEAD
+```
+
+Read the relevant parts of `git diff main...HEAD`. Do not build the description from the latest commit alone or from conversation memory.
+
+Stop if:
+
+- The current branch is `main`. Ask the user to create a feature branch first.
+- The branch has no commits ahead of `main`.
+- There are uncommitted changes the user has not asked to commit.
+
+For a non-trivial change, run checks that match the affected packages. Prefer focused tests plus:
+
+```bash
+bun run check-types
+bun run build
+```
+
+Do not open a PR when a required check fails. Report the failure instead. Do not claim that a command or manual test passed unless it was run.
+
+## 2. Read the current PR template
+
+Read `.github/pull_request_template.md` every time. Its headings and checklist wording are the source of truth.
+
+Keep the template headings in the same order:
+
+1. `## What does this PR do?`
+2. `## How to test`
+3. `## Screenshots / screen recording`
+4. `## Checklist`
+
+Do not replace them with `Summary`, `Details`, `Validation`, or custom headings unless the template itself changes.
+
+## 3. Write the title
+
+- Keep it under 70 characters when practical.
+- State the result, not the activity. Prefer `fix(editor): keep curved room slabs attached` over `update wall files`.
+- Add a package scope when one package clearly owns the change, such as `core:`, `viewer:`, `editor:`, or `mcp:`.
+- Avoid vague verbs such as `improve`, `enhance`, `update`, or `refactor` when a concrete verb fits.
+
+## 4. Write the body in plain language
+
+### What does this PR do?
+
+The reviewer should understand every changed behavior without opening the diff. Do not compress unrelated fixes into a paragraph or a long bullet.
+
+Give each problem its own short item. Use this exact shape:
+
+```markdown
+- **Short feature or problem name**
+  - Issue: One short sentence describing what was wrong or missing.
+  - Fixed: One short sentence describing the behavior after this PR.
+```
+
+Add one more indented sentence only when the reviewer needs an important constraint, risk, or design decision. Keep it short and do not add labels such as `Details`, `Technical`, or `Implementation`.
+
+Example:
+
+```markdown
+- **Curved triangular rooms**
+  - Issue: Slabs and ceilings kept a straight corner after curving a wall.
+  - Fixed: Both surfaces now rebuild from the curved room boundary.
+
+- **Wall and fence thickness**
+  - Issue: Thickness could only be changed from the settings panel.
+  - Fixed: Each face now has a circular thickness handle in 2D and 3D.
+  - The centerline stays fixed, and the change uses one undo step.
+```
+
+Keep the item title concrete. Start with product behavior, not filenames or function names. Cover every meaningful user-visible fix on the branch. Combine items only when they describe the same problem and the same fix.
+
+Avoid this compressed style:
+
+```text
+This PR fixes curved wall topology, adds thickness handles, improves floor-plan previews, updates roof paint slots, and cleans up roof controls.
+```
+
+Link issues with `Fixes #123` or `Refs #123` when applicable. Never invent an issue number.
+
+### How to test
+
+Write numbered reviewer steps. Put the action on the numbered line and the expected result on a short indented line.
+
+Good:
+
+```text
+1. Create a triangular room and curve one wall.
+   - The slab and ceiling should follow the curved corner with no gap.
+
+2. Drag either wall thickness dot.
+   - The wall should stay centered while its thickness changes.
+```
+
+List automated commands only when they were run. Include pass counts when they are known and useful. Do not turn the section into a dump of every command used during development.
+
+### Screenshots / screen recording
+
+- Preserve any existing media verbatim when updating a PR.
+- For a visual or interactive change, add the supplied media. If none exists, write `Not added yet.`
+- For a non-visual change, write `N/A, no visual change.`
+- Do not claim that a recording exists when it does not.
+
+### Checklist
+
+Copy every checklist line from the current template verbatim.
+
+- Tick an item only when it is true.
+- `bun dev` is checked only after local runtime testing.
+- The code-style item is checked only after the requested style command passes.
+- Documentation is checked when docs were updated or when the item explicitly says it is not applicable. Otherwise leave it unchecked.
+- Confirm the actual base branch before checking the target-branch item.
+
+## 5. Human writing pass
+
+Before submitting, read the title and body once as a reviewer who has not seen the branch.
+
+Rewrite anything that fails these checks:
+
+- Use plain words and short sentences.
+- Say what the change does. Avoid phrases that could describe any PR.
+- Remove filler, hype, sales language, and chatbot phrases.
+- Remove repeated points and details that the diff explains on its own.
+- Avoid jargon unless the repository uses the term and the reviewer needs it.
+- Avoid forced lists, excessive bold text, em dashes, and long parenthetical asides.
+- Prefer active voice.
+- Keep a human rhythm. The body should not read like generated release notes.
+- Make every test step concrete and verifiable.
+
+If the summary sounds too small, add the missing problem or behavior. If it sounds dense, remove implementation trivia before shortening the explanation of the bug.
+
+## 6. Push and find the PR
+
+Push the current branch:
+
+```bash
+git push -u origin HEAD
+```
+
+Check whether it already has a PR:
+
+```bash
+gh pr view --json number,url,title,body 2>/dev/null
+```
+
+### No existing PR
+
+Create one with `gh pr create`. Pass the body through a quoted heredoc so Markdown stays intact:
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+<body using the current PR template>
+EOF
+)"
+```
+
+### Existing PR
+
+Do not create another PR. Update the current one from the full branch diff.
+
+Before rewriting it:
+
+```bash
+gh pr view --json number,title,body,url
+git log --oneline main..HEAD
+git diff --stat main...HEAD
+```
+
+When rebuilding the body:
+
+- Preserve `Fixes #123` and `Refs #123` lines.
+- Preserve screenshots, recordings, links, and embedded images verbatim unless the user supplied replacements.
+- Preserve the user's checklist state for work that remains true. Never change an unchecked item to checked without evidence.
+- Keep extra reviewer notes that are still relevant.
+- Remove old claims and test steps that no longer match the branch.
+- Leave the title unchanged unless the branch's purpose clearly changed.
+
+Apply the update with `gh pr edit <number> --body ...`. Change the title only when needed.
+
+## 7. Verify and report
+
+Read the PR back after creation or editing:
+
+```bash
+gh pr view --json number,url,title,body,baseRefName,headRefName
+```
+
+Confirm that the title, template sections, base branch, and body were saved correctly.
+
+Return:
+
+- PR URL
+- Title
+- Checks and tests actually run
+- Any unchecked checklist item or missing recording the reviewer should know about

--- a/apps/editor/lib/build-tab-state.test.ts
+++ b/apps/editor/lib/build-tab-state.test.ts
@@ -48,7 +48,8 @@ test('conical roofs expose only curved-wall footprint source', () => {
 })
 
 test('non-conical roofs expose room and draw footprint sources', () => {
-  expect(getRoofFootprintSources('hip').map((source) => source.value)).toEqual(['room', 'draw'])
-  expect(getRoofFootprintSource('hip', 'walls')).toBe('room')
+  expect(getRoofFootprintSources('hip').map((source) => source.value)).toEqual(['draw', 'room'])
+  expect(getRoofFootprintSource('hip', 'walls')).toBe('draw')
   expect(getRoofFootprintSource('hip', 'draw')).toBe('draw')
+  expect(getRoofFootprintSource('hip', 'room')).toBe('room')
 })

--- a/apps/editor/lib/build-tab-state.ts
+++ b/apps/editor/lib/build-tab-state.ts
@@ -16,8 +16,8 @@ export type RoofFootprintSource = (typeof ROOF_FOOTPRINT_SOURCES)[number]['value
 const CONICAL_ROOF_FOOTPRINT_SOURCES = [ROOF_FOOTPRINT_SOURCES[1]] as const
 
 const STANDARD_ROOF_FOOTPRINT_SOURCES = [
-  ROOF_FOOTPRINT_SOURCES[0],
   ROOF_FOOTPRINT_SOURCES[2],
+  ROOF_FOOTPRINT_SOURCES[0],
 ] as const
 
 export function getRoofFootprintSources(roofType: RoofType) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -402,6 +402,7 @@ export { syncAutoStairOpenings } from './systems/stair/stair-opening-sync'
 export { StairOpeningSystem } from './systems/stair/stair-opening-system'
 export { resolveStairTotalRise, syncStairRises } from './systems/stair/stair-rise'
 export {
+  constrainWallCurveOffsetToAvoidIntersections,
   getClampedWallCurveOffset,
   getMaxWallCurveOffset,
   getWallArcData,

--- a/packages/core/src/schema/nodes/cupola.ts
+++ b/packages/core/src/schema/nodes/cupola.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { BaseNode, nodeType, objectId } from '../base'
 import { MaterialSchema } from '../material'
 
-export const CupolaMaterialRole = z.enum(['base', 'body', 'roof'])
+export const CupolaMaterialRole = z.enum(['base', 'body', 'roof', 'louvers'])
 export type CupolaMaterialRole = z.infer<typeof CupolaMaterialRole>
 
 export const CupolaNode = BaseNode.extend({

--- a/packages/core/src/store/actions/node-actions.ts
+++ b/packages/core/src/store/actions/node-actions.ts
@@ -26,6 +26,7 @@ import {
   type WallNode,
 } from '../../schema'
 import type { CollectionId } from '../../schema/collections'
+import { constrainWallCurveOffsetToAvoidIntersections } from '../../systems/wall/wall-curve'
 import { addActiveSceneCommitNodeIds, runWithSceneCommitNodeIds } from '../history-control'
 import type { SceneState } from '../use-scene'
 
@@ -1464,7 +1465,23 @@ const updateNodesActionImpl = (
       const currentNode = nextNodes[id]
       if (!currentNode) continue
       addLeanToHostRoofId(currentNode, nextNodes, roofsToRefresh)
-      const updatedNode = parseUpdatedNode(currentNode, data)
+      const curveOffset =
+        currentNode.type === 'wall' ? (data as Partial<WallNode>).curveOffset : undefined
+      const constrainedData =
+        currentNode.type === 'wall' && typeof curveOffset === 'number'
+          ? {
+              ...data,
+              curveOffset: constrainWallCurveOffsetToAvoidIntersections(
+                currentNode,
+                curveOffset,
+                Object.values(nextNodes).filter(
+                  (node): node is WallNode =>
+                    node.type === 'wall' && node.parentId === currentNode.parentId,
+                ),
+              ),
+            }
+          : data
+      const updatedNode = parseUpdatedNode(currentNode, constrainedData)
       addLeanToHostRoofId(updatedNode, nextNodes, roofsToRefresh)
 
       // Handle Reparenting Logic

--- a/packages/core/src/store/use-scene-commits.test.ts
+++ b/packages/core/src/store/use-scene-commits.test.ts
@@ -4,7 +4,9 @@ import { initSpaceDetectionSync, type Space } from '../lib/space-detection'
 import { nodeRegistry } from '../registry/registry'
 import type { AnyNodeDefinition } from '../registry/types'
 import { BuildingNode } from '../schema/nodes/building'
+import { CeilingNode } from '../schema/nodes/ceiling'
 import { LevelNode } from '../schema/nodes/level'
+import { SlabNode } from '../schema/nodes/slab'
 import { WallNode } from '../schema/nodes/wall'
 import { SceneMaterial, type SceneMaterialId } from '../schema/scene-material'
 import type { AnyNode, AnyNodeId } from '../schema/types'
@@ -422,6 +424,135 @@ describe('scene commit boundary', () => {
       expect(
         receiverNodes.filter((node) => node.type === 'ceiling' && node.autoFromWalls),
       ).toHaveLength(2)
+    } finally {
+      stopDetection()
+    }
+  })
+
+  test('keeps a triangular room valid when an inward wall curve reaches its neighbours', () => {
+    const walls = [
+      WallNode.parse({ id: 'wall_curve_base', parentId: LEVEL_ID, start: [0, 0], end: [4, 0] }),
+      WallNode.parse({ id: 'wall_curve_right', parentId: LEVEL_ID, start: [4, 0], end: [2, 3] }),
+      WallNode.parse({ id: 'wall_curve_left', parentId: LEVEL_ID, start: [2, 3], end: [0, 0] }),
+    ]
+    const polygon: Array<[number, number]> = [
+      [0, 0],
+      [4, 0],
+      [2, 3],
+    ]
+    const slab = SlabNode.parse({
+      id: 'slab_curve_triangle',
+      parentId: LEVEL_ID,
+      polygon,
+      autoFromWalls: true,
+    })
+    const ceiling = CeilingNode.parse({
+      id: 'ceiling_curve_triangle',
+      parentId: LEVEL_ID,
+      polygon,
+      autoFromWalls: true,
+    })
+    useScene.setState((state) => ({
+      nodes: {
+        ...state.nodes,
+        [LEVEL_ID]: {
+          ...state.nodes[LEVEL_ID],
+          children: [...walls.map((wall) => wall.id), slab.id, ceiling.id],
+        } as AnyNode,
+        ...Object.fromEntries([...walls, slab, ceiling].map((node) => [node.id, node])),
+      },
+    }))
+    clearSceneHistory()
+
+    let spaces: Record<string, Space> = {}
+    const editorStore = {
+      getState: () => ({
+        spaces,
+        setSpaces: (next: Record<string, Space>) => {
+          spaces = next
+        },
+      }),
+    }
+    const stopDetection = initSpaceDetectionSync(useScene, editorStore)
+
+    try {
+      useScene.getState().updateNode(walls[0]!.id, { curveOffset: -2 })
+
+      const nodes = useScene.getState().nodes
+      const curvedWall = nodes[walls[0]!.id]
+      const updatedSlab = nodes[slab.id]
+      const updatedCeiling = nodes[ceiling.id]
+      expect(curvedWall?.type === 'wall' ? curvedWall.curveOffset : null).toBeGreaterThan(-2)
+      expect(Object.values(spaces)).toHaveLength(1)
+      expect(updatedSlab?.type === 'slab' ? updatedSlab.polygon.length : 0).toBeGreaterThan(3)
+      expect(
+        updatedCeiling?.type === 'ceiling' ? updatedCeiling.polygon.length : 0,
+      ).toBeGreaterThan(3)
+    } finally {
+      stopDetection()
+    }
+  })
+
+  test('keeps the full inward curve when a square room has enough clearance', () => {
+    const walls = [
+      WallNode.parse({ id: 'wall_square_base', parentId: LEVEL_ID, start: [0, 0], end: [4, 0] }),
+      WallNode.parse({ id: 'wall_square_right', parentId: LEVEL_ID, start: [4, 0], end: [4, 3] }),
+      WallNode.parse({ id: 'wall_square_top', parentId: LEVEL_ID, start: [4, 3], end: [0, 3] }),
+      WallNode.parse({ id: 'wall_square_left', parentId: LEVEL_ID, start: [0, 3], end: [0, 0] }),
+    ]
+    const polygon: Array<[number, number]> = [
+      [0, 0],
+      [4, 0],
+      [4, 3],
+      [0, 3],
+    ]
+    const slab = SlabNode.parse({
+      id: 'slab_curve_square',
+      parentId: LEVEL_ID,
+      polygon,
+      autoFromWalls: true,
+    })
+    const ceiling = CeilingNode.parse({
+      id: 'ceiling_curve_square',
+      parentId: LEVEL_ID,
+      polygon,
+      autoFromWalls: true,
+    })
+    useScene.setState((state) => ({
+      nodes: {
+        ...state.nodes,
+        [LEVEL_ID]: {
+          ...state.nodes[LEVEL_ID],
+          children: [...walls.map((wall) => wall.id), slab.id, ceiling.id],
+        } as AnyNode,
+        ...Object.fromEntries([...walls, slab, ceiling].map((node) => [node.id, node])),
+      },
+    }))
+    clearSceneHistory()
+
+    let spaces: Record<string, Space> = {}
+    const stopDetection = initSpaceDetectionSync(useScene, {
+      getState: () => ({
+        spaces,
+        setSpaces: (next: Record<string, Space>) => {
+          spaces = next
+        },
+      }),
+    })
+
+    try {
+      useScene.getState().updateNode(walls[0]!.id, { curveOffset: -2 })
+
+      const nodes = useScene.getState().nodes
+      const curvedWall = nodes[walls[0]!.id]
+      const updatedSlab = nodes[slab.id]
+      const updatedCeiling = nodes[ceiling.id]
+      expect(curvedWall?.type === 'wall' ? curvedWall.curveOffset : null).toBe(-2)
+      expect(Object.values(spaces)).toHaveLength(1)
+      expect(updatedSlab?.type === 'slab' ? updatedSlab.polygon.length : 0).toBeGreaterThan(4)
+      expect(
+        updatedCeiling?.type === 'ceiling' ? updatedCeiling.polygon.length : 0,
+      ).toBeGreaterThan(4)
     } finally {
       stopDetection()
     }

--- a/packages/core/src/store/use-scene-wall-slot-migration.test.ts
+++ b/packages/core/src/store/use-scene-wall-slot-migration.test.ts
@@ -281,15 +281,50 @@ describe('procedural kind surface-material → slots migration', () => {
     expect((vent as { topMaterialPreset?: unknown }).topMaterialPreset).toBeUndefined()
   })
 
-  test('gutter and downspout legacy paint migrates to the surface slot', () => {
-    for (const type of ['gutter', 'downspout'] as const) {
-      useScene
-        .getState()
-        .setScene(sceneWithNode({ type, materialPreset: 'library:metal-steel' }), [
-          'site_test',
-        ] as never)
-      const node = (useScene.getState().nodes as Record<string, SlottedNode>).node_test!
-      expect(node.slots).toEqual({ surface: 'library:metal-steel' })
-    }
+  test('gutter and downspout legacy paint migrates to their current slot IDs', () => {
+    useScene
+      .getState()
+      .setScene(sceneWithNode({ type: 'gutter', materialPreset: 'library:metal-steel' }), [
+        'site_test',
+      ] as never)
+    let node = (useScene.getState().nodes as Record<string, SlottedNode>).node_test!
+    expect(node.slots).toEqual({ gutter: 'library:metal-steel' })
+
+    useScene
+      .getState()
+      .setScene(sceneWithNode({ type: 'downspout', materialPreset: 'library:metal-steel' }), [
+        'site_test',
+      ] as never)
+    node = (useScene.getState().nodes as Record<string, SlottedNode>).node_test!
+    expect(node.slots).toEqual({ surface: 'library:metal-steel' })
+  })
+
+  test('renames a saved gutter surface slot without losing its material', () => {
+    useScene.getState().setScene(
+      sceneWithNode({
+        type: 'gutter',
+        slots: { surface: 'library:metal-copper' },
+      }),
+      ['site_test'] as never,
+    )
+
+    const gutter = (useScene.getState().nodes as Record<string, SlottedNode>).node_test!
+    expect(gutter.slots).toEqual({ gutter: 'library:metal-copper' })
+  })
+
+  test('seeds saved cupola louvers from the body slot', () => {
+    useScene.getState().setScene(
+      sceneWithNode({
+        type: 'cupola',
+        slots: { body: 'library:preset-softwhite' },
+      }),
+      ['site_test'] as never,
+    )
+
+    const cupola = (useScene.getState().nodes as Record<string, SlottedNode>).node_test!
+    expect(cupola.slots).toEqual({
+      body: 'library:preset-softwhite',
+      louvers: 'library:preset-softwhite',
+    })
   })
 })

--- a/packages/core/src/store/use-scene.ts
+++ b/packages/core/src/store/use-scene.ts
@@ -417,6 +417,19 @@ function migrateRoleMaterialSlots(
   return changed ? { ...next, slots } : node
 }
 
+function migrateRenamedSlot(node: Record<string, any>, previousId: string, nextId: string) {
+  if (!node.slots || node.slots[previousId] === undefined) return node
+  const slots = { ...node.slots }
+  if (slots[nextId] === undefined) slots[nextId] = slots[previousId]
+  delete slots[previousId]
+  return { ...node, slots }
+}
+
+function migrateCupolaLouverSlot(node: Record<string, any>) {
+  if (!node.slots || node.slots.louvers !== undefined || node.slots.body === undefined) return node
+  return { ...node, slots: { ...node.slots, louvers: node.slots.body } }
+}
+
 // Stair carries per-role legacy fields (`treadMaterial*` / `sideMaterial*` /
 // `railingMaterial*`) plus a catch-all. Map each to its slot via the same
 // fallback chain the renderer uses (`getEffectiveStairSurfaceMaterial`):
@@ -908,7 +921,12 @@ function migrateNodes(nodes: Record<string, any>): {
       )
     }
 
-    if (node.type === 'gutter' || node.type === 'downspout') {
+    if (node.type === 'gutter') {
+      patchedNodes[id] = migrateRenamedSlot(patchedNodes[id], 'surface', 'gutter')
+      patchedNodes[id] = migrateSingleMaterialSlots(patchedNodes[id], ['gutter'], mintedMaterials)
+    }
+
+    if (node.type === 'downspout') {
       patchedNodes[id] = migrateSingleMaterialSlots(patchedNodes[id], ['surface'], mintedMaterials)
     }
 
@@ -921,9 +939,10 @@ function migrateNodes(nodes: Record<string, any>): {
     }
 
     if (node.type === 'cupola') {
+      patchedNodes[id] = migrateCupolaLouverSlot(patchedNodes[id])
       patchedNodes[id] = migrateRoleMaterialSlots(
         patchedNodes[id],
-        ['base', 'body', 'roof'],
+        ['base', 'body', 'roof', 'louvers'],
         mintedMaterials,
       )
     }

--- a/packages/core/src/systems/wall/wall-curve.ts
+++ b/packages/core/src/systems/wall/wall-curve.ts
@@ -3,6 +3,8 @@ import type { Point2D } from './wall-mitering'
 
 const CURVE_EPSILON = 1e-6
 const DEFAULT_SAMPLE_SEGMENTS = 24
+const CURVE_INTERSECTION_SEARCH_STEPS = 20
+const CURVE_INTERSECTION_TOLERANCE = 1e-6
 
 type WallCurveLike = Pick<WallNode | FenceNode, 'start' | 'end' | 'curveOffset'>
 
@@ -187,6 +189,93 @@ export function sampleWallCenterline(wall: WallCurveLike, segments = DEFAULT_SAM
     { length: count + 1 },
     (_, index) => getWallCurveFrameAt(wall, index / count).point,
   )
+}
+
+function segmentIntersectionPoint(a: Point2D, b: Point2D, c: Point2D, d: Point2D): Point2D | null {
+  const abX = b.x - a.x
+  const abY = b.y - a.y
+  const cdX = d.x - c.x
+  const cdY = d.y - c.y
+  const denominator = abX * cdY - abY * cdX
+  if (Math.abs(denominator) <= CURVE_INTERSECTION_TOLERANCE) return null
+
+  const acX = c.x - a.x
+  const acY = c.y - a.y
+  const t = (acX * cdY - acY * cdX) / denominator
+  const u = (acX * abY - acY * abX) / denominator
+  if (
+    t < -CURVE_INTERSECTION_TOLERANCE ||
+    t > 1 + CURVE_INTERSECTION_TOLERANCE ||
+    u < -CURVE_INTERSECTION_TOLERANCE ||
+    u > 1 + CURVE_INTERSECTION_TOLERANCE
+  ) {
+    return null
+  }
+
+  return { x: a.x + t * abX, y: a.y + t * abY }
+}
+
+function pointMatchesEndpoint(point: Point2D, wall: WallCurveLike) {
+  return [getWallStartPoint(wall), getWallEndPoint(wall)].some(
+    (endpoint) => distance(point, endpoint) <= CURVE_INTERSECTION_TOLERANCE,
+  )
+}
+
+function wallCurveIntersectsSibling(wall: WallNode, sibling: WallNode) {
+  const wallPoints = sampleWallCenterline(wall)
+  const siblingPoints = sampleWallCenterline(sibling)
+
+  for (let wallIndex = 0; wallIndex < wallPoints.length - 1; wallIndex += 1) {
+    const wallStart = wallPoints[wallIndex]!
+    const wallEnd = wallPoints[wallIndex + 1]!
+    for (let siblingIndex = 0; siblingIndex < siblingPoints.length - 1; siblingIndex += 1) {
+      const siblingStart = siblingPoints[siblingIndex]!
+      const siblingEnd = siblingPoints[siblingIndex + 1]!
+      const intersection = segmentIntersectionPoint(wallStart, wallEnd, siblingStart, siblingEnd)
+      if (!intersection) continue
+      if (pointMatchesEndpoint(intersection, wall) && pointMatchesEndpoint(intersection, sibling)) {
+        continue
+      }
+      return true
+    }
+  }
+
+  return false
+}
+
+function wallCurveIntersectsSiblings(wall: WallNode, walls: readonly WallNode[]) {
+  if (!isCurvedWall(wall)) return false
+  return walls.some(
+    (sibling) =>
+      sibling.id !== wall.id &&
+      sibling.parentId === wall.parentId &&
+      wallCurveIntersectsSibling(wall, sibling),
+  )
+}
+
+export function constrainWallCurveOffsetToAvoidIntersections(
+  wall: WallNode,
+  proposedOffset: number,
+  walls: readonly WallNode[],
+) {
+  const currentOffset = normalizeWallCurveOffset(wall, wall.curveOffset ?? 0)
+  const normalizedProposal = normalizeWallCurveOffset(wall, proposedOffset)
+  const proposedWall = { ...wall, curveOffset: normalizedProposal }
+  if (!wallCurveIntersectsSiblings(proposedWall, walls)) return normalizedProposal
+
+  const currentWall = { ...wall, curveOffset: currentOffset }
+  if (wallCurveIntersectsSiblings(currentWall, walls)) return currentOffset
+
+  let safeOffset = currentOffset
+  let blockedOffset = normalizedProposal
+  for (let index = 0; index < CURVE_INTERSECTION_SEARCH_STEPS; index += 1) {
+    const candidateOffset = (safeOffset + blockedOffset) / 2
+    const candidateWall = { ...wall, curveOffset: candidateOffset }
+    if (wallCurveIntersectsSiblings(candidateWall, walls)) blockedOffset = candidateOffset
+    else safeOffset = candidateOffset
+  }
+
+  return normalizeWallCurveOffset(wall, safeOffset)
 }
 
 export function getWallCurveLength(wall: WallCurveLike, segments = DEFAULT_SAMPLE_SEGMENTS) {

--- a/packages/editor/src/components/editor/floating-action-menu.tsx
+++ b/packages/editor/src/components/editor/floating-action-menu.tsx
@@ -49,7 +49,7 @@ import {
   duplicatesAsFreshSubtree,
   prepareFreshPlacementRootDuplicate,
 } from '../../lib/fresh-planar-placement'
-import { resolveOverlayPolicy } from '../../lib/interaction/overlay-policy'
+import { resolveFloatingActionMenuVisibility } from '../../lib/interaction/overlay-policy'
 import { curveReshapeScope, holeEditScope } from '../../lib/interaction/scope'
 import { playBlockedQuickActionFeedback } from '../../lib/quick-action-feedback'
 import { collectQuickActionNodeScope } from '../../lib/quick-action-nodes'
@@ -291,10 +291,7 @@ export function FloatingActionMenu() {
   const activeHandleDrag = useActiveHandleDrag()
   // R/T rotation axis for kinds with full 3D orientation (duct fittings).
   const rotationAxis = useEditor((s) => s.rotationAxis)
-  // The floating action menu is an action-conflicting control: hard-hidden
-  // during any active interaction so it never competes with the live action.
   const scope = useInteractionScope((s) => s.scope)
-  const menuStepBack = resolveOverlayPolicy(scope).conflictingControls === 'hidden'
 
   const groupRef = useRef<THREE.Group>(null)
   const menuScaleRef = useRef<HTMLDivElement>(null)
@@ -356,6 +353,7 @@ export function FloatingActionMenu() {
     activeHandleDrag?.nodeId === selectedId &&
     activeHandleDrag?.label === 'height'
   const pillDims = pillNode ? getHeightPillDimensions(pillNode) : null
+  const menuVisibility = resolveFloatingActionMenuVisibility(scope, isHeightDragPill)
 
   // Boolean selector, only re-renders when curving availability actually flips.
   const canCurveSelectedWall = useScene((s) => {
@@ -766,7 +764,7 @@ export function FloatingActionMenu() {
     !(selectedId && node && isValidType && !isFloorplanHovered && mode !== 'delete') ||
     endpointReshape ||
     isCurveReshape ||
-    menuStepBack
+    !menuVisibility.root
   )
     return null
 
@@ -786,35 +784,37 @@ export function FloatingActionMenu() {
             ref={menuScaleRef}
             style={{ transformOrigin: 'center center' }}
           >
-            <NodeActionMenu
-              onFind={node && canFindNode ? handleFind : undefined}
-              onAddHole={node && HOLE_TYPES.includes(node.type) ? handleAddHole : undefined}
-              onCurve={
-                (node?.type === 'fence' && !isSplineFence(node) && !isCurvedWall(node)) ||
-                (node?.type === 'wall' && canCurveSelectedWall)
-                  ? handleCurve
-                  : undefined
-              }
-              onMove={
-                // Fully registry-driven: any kind that declares
-                // `capabilities.movable`, a `floorplanMoveTarget`, or a
-                // 3D `affordanceTools.move` mover gets the Move button.
-                // Adding a new movable kind never touches this file.
-                node && isRegistryMovable(node.type) ? handleMove : undefined
-              }
-              onDelete={handleDelete}
-              onDuplicate={
-                node &&
-                node.type !== 'spawn' &&
-                !DELETE_ONLY_TYPES.includes(node.type) &&
-                !HOLE_TYPES.includes(node.type)
-                  ? handleDuplicate
-                  : undefined
-              }
-              onPointerDown={(e) => e.stopPropagation()}
-              onPointerUp={(e) => e.stopPropagation()}
-            />
-            {quickActions.length > 0 ? (
+            {menuVisibility.actions ? (
+              <NodeActionMenu
+                onFind={node && canFindNode ? handleFind : undefined}
+                onAddHole={node && HOLE_TYPES.includes(node.type) ? handleAddHole : undefined}
+                onCurve={
+                  (node?.type === 'fence' && !isSplineFence(node) && !isCurvedWall(node)) ||
+                  (node?.type === 'wall' && canCurveSelectedWall)
+                    ? handleCurve
+                    : undefined
+                }
+                onMove={
+                  // Fully registry-driven: any kind that declares
+                  // `capabilities.movable`, a `floorplanMoveTarget`, or a
+                  // 3D `affordanceTools.move` mover gets the Move button.
+                  // Adding a new movable kind never touches this file.
+                  node && isRegistryMovable(node.type) ? handleMove : undefined
+                }
+                onDelete={handleDelete}
+                onDuplicate={
+                  node &&
+                  node.type !== 'spawn' &&
+                  !DELETE_ONLY_TYPES.includes(node.type) &&
+                  !HOLE_TYPES.includes(node.type)
+                    ? handleDuplicate
+                    : undefined
+                }
+                onPointerDown={(e) => e.stopPropagation()}
+                onPointerUp={(e) => e.stopPropagation()}
+              />
+            ) : null}
+            {menuVisibility.actions && quickActions.length > 0 ? (
               <div
                 className="pointer-events-auto mt-1 inline-flex w-max items-center justify-center gap-0.5 rounded-lg border border-border/50 bg-background/90 px-1.5 py-1 shadow-md backdrop-blur-md"
                 onPointerDown={(e) => e.stopPropagation()}

--- a/packages/editor/src/components/editor/wall-move-side-handles.tsx
+++ b/packages/editor/src/components/editor/wall-move-side-handles.tsx
@@ -4,8 +4,11 @@ import {
   type AnyNode,
   type AnyNodeId,
   type FenceNode,
+  getFenceCenterlineFrameAt,
+  getFenceCenterlineLength,
   getWallBaseElevationForNodes,
   getWallCurveFrameAt,
+  getWallCurveLength,
   getWallEffectiveHeightForNodes,
   getWallThickness,
   isCurvedWall,
@@ -16,6 +19,7 @@ import {
   type WallNode,
 } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
+import { Html } from '@react-three/drei'
 import { createPortal, type ThreeEvent, useFrame, useThree } from '@react-three/fiber'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -29,6 +33,7 @@ import {
   OrthographicCamera,
   Plane,
   Quaternion,
+  Ray,
   Shape,
   Vector2,
   Vector3,
@@ -37,6 +42,7 @@ import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js
 import { MeshBasicNodeMaterial } from 'three/webgpu'
 import {
   clearStructuralElevationGuide,
+  getFenceBaseElevationForNodes,
   publishStructuralElevationGuide,
   resolveStructuralElevationSnap,
 } from '../../lib/elevation-guides'
@@ -52,6 +58,7 @@ import useInteractionScope, {
 import { suppressBoxSelectForPointer } from '../tools/select/box-select-state'
 import { resolveResizeSnapValue } from './handles/resize-snap'
 import { type HandleDragControls, useHandleDrag } from './handles/use-handle-drag'
+import { MeasurementPill } from './measurement-pill'
 import {
   createArrowHitAreaGeometry,
   createEndpointHitAreaGeometry,
@@ -76,6 +83,8 @@ const CORNER_DASH_SIZE = 0.1
 const CORNER_GAP_SIZE = 0.07
 const CORNER_DASH_THICKNESS = 0.006
 const CORNER_FLOOR_OFFSET = 0.01
+const THICKNESS_HANDLE_RADIUS = 0.075
+const MIN_WALL_THICKNESS = 0.05
 
 type WallMoveHandle = {
   key: string
@@ -140,14 +149,11 @@ export function WallMoveSideHandles() {
   const isCurveReshape = useIsCurveReshape()
 
   const selectedId = selectedIds.length === 1 ? selectedIds[0] : null
-  // Fence side-move / height / corner-pickers now flow through the
-  // registry handle path (see packages/nodes/src/fence/definition.ts).
-  // Only walls still need the legacy renderer here — the registry path
-  // didn't render correctly for walls specifically and was reverted in
-  // commit 0e207a7f; revisit once that's diagnosed.
+  // Walls still use this legacy handle renderer. Fences retain their registry
+  // handles and mount only the matching thickness dots from this component.
   const selectedNode = useScene((state) => {
     const node = selectedId ? state.nodes[selectedId as AnyNodeId] : null
-    return node?.type === 'wall' ? node : null
+    return node?.type === 'wall' || node?.type === 'fence' ? node : null
   })
 
   const shouldRender =
@@ -160,7 +166,11 @@ export function WallMoveSideHandles() {
 
   if (!shouldRender || !selectedNode) return null
 
-  return <WallMoveSideHandlesForWall wall={selectedNode} />
+  return selectedNode.type === 'wall' ? (
+    <WallMoveSideHandlesForWall wall={selectedNode} />
+  ) : (
+    <FenceThicknessHandles fence={selectedNode} />
+  )
 }
 
 function WallMoveSideHandlesForWall({ wall }: { wall: WallNode }) {
@@ -220,6 +230,18 @@ function WallMoveSideHandlesForWall({ wall }: { wall: WallNode }) {
           <WallMoveArrowHandle handle={handle} key={handle.key} wall={effectiveWall} />
         ))}
         <WallHeightArrowHandle wall={effectiveWall} />
+        <StructureThicknessHandle
+          baseElevation={baseElevation}
+          levelObject={levelObject}
+          node={effectiveWall}
+          side={1}
+        />
+        <StructureThicknessHandle
+          baseElevation={baseElevation}
+          levelObject={levelObject}
+          node={effectiveWall}
+          side={-1}
+        />
         <WallCornerLeaderHandle endpoint="start" wall={effectiveWall} />
         <WallCornerLeaderHandle endpoint="end" wall={effectiveWall} />
       </group>
@@ -229,6 +251,276 @@ function WallMoveSideHandlesForWall({ wall }: { wall: WallNode }) {
         wall={effectiveWall}
       />
     </>,
+    levelObject,
+  )
+}
+
+function closestAxisParameterToRay(axisOrigin: Vector3, axisDirection: Vector3, ray: Ray) {
+  const originToRay = new Vector3().subVectors(axisOrigin, ray.origin)
+  const directionDot = axisDirection.dot(ray.direction)
+  const axisDot = axisDirection.dot(originToRay)
+  const rayDot = ray.direction.dot(originToRay)
+  const denominator = 1 - directionDot * directionDot
+  if (Math.abs(denominator) < 1e-6) return -axisDot
+
+  const axisParameter = (directionDot * rayDot - axisDot) / denominator
+  const rayParameter = rayDot + directionDot * axisParameter
+  return rayParameter < 0 ? -axisDot : axisParameter
+}
+
+function StructureThicknessHandle({
+  node,
+  side,
+  baseElevation,
+  levelObject,
+}: {
+  node: WallNode | FenceNode
+  side: 1 | -1
+  baseElevation: number
+  levelObject: Object3D
+}) {
+  const [isHovered, setIsHovered] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
+  const { camera } = useThree()
+  const unit = useViewer((state) => state.unit)
+  const zoom = camera instanceof OrthographicCamera ? 1 / camera.zoom : 1
+  const frame =
+    node.type === 'fence' ? getFenceCenterlineFrameAt(node, 0.5) : getWallCurveFrameAt(node, 0.5)
+  const thickness = node.type === 'fence' ? (node.thickness ?? 0.08) : getWallThickness(node)
+  const structureHeight =
+    node.type === 'fence'
+      ? (node.height ?? 1.8)
+      : getWallEffectiveHeightForNodes(node, useScene.getState().nodes)
+  const outward = new Vector2(frame.normal.x * side, frame.normal.y * side)
+  const faceOffset = thickness / 2 + 0.006
+  const position: [number, number, number] = [
+    frame.point.x + outward.x * faceOffset,
+    structureHeight / 2,
+    frame.point.y + outward.y * faceOffset,
+  ]
+  const rotationY = Math.atan2(outward.x, outward.y)
+  const isActive = isHovered || isDragging
+  const scale = zoom * (isActive ? 1.18 : 1)
+  const hitGeometry = useMemo(() => createEndpointHitAreaGeometry(0.13), [])
+  const hitMaterial = useInvisibleHitAreaMaterial()
+  const dotMaterial = useMemo(
+    () =>
+      new MeshBasicNodeMaterial({
+        color: new Color(ARROW_COLOR),
+        side: DoubleSide,
+        depthTest: false,
+        depthWrite: false,
+      }),
+    [],
+  )
+  const ringMaterial = useMemo(
+    () =>
+      new MeshBasicNodeMaterial({
+        color: new Color(ARROW_HOVER_COLOR),
+        side: DoubleSide,
+        depthTest: false,
+        depthWrite: false,
+      }),
+    [],
+  )
+  const dragControls = useMemo<HandleDragControls>(
+    () => ({
+      onStart: () => {},
+      onEnd: () => {},
+    }),
+    [],
+  )
+
+  useEffect(() => {
+    dotMaterial.color.set(isActive ? ARROW_HOVER_COLOR : ARROW_COLOR)
+  }, [dotMaterial, isActive])
+  useEffect(() => () => hitGeometry.dispose(), [hitGeometry])
+  useEffect(() => () => dotMaterial.dispose(), [dotMaterial])
+  useEffect(() => () => ringMaterial.dispose(), [ringMaterial])
+  useEffect(
+    () => () => {
+      if (document.body.style.cursor === 'ew-resize') document.body.style.cursor = ''
+    },
+    [],
+  )
+
+  const activateThicknessResize = useHandleDrag({
+    kind: 'drag',
+    cursor: 'ew-resize',
+    dragControls,
+    handleIndex: side > 0 ? 0 : 1,
+    node,
+    rideObject: levelObject,
+    setIsDragging,
+    onStart: ({ event, getPointerRay, initialNode, nodeId, rideObject }) => {
+      if (initialNode.type !== 'wall' && initialNode.type !== 'fence') return null
+
+      rideObject.updateWorldMatrix(true, false)
+      const initialFrame =
+        initialNode.type === 'fence'
+          ? getFenceCenterlineFrameAt(initialNode, 0.5)
+          : getWallCurveFrameAt(initialNode, 0.5)
+      const localAxis = new Vector3(initialFrame.normal.x * side, 0, initialFrame.normal.y * side)
+      const initialStructureHeight =
+        initialNode.type === 'fence'
+          ? (initialNode.height ?? 1.8)
+          : getWallEffectiveHeightForNodes(initialNode, useScene.getState().nodes)
+      const initialStructureThickness =
+        initialNode.type === 'fence'
+          ? (initialNode.thickness ?? 0.08)
+          : getWallThickness(initialNode)
+      const minimumThickness = initialNode.type === 'fence' ? 0.03 : MIN_WALL_THICKNESS
+      const localOrigin = new Vector3(
+        initialFrame.point.x + localAxis.x * (initialStructureThickness / 2 + 0.006),
+        baseElevation + initialStructureHeight / 2,
+        initialFrame.point.y + localAxis.z * (initialStructureThickness / 2 + 0.006),
+      )
+      const worldOrigin = localOrigin.clone().applyMatrix4(rideObject.matrixWorld)
+      const worldAxisEnd = localOrigin.clone().add(localAxis).applyMatrix4(rideObject.matrixWorld)
+      const worldAxis = worldAxisEnd.sub(worldOrigin)
+      const axisScale = worldAxis.length()
+      if (axisScale < 1e-6) return null
+      worldAxis.normalize()
+
+      const pointerRay = new Ray()
+      const initialPointer =
+        closestAxisParameterToRay(
+          worldOrigin,
+          worldAxis,
+          getPointerRay(event.nativeEvent.clientX, event.nativeEvent.clientY, pointerRay),
+        ) / axisScale
+      let lastThickness = initialStructureThickness
+
+      return {
+        onBegin: () => {
+          useInteractionScope.getState().begin({
+            kind: 'handle-drag',
+            nodeId,
+            handle: 'thickness',
+          })
+        },
+        onEnd: () => {
+          useInteractionScope.getState().endIf((scope) => scope.kind === 'handle-drag')
+        },
+        move: ({ event: moveEvent, getPointerRay: getMovePointerRay }) => {
+          const currentPointer =
+            closestAxisParameterToRay(
+              worldOrigin,
+              worldAxis,
+              getMovePointerRay(moveEvent.clientX, moveEvent.clientY, pointerRay),
+            ) / axisScale
+          const rawThickness = initialStructureThickness + (currentPointer - initialPointer) * 2
+          const nextThickness = Math.max(
+            minimumThickness,
+            resolveResizeSnapValue({
+              rawValue: rawThickness,
+              fallbackValue: lastThickness,
+              gridSnapEnabled: true,
+              gridSnapActive: isGridSnapActive(),
+              gridSnapStep: useEditor.getState().gridSnapStep,
+              magneticSnapActive: false,
+            }),
+          )
+          if (nextThickness !== lastThickness) sfxEmitter.emit('sfx:resize')
+          lastThickness = nextThickness
+          return { thickness: nextThickness }
+        },
+      }
+    },
+  })
+
+  return (
+    <>
+      <group position={position} rotation={[0, rotationY, 0]} scale={scale}>
+        <InvisibleHandleHitArea
+          geometry={hitGeometry}
+          material={hitMaterial}
+          onPointerDown={activateThicknessResize}
+          onPointerEnter={(event) => {
+            event.stopPropagation()
+            setIsHovered(true)
+            document.body.style.cursor = 'ew-resize'
+          }}
+          onPointerLeave={(event) => {
+            event.stopPropagation()
+            setIsHovered(false)
+            if (!isDragging && document.body.style.cursor === 'ew-resize') {
+              document.body.style.cursor = ''
+            }
+          }}
+          scale={1}
+        />
+        <mesh material={dotMaterial} raycast={NO_RAYCAST} renderOrder={1003}>
+          <circleGeometry args={[THICKNESS_HANDLE_RADIUS, 32]} />
+        </mesh>
+        <mesh material={ringMaterial} raycast={NO_RAYCAST} renderOrder={1002}>
+          <ringGeometry args={[THICKNESS_HANDLE_RADIUS, THICKNESS_HANDLE_RADIUS * 1.18, 32]} />
+        </mesh>
+      </group>
+      {isDragging ? (
+        <Html
+          center
+          position={[position[0], position[1] + 0.22, position[2]]}
+          style={{ pointerEvents: 'none', userSelect: 'none' }}
+          zIndexRange={[25, 0]}
+        >
+          <MeasurementPill
+            height={structureHeight}
+            length={
+              node.type === 'fence' ? getFenceCenterlineLength(node) : getWallCurveLength(node)
+            }
+            primary="thickness"
+            thickness={thickness}
+            unit={unit}
+          />
+        </Html>
+      ) : null}
+    </>
+  )
+}
+
+function FenceThicknessHandles({ fence }: { fence: FenceNode }) {
+  const nodes = useScene((state) => state.nodes)
+  const liveOverride = useLiveNodeOverrides((state) => state.overrides.get(fence.id))
+  const effectiveFence = useMemo(
+    () => (liveOverride ? ({ ...fence, ...liveOverride } as FenceNode) : fence),
+    [fence, liveOverride],
+  )
+  const [levelObject, setLevelObject] = useState<Object3D | null>(() =>
+    fence.parentId ? (sceneRegistry.nodes.get(fence.parentId) ?? null) : null,
+  )
+
+  useEffect(() => {
+    let frameId = 0
+    const resolveLevelObject = () => {
+      const next = fence.parentId ? (sceneRegistry.nodes.get(fence.parentId) ?? null) : null
+      setLevelObject(next)
+      if (!next) frameId = window.requestAnimationFrame(resolveLevelObject)
+    }
+    resolveLevelObject()
+    return () => {
+      if (frameId) window.cancelAnimationFrame(frameId)
+    }
+  }, [fence.parentId])
+
+  if (!levelObject) return null
+
+  const baseElevation = getFenceBaseElevationForNodes(effectiveFence, nodes)
+  return createPortal(
+    <group position={[0, baseElevation, 0]}>
+      <StructureThicknessHandle
+        baseElevation={baseElevation}
+        levelObject={levelObject}
+        node={effectiveFence}
+        side={1}
+      />
+      <StructureThicknessHandle
+        baseElevation={baseElevation}
+        levelObject={levelObject}
+        node={effectiveFence}
+        side={-1}
+      />
+    </group>,
     levelObject,
   )
 }

--- a/packages/editor/src/lib/elevation-guides.ts
+++ b/packages/editor/src/lib/elevation-guides.ts
@@ -1,6 +1,7 @@
 import {
   type AnyNode,
   type AnyNodeId,
+  type FenceNode,
   findLevelAncestorId,
   getWallBaseElevationForNodes,
   getWallEffectiveHeightForNodes,
@@ -53,8 +54,10 @@ function segmentCenter(
 // A stale host resolves to the level base — the sculpted ground under the
 // fence's start point, sampled where the builder samples it, so the guide line
 // lands on the rail it claims to describe.
-function fenceBaseElevation(node: AnyNode, nodes: Record<string, AnyNode>): number {
-  if (node.type !== 'fence') return 0
+export function getFenceBaseElevationForNodes(
+  node: FenceNode,
+  nodes: Record<string, AnyNode>,
+): number {
   const host = node.supportSlabId ? nodes[node.supportSlabId as AnyNodeId] : undefined
   const hosted = host?.type === 'slab' && (host.parentId ?? null) === (node.parentId ?? null)
   const levelId = findLevelAncestorId(node.id as AnyNodeId, nodes)
@@ -161,7 +164,7 @@ export function collectElevationSnapTargets(
     }
 
     if (node.type === 'fence') {
-      const base = fenceBaseElevation(node, nodes)
+      const base = getFenceBaseElevationForNodes(node, nodes)
       const center = segmentCenter(node.start, node.end)
       targets.push({
         id: `${node.id}:base`,

--- a/packages/editor/src/lib/floorplan/apply-alignment.test.ts
+++ b/packages/editor/src/lib/floorplan/apply-alignment.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { useScene } from '@pascal-app/core'
+import { LevelNode, useScene, WallNode } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import useAlignmentGuides from '../../store/use-alignment-guides'
-import { applyFloorplanAlignment } from './apply-alignment'
+import { alignFloorplanDraftPoint, applyFloorplanAlignment } from './apply-alignment'
 
 describe('applyFloorplanAlignment', () => {
   beforeEach(() => {
@@ -36,5 +36,35 @@ describe('applyFloorplanAlignment', () => {
     expect(result.snapped).toBe(false)
     expect(result.guides).toHaveLength(1)
     expect(useAlignmentGuides.getState().guides).toHaveLength(1)
+  })
+
+  test('can restrict candidates to the active level', () => {
+    const lowerLevel = LevelNode.parse({ id: 'level_lower', level: 0 })
+    const upperLevel = LevelNode.parse({ id: 'level_upper', level: 1 })
+    const lowerWall = WallNode.parse({
+      id: 'wall_lower',
+      parentId: lowerLevel.id,
+      start: [10, 10],
+      end: [14, 10],
+    })
+    const upperWall = WallNode.parse({
+      id: 'wall_upper',
+      parentId: upperLevel.id,
+      start: [0, 0],
+      end: [4, 0],
+    })
+    useScene.setState({
+      nodes: Object.fromEntries(
+        [lowerLevel, upperLevel, lowerWall, upperWall].map((node) => [node.id, node]),
+      ),
+    } as never)
+
+    expect(
+      alignFloorplanDraftPoint([0.04, 0], {
+        applySnap: true,
+        levelId: lowerLevel.id,
+      }),
+    ).toEqual([0.04, 0])
+    expect(useAlignmentGuides.getState().guides).toHaveLength(0)
   })
 })

--- a/packages/editor/src/lib/floorplan/apply-alignment.ts
+++ b/packages/editor/src/lib/floorplan/apply-alignment.ts
@@ -2,6 +2,7 @@ import {
   type AlignmentAnchor,
   type AlignmentGuide,
   collectAlignmentAnchors,
+  resolveLevelId,
   useScene,
 } from '@pascal-app/core'
 import useAlignmentGuides from '../../store/use-alignment-guides'
@@ -96,13 +97,21 @@ export function alignFloorplanDraftPoint(
     bypass?: boolean
     threshold?: number
     excludeIds?: readonly string[]
+    levelId?: string | null
   },
 ): [number, number] {
   if (opts?.bypass) {
     useAlignmentGuides.getState().clear()
     return [point[0], point[1]]
   }
-  let candidates = collectAlignmentAnchors(useScene.getState().nodes, FLOORPLAN_DRAFT_ALIGN_ID)
+  const nodes = useScene.getState().nodes
+  let candidates = collectAlignmentAnchors(nodes, FLOORPLAN_DRAFT_ALIGN_ID)
+  if (opts && 'levelId' in opts) {
+    candidates = candidates.filter((anchor) => {
+      const candidate = nodes[anchor.nodeId as keyof typeof nodes]
+      return candidate ? resolveLevelId(candidate, nodes) === opts.levelId : false
+    })
+  }
   if (opts?.excludeIds?.length) {
     const excluded = new Set(opts.excludeIds)
     candidates = candidates.filter((anchor) => !excluded.has(anchor.nodeId))

--- a/packages/editor/src/lib/interaction/overlay-policy.test.ts
+++ b/packages/editor/src/lib/interaction/overlay-policy.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 import type { AnyNode } from '@pascal-app/core'
-import { resolveOverlayPolicy, shouldShowEditingControls } from './overlay-policy'
+import {
+  resolveFloatingActionMenuVisibility,
+  resolveOverlayPolicy,
+  shouldShowEditingControls,
+} from './overlay-policy'
 import type { ActiveInteractionScope } from './scope'
 
 const mockNode = (id: string, type: string): AnyNode => ({ id, type }) as unknown as AnyNode
@@ -56,5 +60,25 @@ describe('shouldShowEditingControls', () => {
   test('hides controls that can mutate a read-only scene', () => {
     expect(shouldShowEditingControls(false)).toBe(true)
     expect(shouldShowEditingControls(true)).toBe(false)
+  })
+})
+
+describe('resolveFloatingActionMenuVisibility', () => {
+  test('keeps the active measurement pill while hiding action buttons during a height drag', () => {
+    const visibility = resolveFloatingActionMenuVisibility(
+      { kind: 'handle-drag', nodeId: 'wall_1', handle: 'height' },
+      true,
+    )
+
+    expect(visibility).toEqual({ root: true, actions: false })
+  })
+
+  test('hides the whole menu during interactions without an active measurement pill', () => {
+    const visibility = resolveFloatingActionMenuVisibility(
+      { kind: 'handle-drag', nodeId: 'wall_1', handle: 'elevation' },
+      false,
+    )
+
+    expect(visibility).toEqual({ root: false, actions: false })
   })
 })

--- a/packages/editor/src/lib/interaction/overlay-policy.ts
+++ b/packages/editor/src/lib/interaction/overlay-policy.ts
@@ -58,6 +58,18 @@ export function resolveOverlayPolicy(scope: InteractionScope): OverlayPolicy {
   return isActive(scope) ? ACTIVE_POLICY : IDLE_POLICY
 }
 
+export function resolveFloatingActionMenuVisibility(
+  scope: InteractionScope,
+  hasActiveMeasurementPill: boolean,
+): { root: boolean; actions: boolean } {
+  const policy = resolveOverlayPolicy(scope)
+  const actions = policy.conflictingControls === 'shown'
+  return {
+    root: actions || (hasActiveMeasurementPill && policy.activeAffordances === 'shown'),
+    actions,
+  }
+}
+
 export function shouldShowEditingControls(readOnly: boolean): boolean {
   return !readOnly
 }

--- a/packages/nodes/src/cupola/__tests__/geometry.test.ts
+++ b/packages/nodes/src/cupola/__tests__/geometry.test.ts
@@ -18,7 +18,7 @@ describe('buildCupolaGeometry', () => {
     expect(geo.getAttribute('normal').count).toBe(p.count)
     expect(geo.getAttribute('uv').count).toBe(p.count)
     expect(geo.getAttribute('uv2').count).toBe(p.count)
-    expect(new Set(geo.groups.map((group) => group.materialIndex))).toEqual(new Set([0, 1, 2]))
+    expect(new Set(geo.groups.map((group) => group.materialIndex))).toEqual(new Set([0, 1, 2, 3]))
     expect(geo.groups.reduce((count, group) => count + group.count, 0)).toBe(p.count)
   })
 

--- a/packages/nodes/src/cupola/__tests__/paint.test.ts
+++ b/packages/nodes/src/cupola/__tests__/paint.test.ts
@@ -1,12 +1,26 @@
 import { describe, expect, test } from 'bun:test'
+import { cupolaDefinition } from '../definition'
 import { cupolaPaint, resolveCupolaMaterialRole } from '../paint'
 import { CupolaNode } from '../schema'
 
 describe('cupola paint', () => {
-  test('maps geometry groups to base, body, and roof', () => {
+  test('declares and seeds metallic louvers for new cupolas', () => {
+    const defaults = cupolaDefinition.defaults()
+    const node = CupolaNode.parse(defaults)
+
+    expect(node.slots?.louvers).toBe('library:preset-metal')
+    expect(cupolaDefinition.capabilities.slots?.(node)).toContainEqual({
+      slotId: 'louvers',
+      label: 'Louvers',
+      default: 'library:preset-metal',
+    })
+  })
+
+  test('maps geometry groups to base, body, roof, and louvers', () => {
     expect(resolveCupolaMaterialRole(0)).toBe('base')
     expect(resolveCupolaMaterialRole(1)).toBe('body')
     expect(resolveCupolaMaterialRole(2)).toBe('roof')
+    expect(resolveCupolaMaterialRole(3)).toBe('louvers')
   })
 
   test('updates only the selected construction part', () => {
@@ -14,12 +28,12 @@ describe('cupola paint', () => {
     expect(
       cupolaPaint.buildPatch({
         node,
-        role: 'roof',
+        role: 'louvers',
         material: undefined,
         materialPreset: 'library:copper',
       }),
     ).toEqual({
-      slots: { body: 'library:louver', roof: 'library:copper' },
+      slots: { body: 'library:louver', louvers: 'library:copper' },
     })
   })
 

--- a/packages/nodes/src/cupola/definition.ts
+++ b/packages/nodes/src/cupola/definition.ts
@@ -15,6 +15,7 @@ const HEIGHT_HANDLE_OFFSET = 0.25
 const ROTATE_CORNER_OFFSET = 0.12
 const MIN_DIM = 0.3
 const MIN_HEIGHT = 0.4
+const CUPOLA_LOUVERS_DEFAULT = 'library:preset-metal'
 
 function getBodyMidY(n: CupolaNodeType): number {
   return Math.max(0.001, n.height) / 2
@@ -108,7 +109,7 @@ const cupolaHandles: HandleDescriptor<CupolaNodeType>[] = [
  */
 export const cupolaDefinition: NodeDefinition<typeof CupolaNode> = {
   kind: 'cupola',
-  schemaVersion: 3,
+  schemaVersion: 4,
   schema: CupolaNode,
   category: 'structure',
   surfaceRole: 'roof',
@@ -116,7 +117,10 @@ export const cupolaDefinition: NodeDefinition<typeof CupolaNode> = {
   defaults: () => {
     const stub = CupolaNodeSchema.parse({ id: 'cupola_default' as never, type: 'cupola' })
     const { id: _id, type: _type, ...rest } = stub
-    return rest
+    return {
+      ...rest,
+      slots: { ...(rest.slots ?? {}), louvers: CUPOLA_LOUVERS_DEFAULT },
+    }
   },
 
   capabilities: {
@@ -124,6 +128,7 @@ export const cupolaDefinition: NodeDefinition<typeof CupolaNode> = {
       { slotId: 'base', label: 'Base', default: 'library:preset-softwhite' },
       { slotId: 'body', label: 'Body', default: 'library:preset-softwhite' },
       { slotId: 'roof', label: 'Roof', default: 'library:preset-softwhite' },
+      { slotId: 'louvers', label: 'Louvers', default: CUPOLA_LOUVERS_DEFAULT },
     ],
     selectable: { hitVolume: 'bbox' },
     duplicable: true,

--- a/packages/nodes/src/cupola/geometry.ts
+++ b/packages/nodes/src/cupola/geometry.ts
@@ -11,6 +11,7 @@ export const CUPOLA_MATERIAL_INDEX = {
   base: 0,
   body: 1,
   roof: 2,
+  louvers: 3,
 } as const
 
 /**
@@ -96,7 +97,7 @@ export function buildCupolaGeometry(node: CupolaNode): THREE.BufferGeometry {
   geo.addGroup(0, baseEnd, CUPOLA_MATERIAL_INDEX.base)
   geo.addGroup(baseEnd, bodyEnd - baseEnd, CUPOLA_MATERIAL_INDEX.body)
   geo.addGroup(bodyEnd, corniceEnd - bodyEnd, CUPOLA_MATERIAL_INDEX.roof)
-  geo.addGroup(corniceEnd, louversEnd - corniceEnd, CUPOLA_MATERIAL_INDEX.body)
+  geo.addGroup(corniceEnd, louversEnd - corniceEnd, CUPOLA_MATERIAL_INDEX.louvers)
   geo.addGroup(louversEnd, p.length / 3 - louversEnd, CUPOLA_MATERIAL_INDEX.roof)
   copyUvToSecondaryChannel(geo)
   geo.computeBoundingSphere()

--- a/packages/nodes/src/cupola/paint.ts
+++ b/packages/nodes/src/cupola/paint.ts
@@ -8,6 +8,7 @@ type LegacyCupola = AnyNode & { material?: MaterialSchema; materialPreset?: stri
 export function resolveCupolaMaterialRole(materialIndex: number | null): CupolaMaterialRole {
   if (materialIndex === CUPOLA_MATERIAL_INDEX.body) return 'body'
   if (materialIndex === CUPOLA_MATERIAL_INDEX.roof) return 'roof'
+  if (materialIndex === CUPOLA_MATERIAL_INDEX.louvers) return 'louvers'
   return 'base'
 }
 

--- a/packages/nodes/src/cupola/renderer.tsx
+++ b/packages/nodes/src/cupola/renderer.tsx
@@ -71,7 +71,7 @@ const CupolaRenderer = ({ node: storeNode }: { node: CupolaNode }) => {
 
   const material = useMemo(() => {
     const roleDefault = createSurfaceRoleMaterial('roof', colorPreset, THREE.FrontSide, sceneTheme)
-    const resolve = (role: 'base' | 'body' | 'roof') => {
+    const resolve = (role: 'base' | 'body' | 'roof' | 'louvers') => {
       if (!textures) return roleDefault
       const slotMaterial = resolveMaterialRef(node.slots?.[role], sceneMaterials, shading)
       if (slotMaterial) return slotMaterial
@@ -81,7 +81,7 @@ const CupolaRenderer = ({ node: storeNode }: { node: CupolaNode }) => {
       }
       return roleDefault
     }
-    return [resolve('base'), resolve('body'), resolve('roof')]
+    return [resolve('base'), resolve('body'), resolve('roof'), resolve('louvers')]
   }, [
     textures,
     colorPreset,

--- a/packages/nodes/src/eyebrow-vent/__tests__/paint.test.ts
+++ b/packages/nodes/src/eyebrow-vent/__tests__/paint.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, test } from 'bun:test'
+import { eyebrowVentDefinition } from '../definition'
 import { eyebrowVentPaint, resolveEyebrowVentMaterialRole } from '../paint'
 import { EyebrowVentNode } from '../schema'
 
 describe('eyebrow vent paint', () => {
+  test('presents the front slot as Louvers', () => {
+    const node = EyebrowVentNode.parse({})
+    expect(eyebrowVentDefinition.capabilities.slots?.(node)).toContainEqual({
+      slotId: 'front',
+      label: 'Louvers',
+      default: 'library:preset-softwhite',
+    })
+  })
+
   test('maps geometry groups to hood and front', () => {
     expect(resolveEyebrowVentMaterialRole(0)).toBe('hood')
     expect(resolveEyebrowVentMaterialRole(1)).toBe('front')

--- a/packages/nodes/src/eyebrow-vent/definition.ts
+++ b/packages/nodes/src/eyebrow-vent/definition.ts
@@ -129,7 +129,7 @@ export const eyebrowVentDefinition: NodeDefinition<typeof EyebrowVentNode> = {
   capabilities: {
     slots: () => [
       { slotId: 'hood', label: 'Hood', default: 'library:preset-softwhite' },
-      { slotId: 'front', label: 'Front', default: 'library:preset-softwhite' },
+      { slotId: 'front', label: 'Louvers', default: 'library:preset-softwhite' },
     ],
     selectable: { hitVolume: 'bbox' },
     duplicable: true,

--- a/packages/nodes/src/fence/definition.ts
+++ b/packages/nodes/src/fence/definition.ts
@@ -17,6 +17,7 @@ import {
   fenceCurveAffordance,
   fenceMoveEndpointAffordance,
   fenceTangentAffordance,
+  fenceThicknessAffordance,
 } from './floorplan-affordances'
 import { fenceFloorplanMoveTarget } from './floorplan-move'
 import { buildFenceGeometry } from './geometry'
@@ -361,6 +362,7 @@ export const fenceDefinition: NodeDefinition<typeof FenceNode> = {
     'move-control-point': fenceControlPointAffordance,
     'move-tangent': fenceTangentAffordance,
     curve: fenceCurveAffordance,
+    thickness: fenceThicknessAffordance,
   },
   // Body move on the fence is driven by the two `move-arrow` chevrons
   // the floor-plan builder emits at the midpoint. Pointer-down enters

--- a/packages/nodes/src/fence/floorplan-affordances.ts
+++ b/packages/nodes/src/fence/floorplan-affordances.ts
@@ -4,6 +4,7 @@ import {
   type FenceNode,
   type FloorplanAffordance,
   type FloorplanAffordanceSession,
+  getFenceCenterlineFrameAt,
   getMaxWallCurveOffset,
   getWallChordFrame,
   normalizeWallCurveOffset,
@@ -48,11 +49,13 @@ const LINKED_FENCE_ENDPOINT_EPSILON = 0.025
 type FenceEndpointPayload = { fenceId: AnyNodeId; endpoint: 'start' | 'end' }
 type FenceControlPointPayload = { fenceId: AnyNodeId; index: number }
 type FenceTangentPayload = { fenceId: AnyNodeId; index: number; side: 'in' | 'out' }
+type FenceThicknessPayload = { fenceId: AnyNodeId; side: 1 | -1 }
 
 // Must match the floorplan builder's TANGENT_HANDLE_ARM_SCALE: the on-screen
 // arm is this many times the raw tangent vector, so dividing the dragged
 // offset back out recovers the stored tangent.
 const TANGENT_HANDLE_ARM_SCALE = 3
+const MIN_FENCE_THICKNESS = 0.03
 
 function pointsNearlyEqual(a: FencePlanPoint, b: FencePlanPoint): boolean {
   return (
@@ -139,6 +142,40 @@ export const fenceCurveAffordance: FloorplanAffordance<FenceNode> = {
       },
       commit() {
         useScene.getState().updateNodes([{ id: fenceId, data: { curveOffset: lastCurveOffset } }])
+        useLiveNodeOverrides.getState().clear(fenceId)
+      },
+    }
+  },
+}
+
+export const fenceThicknessAffordance: FloorplanAffordance<FenceNode> = {
+  start({ node, payload, initialPlanPoint }): FloorplanAffordanceSession {
+    const { side } = payload as FenceThicknessPayload
+    const frame = getFenceCenterlineFrameAt(node, 0.5)
+    const outwardX = frame.normal.x * side
+    const outwardY = frame.normal.y * side
+    const initialThickness = node.thickness ?? 0.08
+    const fenceId = node.id as AnyNodeId
+    let lastThickness = initialThickness
+
+    return {
+      affectedIds: [fenceId],
+      apply({ planPoint }) {
+        const outwardDelta =
+          (planPoint[0] - initialPlanPoint[0]) * outwardX +
+          (planPoint[1] - initialPlanPoint[1]) * outwardY
+        lastThickness = Math.max(
+          MIN_FENCE_THICKNESS,
+          snapScalarToGrid(initialThickness + outwardDelta * 2, getSegmentGridStep()),
+        )
+        useLiveNodeOverrides.getState().set(fenceId, { thickness: lastThickness })
+        useScene.getState().markDirty(fenceId)
+      },
+      canCommit() {
+        return true
+      },
+      commit() {
+        useScene.getState().updateNodes([{ id: fenceId, data: { thickness: lastThickness } }])
         useLiveNodeOverrides.getState().clear(fenceId)
       },
     }

--- a/packages/nodes/src/fence/floorplan-thickness.test.ts
+++ b/packages/nodes/src/fence/floorplan-thickness.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  type AnyNodeId,
+  type FloorplanGeometry,
+  type GeometryContext,
+  useLiveNodeOverrides,
+  useScene,
+} from '@pascal-app/core'
+import { buildFenceFloorplan } from './floorplan'
+import { fenceThicknessAffordance } from './floorplan-affordances'
+import { FenceNode } from './schema'
+
+const modifiers = {
+  shiftKey: false,
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+}
+
+function flatten(geometry: FloorplanGeometry): FloorplanGeometry[] {
+  return geometry.kind === 'group' ? [geometry, ...geometry.children.flatMap(flatten)] : [geometry]
+}
+
+function selectedContext(): GeometryContext {
+  return {
+    resolve: () => undefined,
+    children: [],
+    siblings: [],
+    parent: null,
+    viewState: {
+      selected: true,
+      highlighted: false,
+      hovered: false,
+      moving: false,
+      unit: 'metric',
+    },
+  }
+}
+
+describe('fence thickness handles', () => {
+  afterEach(() => {
+    useLiveNodeOverrides.getState().clearAll()
+  })
+
+  test('places one floor-plan handle on each curved fence face', () => {
+    const fence = FenceNode.parse({
+      id: 'fence_curve-thickness',
+      parentId: 'level_main',
+      start: [0, 0],
+      end: [4, 0],
+      curveOffset: 1,
+      thickness: 0.08,
+    })
+    const handles = flatten(buildFenceFloorplan(fence, selectedContext())).filter(
+      (entry) => entry.kind === 'endpoint-handle' && entry.affordance === 'thickness',
+    )
+
+    expect(handles).toHaveLength(2)
+    if (handles[0]?.kind !== 'endpoint-handle' || handles[1]?.kind !== 'endpoint-handle') return
+    expect(handles[0].point).toEqual([2, -0.96])
+    expect(handles[1].point).toEqual([2, -1.04])
+  })
+
+  test('previews and commits a centerline-fixed thickness change', () => {
+    const fence = FenceNode.parse({
+      id: 'fence_thickness',
+      parentId: 'level_main',
+      start: [0, 0],
+      end: [4, 0],
+      thickness: 0.08,
+    })
+    useScene.setState({ nodes: { [fence.id]: fence } as never })
+
+    const session = fenceThicknessAffordance.start({
+      node: fence,
+      payload: { fenceId: fence.id, side: 1 },
+      nodes: useScene.getState().nodes,
+      initialPlanPoint: [2, 0.04],
+      gridSnapStep: 0.1,
+    })
+    session.apply({ planPoint: [2, 0.14], modifiers })
+
+    expect((useScene.getState().nodes[fence.id] as typeof fence).thickness).toBe(0.08)
+    expect(useLiveNodeOverrides.getState().get(fence.id as AnyNodeId)?.thickness).toBeCloseTo(0.28)
+
+    session.commit?.()
+
+    const committed = useScene.getState().nodes[fence.id] as typeof fence
+    expect(committed.thickness).toBeCloseTo(0.28)
+    expect(committed.start).toEqual([0, 0])
+    expect(committed.end).toEqual([4, 0])
+  })
+
+  test('clamps inward dragging to the fence schema minimum', () => {
+    const fence = FenceNode.parse({
+      id: 'fence_thickness-min',
+      parentId: 'level_main',
+      start: [0, 0],
+      end: [4, 0],
+      thickness: 0.08,
+    })
+    useScene.setState({ nodes: { [fence.id]: fence } as never })
+
+    const session = fenceThicknessAffordance.start({
+      node: fence,
+      payload: { fenceId: fence.id, side: -1 },
+      nodes: useScene.getState().nodes,
+      initialPlanPoint: [2, -0.04],
+      gridSnapStep: 0.1,
+    })
+    session.apply({ planPoint: [2, 0.2], modifiers })
+    session.commit?.()
+
+    expect((useScene.getState().nodes[fence.id] as typeof fence).thickness).toBe(0.03)
+  })
+})

--- a/packages/nodes/src/fence/floorplan.ts
+++ b/packages/nodes/src/fence/floorplan.ts
@@ -448,6 +448,21 @@ export function buildFenceFloorplan(node: FenceNode, ctx: GeometryContext): Floo
       })
     }
 
+    const thicknessFrame = getFenceCenterlineFrameAt(node, 0.5)
+    const halfThickness = (node.thickness ?? 0.08) / 2
+    for (const side of [1, -1] as const) {
+      children.push({
+        kind: 'endpoint-handle',
+        point: [
+          thicknessFrame.point.x + thicknessFrame.normal.x * halfThickness * side,
+          thicknessFrame.point.y + thicknessFrame.normal.y * halfThickness * side,
+        ],
+        state: 'idle',
+        affordance: 'thickness',
+        payload: { fenceId: node.id, side },
+      })
+    }
+
     // Two perpendicular `move-arrow` chevrons at the fence midpoint.
     // No `affordance` → the registry layer routes pointer-down through
     // `setMovingNode`, which the `FloorplanRegistryMoveOverlay` picks

--- a/packages/nodes/src/gutter/definition.test.ts
+++ b/packages/nodes/src/gutter/definition.test.ts
@@ -3,26 +3,29 @@ import { GutterNode } from '@pascal-app/core'
 import { gutterDefinition } from './definition'
 
 describe('gutter paint capability', () => {
-  test('paints the complete gutter as one surface', () => {
+  test('paints the complete gutter through the gutter slot', () => {
     const node = GutterNode.parse({ id: 'gutter_test', type: 'gutter' })
     const paint = gutterDefinition.capabilities.paint
 
+    expect(gutterDefinition.capabilities.slots?.(node)).toEqual([
+      { slotId: 'gutter', label: 'Gutter', default: 'library:preset-softwhite' },
+    ])
     expect(paint?.materialTarget).toBe('gutter')
     expect(
       paint?.resolveRole({
         node,
         materialIndex: null,
       }),
-    ).toBe('surface')
+    ).toBe('gutter')
     expect(
       paint?.buildPatch({
         node,
-        role: 'surface',
+        role: 'gutter',
         material: undefined,
         materialPreset: 'library:metal-steel',
       }),
     ).toEqual({
-      slots: { surface: 'library:metal-steel' },
+      slots: { gutter: 'library:metal-steel' },
     })
   })
 })

--- a/packages/nodes/src/gutter/definition.ts
+++ b/packages/nodes/src/gutter/definition.ts
@@ -4,9 +4,9 @@ import {
   type HandleDescriptor,
   type NodeDefinition,
 } from '@pascal-app/core'
-import { surfacePaintCapability } from '../shared/surface-paint'
 import { buildGutterFloorplan } from './floorplan'
 import { snapLengthToCorner } from './length-snap'
+import { gutterPaint } from './paint'
 import { gutterParametrics } from './parametrics'
 import { GutterNode } from './schema'
 
@@ -141,7 +141,7 @@ const gutterHandles: HandleDescriptor<GutterNodeType>[] = [
  */
 export const gutterDefinition: NodeDefinition<typeof GutterNode> = {
   kind: 'gutter',
-  schemaVersion: 3,
+  schemaVersion: 4,
   schema: GutterNode,
   category: 'structure',
   surfaceRole: 'roof',
@@ -157,11 +157,11 @@ export const gutterDefinition: NodeDefinition<typeof GutterNode> = {
   },
 
   capabilities: {
-    slots: () => [{ slotId: 'surface', label: 'Surface', default: 'library:preset-softwhite' }],
+    slots: () => [{ slotId: 'gutter', label: 'Gutter', default: 'library:preset-softwhite' }],
     selectable: { hitVolume: 'bbox' },
     duplicable: true,
     deletable: true,
-    paint: { ...surfacePaintCapability, materialTarget: 'gutter' },
+    paint: gutterPaint,
     // Mounts on a roof segment via `roofSegmentId`. Sits ON TOP of the
     // eave fascia — no `buildCut`, just the dirty cascade so the
     // parent roof's merged shell rebuilds when the gutter moves /

--- a/packages/nodes/src/gutter/paint.ts
+++ b/packages/nodes/src/gutter/paint.ts
@@ -1,0 +1,8 @@
+import type { PaintCapability } from '@pascal-app/core'
+import { surfacePaintCapability } from '../shared/surface-paint'
+
+export const gutterPaint: PaintCapability = {
+  ...surfacePaintCapability,
+  materialTarget: 'gutter',
+  resolveRole: () => 'gutter',
+}

--- a/packages/nodes/src/gutter/renderer.tsx
+++ b/packages/nodes/src/gutter/renderer.tsx
@@ -237,7 +237,7 @@ const GutterRenderer = ({ node: storeNode }: { node: GutterNode }) => {
     if (!textures) {
       return createSurfaceRoleMaterial('roof', colorPreset, THREE.FrontSide, sceneTheme)
     }
-    const slotMaterial = resolveMaterialRef(node.slots?.surface, sceneMaterials, shading)
+    const slotMaterial = resolveMaterialRef(node.slots?.gutter, sceneMaterials, shading)
     if (slotMaterial) return slotMaterial
     if (!node.material && !node.materialPreset) {
       return createSurfaceRoleMaterial('roof', colorPreset, THREE.FrontSide, sceneTheme)
@@ -250,7 +250,7 @@ const GutterRenderer = ({ node: storeNode }: { node: GutterNode }) => {
     colorPreset,
     sceneTheme,
     shading,
-    node.slots?.surface,
+    node.slots?.gutter,
     node.material,
     node.materialPreset,
     sceneMaterials,

--- a/packages/nodes/src/roof-segment/panel.tsx
+++ b/packages/nodes/src/roof-segment/panel.tsx
@@ -466,14 +466,6 @@ export default function RoofSegmentPanel() {
         </PanelSection>
       )}
 
-      <PanelSection title="Drainage">
-        <ToggleControl
-          checked={autoGutterEnabled}
-          label="Auto gutters"
-          onChange={handleAutoGutterToggle}
-        />
-      </PanelSection>
-
       <PanelSection title="Wall Height">
         <SliderControl
           label="Wall"

--- a/packages/nodes/src/roof/roof-footprint.test.ts
+++ b/packages/nodes/src/roof/roof-footprint.test.ts
@@ -15,8 +15,10 @@ describe('roof footprint sources', () => {
   test('normalizes footprint sources for the selected roof type', () => {
     expect(parseRoofFootprintSource('room', 'conical')).toBe('walls')
     expect(parseRoofFootprintSource('draw', 'conical')).toBe('walls')
-    expect(parseRoofFootprintSource('walls', 'hip')).toBe('room')
+    expect(parseRoofFootprintSource('walls', 'hip')).toBe('draw')
+    expect(parseRoofFootprintSource(undefined, 'hip')).toBe('draw')
     expect(parseRoofFootprintSource('draw', 'hip')).toBe('draw')
+    expect(parseRoofFootprintSource('room', 'hip')).toBe('room')
   })
 
   test('fits a rotated rectangular room', () => {

--- a/packages/nodes/src/roof/roof-footprint.ts
+++ b/packages/nodes/src/roof/roof-footprint.ts
@@ -51,7 +51,7 @@ export function isConicalRoofWallEligible(
 
 export function parseRoofFootprintSource(value: unknown, roofType: RoofType): RoofFootprintSource {
   if (roofType === 'conical') return 'walls'
-  return value === 'draw' ? 'draw' : 'room'
+  return value === 'room' ? 'room' : 'draw'
 }
 
 export function subscribeToConicalRoofWallClicks(options: {

--- a/packages/nodes/src/wall/curve-eligibility.ts
+++ b/packages/nodes/src/wall/curve-eligibility.ts
@@ -1,0 +1,11 @@
+import type { AnyNode } from '@pascal-app/core'
+
+export function hasWallCurveBlockingChildren(children: readonly AnyNode[]) {
+  return children.some((child) => {
+    if (child.type === 'door' || child.type === 'window' || child.type === 'lean-to-extension') {
+      return true
+    }
+    if (child.type !== 'item') return false
+    return child.asset?.attachTo === 'wall' || child.asset?.attachTo === 'wall-side'
+  })
+}

--- a/packages/nodes/src/wall/curve-tool.tsx
+++ b/packages/nodes/src/wall/curve-tool.tsx
@@ -3,6 +3,7 @@
 import {
   type AnyNodeId,
   acquireSceneHistoryPause,
+  constrainWallCurveOffsetToAvoidIntersections,
   emitter,
   type GridEvent,
   getClampedWallCurveOffset,
@@ -10,6 +11,7 @@ import {
   getWallChordFrame,
   getWallMidpointHandlePoint,
   normalizeWallCurveOffset,
+  useLiveNodeOverrides,
   useScene,
   type WallNode,
 } from '@pascal-app/core'
@@ -56,6 +58,10 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
     const originalCurveOffset = originalCurveOffsetRef.current
     const chord = getWallChordFrame(node)
     const maxCurveOffset = getMaxWallCurveOffset(node)
+    const levelWalls = Object.values(useScene.getState().nodes).filter(
+      (candidate): candidate is WallNode =>
+        candidate.type === 'wall' && candidate.parentId === node.parentId,
+    )
 
     let releaseHistory = acquireSceneHistoryPause(useScene)
     let wasFinalized = false
@@ -72,16 +78,13 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
       }
       const handlePoint = getWallMidpointHandlePoint(nextNode)
       setCursorLocalPos([handlePoint.x, 0, handlePoint.y])
-      useScene.getState().updateNode(nodeId, { curveOffset })
+      useLiveNodeOverrides.getState().set(nodeId as AnyNodeId, { curveOffset })
       useScene.getState().markDirty(nodeId as AnyNodeId)
     }
 
     const restoreOriginal = () => {
-      if (previewOffsetRef.current === originalCurveOffset) {
-        return
-      }
       previewOffsetRef.current = originalCurveOffset
-      useScene.getState().updateNode(nodeId, { curveOffset: originalCurveOffset })
+      useLiveNodeOverrides.getState().clear(nodeId as AnyNodeId)
       useScene.getState().markDirty(nodeId as AnyNodeId)
     }
 
@@ -102,9 +105,14 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
         (localZ - chord.midpoint.y) * chord.normal.y
       )
       const snappedOffset = snapScalarToGrid(offsetFromMidpoint, snapStep)
-      const nextCurveOffset = normalizeWallCurveOffset(
+      const requestedCurveOffset = normalizeWallCurveOffset(
         node,
         Math.max(-maxCurveOffset, Math.min(maxCurveOffset, snappedOffset)),
+      )
+      const nextCurveOffset = constrainWallCurveOffsetToAvoidIntersections(
+        node,
+        requestedCurveOffset,
+        levelWalls,
       )
 
       if (
@@ -127,13 +135,10 @@ export const CurveWallTool: React.FC<{ node: WallNode }> = ({ node }) => {
 
       const curveOffset = previewOffsetRef.current
       wasFinalized = true
+      useLiveNodeOverrides.getState().clear(nodeId as AnyNodeId)
+      useScene.getState().markDirty(nodeId as AnyNodeId)
 
       if (curveOffset !== originalCurveOffset) {
-        // Restore original baseline while paused so the next resume+update
-        // registers as a single tracked change (undo reverts to original).
-        useScene.getState().updateNode(nodeId, { curveOffset: originalCurveOffset })
-        useScene.getState().markDirty(nodeId as AnyNodeId)
-
         releaseHistory()
         useScene.getState().updateNode(nodeId, { curveOffset })
         useScene.getState().markDirty(nodeId as AnyNodeId)

--- a/packages/nodes/src/wall/definition.test.ts
+++ b/packages/nodes/src/wall/definition.test.ts
@@ -38,6 +38,29 @@ describe('wallDefinition floor-plan extension', () => {
     expect(canCurve?.({ node: wall, nodes })).toBe(false)
     expect(canCurve?.({ node: { ...wall, children: [] }, nodes })).toBe(true)
   })
+
+  test('disables curving for hosted lean-to extensions', () => {
+    const wall = wallDefinition.schema.parse({
+      id: 'wall_lean-to-host',
+      children: ['leanto_test'],
+      start: [0, 0],
+      end: [4, 0],
+    })
+    const nodes = {
+      [wall.id]: wall,
+      leanto_test: {
+        object: 'node',
+        id: 'leanto_test',
+        type: 'lean-to-extension',
+        parentId: wall.id,
+        visible: true,
+        metadata: {},
+      } as AnyNode,
+    } as Record<AnyNodeId, AnyNode>
+
+    const canCurve = getFloorplanNodeExtension(wallDefinition)?.actionMenu?.canCurve
+    expect(canCurve?.({ node: wall, nodes })).toBe(false)
+  })
 })
 
 test('wall top surface follows the effective level-bound height', () => {

--- a/packages/nodes/src/wall/definition.ts
+++ b/packages/nodes/src/wall/definition.ts
@@ -7,8 +7,13 @@ import {
 } from '@pascal-app/core'
 import type { FloorplanNodeExtension } from '@pascal-app/editor'
 import { buildWallContextualDimensions } from './contextual-dimensions'
+import { hasWallCurveBlockingChildren } from './curve-eligibility'
 import { buildWallFloorplan, computeWallFloorplanLevelData } from './floorplan'
-import { wallCurveAffordance, wallMoveEndpointAffordance } from './floorplan-affordances'
+import {
+  wallCurveAffordance,
+  wallMoveEndpointAffordance,
+  wallThicknessAffordance,
+} from './floorplan-affordances'
 import { wallFloorplanMoveTarget } from './floorplan-move'
 import { wallFloorplanSiblingOverrides } from './floorplan-overrides'
 import {
@@ -49,19 +54,12 @@ export const wallDefinition: NodeDefinition<typeof WallNode> = {
       contextualDimensions: buildWallContextualDimensions,
       actionMenu: {
         canCurve: ({ node, nodes }) =>
-          !node.children.some((childId) => {
-            const child = nodes[childId as AnyNodeId]
-            if (!child) return false
-            if (
-              child.type === 'door' ||
-              child.type === 'window' ||
-              child.type === 'lean-to-extension'
-            ) {
-              return true
-            }
-            if (child.type !== 'item') return false
-            return child.asset?.attachTo === 'wall' || child.asset?.attachTo === 'wall-side'
-          }),
+          !hasWallCurveBlockingChildren(
+            node.children.flatMap((childId) => {
+              const child = nodes[childId as AnyNodeId]
+              return child ? [child] : []
+            }),
+          ),
       },
     } satisfies FloorplanNodeExtension<WallNode>,
   },
@@ -163,6 +161,7 @@ export const wallDefinition: NodeDefinition<typeof WallNode> = {
   floorplanAffordances: {
     'move-endpoint': wallMoveEndpointAffordance,
     curve: wallCurveAffordance,
+    thickness: wallThicknessAffordance,
   },
   floorplanMoveTarget: wallFloorplanMoveTarget,
   floorplanSiblingOverrides: wallFloorplanSiblingOverrides,

--- a/packages/nodes/src/wall/floorplan-affordances.test.ts
+++ b/packages/nodes/src/wall/floorplan-affordances.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import { type AnyNodeId, useLiveNodeOverrides, useScene, WallNode } from '@pascal-app/core'
-import { wallCurveAffordance } from './floorplan-affordances'
+import {
+  wallCurveAffordance,
+  wallMoveEndpointAffordance,
+  wallThicknessAffordance,
+} from './floorplan-affordances'
 
 globalThis.requestAnimationFrame ??= (callback) => {
   callback(0)
@@ -46,5 +50,141 @@ describe('wall center curve handle release', () => {
 
     expect((useScene.getState().nodes[wall.id] as typeof wall).curveOffset).not.toBe(0)
     expect(useLiveNodeOverrides.getState().get(wall.id as AnyNodeId)).toBeUndefined()
+  })
+
+  test('previews and commits the collision-constrained curve offset', () => {
+    const wall = WallNode.parse({
+      id: 'wall_curve-base',
+      parentId: 'level_curve',
+      start: [0, 0],
+      end: [4, 0],
+    })
+    const right = WallNode.parse({
+      id: 'wall_curve-right',
+      parentId: 'level_curve',
+      start: [4, 0],
+      end: [2, 3],
+    })
+    const left = WallNode.parse({
+      id: 'wall_curve-left',
+      parentId: 'level_curve',
+      start: [2, 3],
+      end: [0, 0],
+    })
+    useScene.setState({
+      nodes: { [wall.id]: wall, [right.id]: right, [left.id]: left } as never,
+    })
+
+    const session = wallCurveAffordance.start({
+      node: wall,
+      payload: { wallId: wall.id },
+      nodes: useScene.getState().nodes,
+      initialPlanPoint: [2, 0],
+      gridSnapStep: 0.1,
+    })
+    session.apply({ planPoint: [2, 2], modifiers })
+
+    const previewOffset = useLiveNodeOverrides.getState().get(wall.id as AnyNodeId)?.curveOffset
+    expect(previewOffset).toBeNumber()
+    expect(previewOffset as number).toBeGreaterThan(-2)
+
+    session.commit?.()
+
+    expect((useScene.getState().nodes[wall.id] as typeof wall).curveOffset).toBe(previewOffset)
+  })
+})
+
+describe('wall endpoint floorplan affordance', () => {
+  afterEach(() => {
+    useLiveNodeOverrides.getState().clearAll()
+  })
+
+  test('does not cascade into a wall on another level with matching endpoints', () => {
+    const lower = WallNode.parse({
+      id: 'wall_lower',
+      parentId: 'level_lower',
+      start: [0, 0],
+      end: [4, 0],
+    })
+    const upper = WallNode.parse({
+      id: 'wall_upper',
+      parentId: 'level_upper',
+      start: [0, 0],
+      end: [4, 0],
+    })
+    useScene.setState({ nodes: { [lower.id]: lower, [upper.id]: upper } as never })
+
+    const session = wallMoveEndpointAffordance.start({
+      node: lower,
+      payload: { wallId: lower.id, endpoint: 'start' },
+      nodes: useScene.getState().nodes,
+      initialPlanPoint: [0, 0],
+      gridSnapStep: 0.1,
+    })
+    session.apply({ planPoint: [0, 1], modifiers })
+    session.commit?.()
+
+    expect((useScene.getState().nodes[lower.id] as typeof lower).start).toEqual([0, 1])
+    expect((useScene.getState().nodes[upper.id] as typeof upper).start).toEqual([0, 0])
+  })
+})
+
+describe('wall thickness floorplan affordance', () => {
+  afterEach(() => {
+    useLiveNodeOverrides.getState().clearAll()
+  })
+
+  test('previews and commits thickness while keeping the centerline fixed', () => {
+    const wall = WallNode.parse({
+      id: 'wall_thickness',
+      parentId: 'level_main',
+      start: [0, 0],
+      end: [4, 0],
+      thickness: 0.1,
+    })
+    useScene.setState({ nodes: { [wall.id]: wall } as never })
+
+    const session = wallThicknessAffordance.start({
+      node: wall,
+      payload: { wallId: wall.id, side: 1 },
+      nodes: useScene.getState().nodes,
+      initialPlanPoint: [2, 0.05],
+      gridSnapStep: 0.1,
+    })
+    session.apply({ planPoint: [2, 0.15], modifiers })
+
+    expect((useScene.getState().nodes[wall.id] as typeof wall).thickness).toBe(0.1)
+    expect(useLiveNodeOverrides.getState().get(wall.id as AnyNodeId)?.thickness).toBeCloseTo(0.3)
+
+    session.commit?.()
+
+    const committed = useScene.getState().nodes[wall.id] as typeof wall
+    expect(committed.thickness).toBeCloseTo(0.3)
+    expect(committed.start).toEqual([0, 0])
+    expect(committed.end).toEqual([4, 0])
+    expect(useLiveNodeOverrides.getState().get(wall.id as AnyNodeId)).toBeUndefined()
+  })
+
+  test('clamps an inward drag to the minimum wall thickness', () => {
+    const wall = WallNode.parse({
+      id: 'wall_thickness-min',
+      parentId: 'level_main',
+      start: [0, 0],
+      end: [4, 0],
+      thickness: 0.1,
+    })
+    useScene.setState({ nodes: { [wall.id]: wall } as never })
+
+    const session = wallThicknessAffordance.start({
+      node: wall,
+      payload: { wallId: wall.id, side: -1 },
+      nodes: useScene.getState().nodes,
+      initialPlanPoint: [2, -0.05],
+      gridSnapStep: 0.1,
+    })
+    session.apply({ planPoint: [2, 0.2], modifiers })
+    session.commit?.()
+
+    expect((useScene.getState().nodes[wall.id] as typeof wall).thickness).toBe(0.05)
   })
 })

--- a/packages/nodes/src/wall/floorplan-affordances.ts
+++ b/packages/nodes/src/wall/floorplan-affordances.ts
@@ -1,10 +1,13 @@
 import {
   type AnyNode,
   type AnyNodeId,
+  constrainWallCurveOffsetToAvoidIntersections,
   type FloorplanAffordance,
   type FloorplanAffordanceSession,
   getMaxWallCurveOffset,
   getWallChordFrame,
+  getWallCurveFrameAt,
+  getWallThickness,
   normalizeWallCurveOffset,
   runAsSingleSceneHistoryStep,
   useLiveNodeOverrides,
@@ -51,6 +54,9 @@ import {
  */
 
 type WallEndpointPayload = { wallId: AnyNodeId; endpoint: 'start' | 'end' }
+type WallThicknessPayload = { wallId: AnyNodeId; side: 1 | -1 }
+
+const MIN_WALL_THICKNESS = 0.05
 
 function pointsEqual(a: readonly number[], b: readonly number[]) {
   return a[0] === b[0] && a[1] === b[1]
@@ -58,11 +64,18 @@ function pointsEqual(a: readonly number[], b: readonly number[]) {
 
 function collectLevelWalls(
   nodes: Record<AnyNodeId, AnyNode>,
+  parentId: AnyNodeId | null,
   excludeWallId?: AnyNodeId,
 ): WallNode[] {
   const out: WallNode[] = []
   for (const node of Object.values(nodes)) {
-    if (node?.type === 'wall' && node.id !== excludeWallId) out.push(node as WallNode)
+    if (
+      node?.type === 'wall' &&
+      node.id !== excludeWallId &&
+      (node.parentId ?? null) === parentId
+    ) {
+      out.push(node as WallNode)
+    }
   }
   return out
 }
@@ -70,6 +83,7 @@ function collectLevelWalls(
 function collectLinkedWalls(
   nodes: Record<AnyNodeId, AnyNode>,
   draggedWallId: AnyNodeId,
+  parentId: AnyNodeId | null,
   originalStart: WallPlanPoint,
   originalEnd: WallPlanPoint,
 ): Array<{ id: AnyNodeId; start: WallPlanPoint; end: WallPlanPoint }> {
@@ -77,6 +91,7 @@ function collectLinkedWalls(
   for (const node of Object.values(nodes)) {
     if (node?.type !== 'wall') continue
     if (node.id === draggedWallId) continue
+    if ((node.parentId ?? null) !== parentId) continue
     const wall = node as WallNode
     if (
       pointsEqual(wall.start, originalStart) ||
@@ -131,9 +146,18 @@ export const wallCurveAffordance: FloorplanAffordance<WallNode> = {
           (y - chord.midpoint.y) * chord.normal.y
         )
         const snappedOffset = snapScalarToGrid(offsetFromMidpoint, snapStep)
-        const nextCurveOffset = normalizeWallCurveOffset(
+        const requestedCurveOffset = normalizeWallCurveOffset(
           node,
           Math.max(-maxOffset, Math.min(maxOffset, snappedOffset)),
+        )
+        const sceneNodes = useScene.getState().nodes
+        const nextCurveOffset = constrainWallCurveOffsetToAvoidIntersections(
+          node,
+          requestedCurveOffset,
+          Object.values(sceneNodes).filter(
+            (candidate): candidate is WallNode =>
+              candidate.type === 'wall' && candidate.parentId === node.parentId,
+          ),
         )
         lastCurveOffset = nextCurveOffset
 
@@ -160,6 +184,41 @@ export const wallCurveAffordance: FloorplanAffordance<WallNode> = {
   },
 }
 
+export const wallThicknessAffordance: FloorplanAffordance<WallNode> = {
+  start({ node, payload, initialPlanPoint }): FloorplanAffordanceSession {
+    const { side } = payload as WallThicknessPayload
+    const frame = getWallCurveFrameAt(node, 0.5)
+    const outwardX = frame.normal.x * side
+    const outwardY = frame.normal.y * side
+    const initialThickness = getWallThickness(node)
+    const wallId = node.id as AnyNodeId
+    let lastThickness = initialThickness
+
+    return {
+      affectedIds: [wallId],
+      apply({ planPoint }) {
+        const outwardDelta =
+          (planPoint[0] - initialPlanPoint[0]) * outwardX +
+          (planPoint[1] - initialPlanPoint[1]) * outwardY
+        const rawThickness = initialThickness + outwardDelta * 2
+        lastThickness = Math.max(
+          MIN_WALL_THICKNESS,
+          snapScalarToGrid(rawThickness, getSegmentGridStep()),
+        )
+        useLiveNodeOverrides.getState().set(wallId, { thickness: lastThickness })
+        useScene.getState().markDirty(wallId)
+      },
+      canCommit() {
+        return true
+      },
+      commit() {
+        useScene.getState().updateNodes([{ id: wallId, data: { thickness: lastThickness } }])
+        useLiveNodeOverrides.getState().clear(wallId)
+      },
+    }
+  },
+}
+
 export const wallMoveEndpointAffordance: FloorplanAffordance<WallNode> = {
   start({ node, payload, nodes }): FloorplanAffordanceSession {
     const { endpoint } = payload as WallEndpointPayload
@@ -167,7 +226,8 @@ export const wallMoveEndpointAffordance: FloorplanAffordance<WallNode> = {
       endpoint === 'start' ? ([...node.end] as WallPlanPoint) : ([...node.start] as WallPlanPoint)
     const originalStart: WallPlanPoint = [...node.start] as WallPlanPoint
     const originalEnd: WallPlanPoint = [...node.end] as WallPlanPoint
-    const linkedWalls = collectLinkedWalls(nodes, node.id, originalStart, originalEnd)
+    const parentId = (node.parentId ?? null) as AnyNodeId | null
+    const linkedWalls = collectLinkedWalls(nodes, node.id, parentId, originalStart, originalEnd)
     const affectedIds: AnyNodeId[] = [node.id, ...linkedWalls.map((w) => w.id)]
     const movingOriginal: WallPlanPoint = endpoint === 'start' ? originalStart : originalEnd
     // Walls attached to the MOVING corner cascade with the drag, but the snap
@@ -197,7 +257,7 @@ export const wallMoveEndpointAffordance: FloorplanAffordance<WallNode> = {
         // the moving corner are excluded (stale coordinates); under
         // Alt-detach they stay put, so they rejoin the candidate pool.
         const sceneNodes = useScene.getState().nodes
-        const walls = collectLevelWalls(sceneNodes, node.id)
+        const walls = collectLevelWalls(sceneNodes, parentId, node.id)
         const staleWallIds = modifiers.altKey ? [node.id] : [node.id, ...movingLinkedWallIds]
         // The grid step follows the active snapping mode (`getSegmentGridStep()`
         // is 0 outside grid mode), so `'lines' / 'angles' / 'off'` no longer
@@ -227,6 +287,7 @@ export const wallMoveEndpointAffordance: FloorplanAffordance<WallNode> = {
           applySnap: isMagneticSnapActive(),
           bypass: !isAlignmentGuideActive(),
           excludeIds: staleWallIds,
+          levelId: parentId,
         }) as WallPlanPoint
 
         const primaryStart: WallPlanPoint = endpoint === 'start' ? aligned : fixedPoint

--- a/packages/nodes/src/wall/floorplan-move.test.ts
+++ b/packages/nodes/src/wall/floorplan-move.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, expect, test } from 'bun:test'
+import {
+  CeilingNode,
+  LevelNode,
+  SlabNode,
+  useLiveNodeOverrides,
+  useScene,
+  WallNode,
+} from '@pascal-app/core'
+import { wallFloorplanMoveTarget } from './floorplan-move'
+
+const square = [
+  [0, 0],
+  [4, 0],
+  [4, 4],
+  [0, 4],
+] as [number, number][]
+
+afterEach(() => {
+  useLiveNodeOverrides.getState().clearAll()
+})
+
+test('whole-wall floorplan move previews and commits automatic slab and ceiling polygons', () => {
+  const level = LevelNode.parse({
+    id: 'level_move-preview',
+    level: 0,
+    height: 3,
+    children: [],
+  })
+  const walls = [
+    WallNode.parse({
+      id: 'wall_move-bottom',
+      parentId: level.id,
+      start: [0, 0],
+      end: [4, 0],
+    }),
+    WallNode.parse({
+      id: 'wall_move-right',
+      parentId: level.id,
+      start: [4, 0],
+      end: [4, 4],
+    }),
+    WallNode.parse({
+      id: 'wall_move-top',
+      parentId: level.id,
+      start: [4, 4],
+      end: [0, 4],
+    }),
+    WallNode.parse({
+      id: 'wall_move-left',
+      parentId: level.id,
+      start: [0, 4],
+      end: [0, 0],
+    }),
+  ]
+  const slab = SlabNode.parse({
+    id: 'slab_move-preview',
+    parentId: level.id,
+    polygon: square,
+    autoFromWalls: true,
+  })
+  const ceiling = CeilingNode.parse({
+    id: 'ceiling_move-preview',
+    parentId: level.id,
+    polygon: square,
+    autoFromWalls: true,
+  })
+  const nodes = Object.fromEntries(
+    [level, ...walls, slab, ceiling].map((entry) => [entry.id, entry]),
+  )
+  useScene.setState({ nodes } as never)
+
+  const session = wallFloorplanMoveTarget({
+    node: walls[0]!,
+    nodes: useScene.getState().nodes,
+    sceneApi: {} as never,
+  })
+  const modifiers = {
+    shiftKey: false,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+  }
+  session.apply({ planPoint: [2, 0], modifiers })
+  session.apply({ planPoint: [2, 1], modifiers })
+
+  const slabPreview = useLiveNodeOverrides.getState().get(slab.id)?.polygon
+  const ceilingPreview = useLiveNodeOverrides.getState().get(ceiling.id)?.polygon
+  expect(slabPreview).toBeArray()
+  expect(ceilingPreview).toEqual(slabPreview)
+  expect(slabPreview).not.toEqual(square)
+
+  session.commit?.()
+
+  expect((useScene.getState().nodes[slab.id] as typeof slab).polygon).toEqual(slabPreview)
+  expect((useScene.getState().nodes[ceiling.id] as typeof ceiling).polygon).toEqual(ceilingPreview)
+  expect(useLiveNodeOverrides.getState().get(slab.id)).toBeUndefined()
+  expect(useLiveNodeOverrides.getState().get(ceiling.id)).toBeUndefined()
+})

--- a/packages/nodes/src/wall/floorplan-move.ts
+++ b/packages/nodes/src/wall/floorplan-move.ts
@@ -1,11 +1,21 @@
 import {
   type AnyNode,
   type AnyNodeId,
+  type AutoCeilingSyncPlan,
+  type AutoSlabSyncPlan,
+  type CeilingNode,
+  detectSpacesForLevel,
   type FloorplanMoveTarget,
   type FloorplanMoveTargetSession,
+  getCeilingClampBound,
   getPerpendicularWallMoveAxis,
   getPlannedLinkedWallUpdates,
+  getStoredLevelHeight,
+  type LevelNode,
+  planAutoCeilingsForLevel,
+  planAutoSlabsForLevel,
   planWallMoveJunctions,
+  type SlabNode,
   useLiveNodeOverrides,
   useScene,
   type WallNode,
@@ -28,6 +38,24 @@ import {
   type LinkedWallSnapshot,
   stripWallIsNewMetadata,
 } from './move-shared'
+
+function getLevelSlabs(levelId: string, nodes: ReturnType<typeof useScene.getState>['nodes']) {
+  return Object.values(nodes).filter(
+    (entry): entry is SlabNode => entry?.type === 'slab' && (entry.parentId ?? null) === levelId,
+  )
+}
+
+function getLevelCeilings(levelId: string, nodes: ReturnType<typeof useScene.getState>['nodes']) {
+  return Object.values(nodes).filter(
+    (entry): entry is CeilingNode =>
+      entry?.type === 'ceiling' && (entry.parentId ?? null) === levelId,
+  )
+}
+
+type WallMoveSurfacePlans = {
+  slabs: AutoSlabSyncPlan
+  ceilings: AutoCeilingSyncPlan
+}
 
 /**
  * 2D floor-plan move handler for wall.
@@ -53,10 +81,9 @@ import {
  * overrides after the write lands so the system reads from the new
  * committed scene state.
  *
- * Auto-slab live preview and ghost bridge SVG previews — visible in
- * the 3D tool — are deliberately deferred. Slab polygons re-derive on
- * commit through the normal scene reactions; bridges appear at commit
- * time. Follow-up work to surface them mid-drag is tracked separately.
+ * Existing automatic slabs and ceilings receive live polygon overrides during
+ * the drag. New surfaces and removals stay deferred until commit because live
+ * overrides cannot represent nodes that do not exist in the scene.
  */
 export const wallFloorplanMoveTarget: FloorplanMoveTarget<WallNode> = ({ node }) => {
   const wallId = node.id as AnyNodeId
@@ -101,9 +128,83 @@ export const wallFloorplanMoveTarget: FloorplanMoveTarget<WallNode> = ({ node })
   let lastDelta: WallPlanPoint = [0, 0]
   let lastNextStart: WallPlanPoint = originalStart
   let lastNextEnd: WallPlanPoint = originalEnd
+  const levelId = node.parentId ?? null
+  const affectedIds: AnyNodeId[] = [wallId, ...linkedOriginals.map((wall) => wall.id as AnyNodeId)]
+  const affectedIdSet = new Set(affectedIds)
+  const touchedSurfaceIds = new Set<AnyNodeId>()
+  let latestSurfacePlans: WallMoveSurfacePlans | null = null
+
+  const planSurfaces = (walls: WallNode[]): WallMoveSurfacePlans | null => {
+    if (!levelId) return null
+    const sceneState = useScene.getState()
+    const levelWalls = walls.filter((wall) => (wall.parentId ?? null) === levelId)
+    const { roomPolygons } = detectSpacesForLevel(levelId, levelWalls)
+    const slabs = planAutoSlabsForLevel(roomPolygons, getLevelSlabs(levelId, sceneState.nodes))
+    const levelNode = sceneState.nodes[levelId as AnyNodeId]
+    const ceilings = planAutoCeilingsForLevel(
+      roomPolygons,
+      getLevelCeilings(levelId, sceneState.nodes),
+      {
+        storeyHeight:
+          levelNode?.type === 'level' ? getStoredLevelHeight(levelNode as LevelNode) : undefined,
+        ceilingClampBound: (polygon) => getCeilingClampBound(levelId, sceneState.nodes, polygon),
+      },
+    )
+    return { slabs, ceilings }
+  }
+
+  const publishSurfacePreviews = (walls: WallNode[]) => {
+    const plans = planSurfaces(walls)
+    latestSurfacePlans = plans
+    if (!plans) return
+
+    const entries: Array<[AnyNodeId, Record<string, unknown>]> = []
+    for (const update of plans.slabs.update) {
+      if (update.data.polygon !== undefined) {
+        entries.push([update.id as AnyNodeId, { polygon: update.data.polygon }])
+      }
+    }
+    for (const update of plans.ceilings.update) {
+      if (update.data.polygon !== undefined || update.data.height !== undefined) {
+        entries.push([update.id as AnyNodeId, update.data as Record<string, unknown>])
+      }
+    }
+
+    const nextIds = new Set(entries.map(([id]) => id))
+    const overrides = useLiveNodeOverrides.getState()
+    const sceneState = useScene.getState()
+    for (const id of touchedSurfaceIds) {
+      if (nextIds.has(id)) continue
+      overrides.clear(id)
+      sceneState.markDirty(id)
+      touchedSurfaceIds.delete(id)
+    }
+    if (entries.length > 0) {
+      overrides.setMany(entries)
+      for (const [id] of entries) {
+        touchedSurfaceIds.add(id)
+        if (!affectedIdSet.has(id)) {
+          affectedIdSet.add(id)
+          affectedIds.push(id)
+        }
+        sceneState.markDirty(id)
+      }
+    }
+  }
+
+  const clearSurfacePreviews = () => {
+    const overrides = useLiveNodeOverrides.getState()
+    const sceneState = useScene.getState()
+    for (const id of touchedSurfaceIds) {
+      overrides.clear(id)
+      sceneState.markDirty(id)
+    }
+    touchedSurfaceIds.clear()
+    latestSurfacePlans = null
+  }
 
   const session: FloorplanMoveTargetSession = {
-    affectedIds: [wallId, ...linkedOriginals.map((w) => w.id as AnyNodeId)],
+    affectedIds,
 
     apply({ planPoint }) {
       if (!rawAnchor) {
@@ -221,6 +322,7 @@ export const wallFloorplanMoveTarget: FloorplanMoveTarget<WallNode> = ({ node })
         thickness: getFloorplanWallThickness(wall),
       }))
       useWallMoveGhosts.getState().setBridges(ghostBridges)
+      publishSurfacePreviews([...previewSceneWalls, ...bridgePreviews.map(({ wall }) => wall)])
 
       // `WallSystem` only runs its rebuild pass when `dirtyNodes` is
       // non-empty. We're not writing to scene any more, but we still
@@ -249,6 +351,7 @@ export const wallFloorplanMoveTarget: FloorplanMoveTarget<WallNode> = ({ node })
         const overrides = useLiveNodeOverrides.getState()
         overrides.clear(wallId)
         for (const wall of linkedOriginals) overrides.clear(wall.id as AnyNodeId)
+        clearSurfacePreviews()
         return
       }
 
@@ -305,10 +408,51 @@ export const wallFloorplanMoveTarget: FloorplanMoveTarget<WallNode> = ({ node })
         wallCount: Object.values(sceneState.nodes).filter((entry) => entry?.type === 'wall').length,
       })
 
+      const finalWalls = [
+        ...existingWalls,
+        ...bridgeCreates.map(
+          (entry) => ({ ...entry.node, parentId: entry.parentId ?? null }) as WallNode,
+        ),
+      ]
+      const surfacePlans = planSurfaces(finalWalls) ?? latestSurfacePlans
+      const surfaceUpdates = surfacePlans
+        ? [
+            ...surfacePlans.slabs.update.map((entry) => ({
+              id: entry.id as AnyNodeId,
+              data: entry.data as Partial<AnyNode>,
+            })),
+            ...surfacePlans.ceilings.update.map((entry) => ({
+              id: entry.id as AnyNodeId,
+              data: entry.data as Partial<AnyNode>,
+            })),
+          ]
+        : []
+      const surfaceCreates = surfacePlans
+        ? [
+            ...surfacePlans.slabs.create.map((slab) => ({
+              node: slab,
+              parentId: levelId as AnyNodeId,
+            })),
+            ...surfacePlans.ceilings.create.map((ceiling) => ({
+              node: ceiling,
+              parentId: levelId as AnyNodeId,
+            })),
+          ]
+        : []
+      const surfaceDeletes = surfacePlans
+        ? [
+            ...surfacePlans.slabs.delete.map((id) => id as AnyNodeId),
+            ...surfacePlans.ceilings.delete.map((id) => id as AnyNodeId),
+          ]
+        : []
+
       sceneState.applyNodeChanges({
-        update: commitUpdates as Array<{ id: AnyNodeId; data: Partial<AnyNode> }>,
-        create: bridgeCreates,
-        delete: Array.from(collapsedLinkedWallIds),
+        update: [
+          ...(commitUpdates as Array<{ id: AnyNodeId; data: Partial<AnyNode> }>),
+          ...surfaceUpdates,
+        ],
+        create: [...bridgeCreates, ...surfaceCreates],
+        delete: Array.from(new Set([...collapsedLinkedWallIds, ...surfaceDeletes])),
       })
 
       // Drop the live overrides now that the committed scene state
@@ -319,6 +463,7 @@ export const wallFloorplanMoveTarget: FloorplanMoveTarget<WallNode> = ({ node })
       const overrides = useLiveNodeOverrides.getState()
       overrides.clear(wallId)
       for (const wall of linkedOriginals) overrides.clear(wall.id as AnyNodeId)
+      clearSurfacePreviews()
 
       // Swap ghosts → real walls: the bridges we just created render
       // through the registry layer, so the dashed previews aren't

--- a/packages/nodes/src/wall/floorplan.test.ts
+++ b/packages/nodes/src/wall/floorplan.test.ts
@@ -226,4 +226,21 @@ describe('buildWallFloorplan render purpose', () => {
     expect(arrows[1].point[0]).toBeCloseTo(2)
     expect(arrows[1].point[1]).toBeCloseTo(-1.115)
   })
+
+  test('places thickness handles on both visible faces of a curved wall', () => {
+    const curved = WallNode.parse({ ...wall, curveOffset: 1 })
+    const geometry = buildWallFloorplan(curved, context('edit', true))
+    const handles = geometry
+      ? flatten(geometry).filter(
+          (entry) => entry.kind === 'endpoint-handle' && entry.affordance === 'thickness',
+        )
+      : []
+
+    expect(handles).toHaveLength(2)
+    if (handles[0]?.kind !== 'endpoint-handle' || handles[1]?.kind !== 'endpoint-handle') return
+    expect(handles[0].point[0]).toBeCloseTo(2)
+    expect(handles[0].point[1]).toBeCloseTo(-0.935)
+    expect(handles[1].point[0]).toBeCloseTo(2)
+    expect(handles[1].point[1]).toBeCloseTo(-1.065)
+  })
 })

--- a/packages/nodes/src/wall/floorplan.ts
+++ b/packages/nodes/src/wall/floorplan.ts
@@ -22,6 +22,7 @@ import {
   renderPlannedConstructionDimensions,
   type WallConstructionDimensionPlan,
 } from './construction-dimensions'
+import { hasWallCurveBlockingChildren } from './curve-eligibility'
 
 // Same constants the legacy `getFloorplanWall` uses (editor/lib/floorplan/walls.ts).
 // Slightly exaggerates thin walls so the 2D plan stays legible without
@@ -266,6 +267,21 @@ export function buildWallFloorplan(node: WallNode, ctx: GeometryContext): Floorp
       payload: { wallId: node.id, endpoint: 'end' as const },
     })
 
+    const thicknessFrame = getWallCurveFrameAt(self, 0.5)
+    const halfVisibleThickness = getWallThickness(self) / 2
+    for (const side of [1, -1] as const) {
+      children.push({
+        kind: 'endpoint-handle',
+        point: [
+          thicknessFrame.point.x + thicknessFrame.normal.x * halfVisibleThickness * side,
+          thicknessFrame.point.y + thicknessFrame.normal.y * halfVisibleThickness * side,
+        ],
+        state: 'idle',
+        affordance: 'thickness',
+        payload: { wallId: node.id, side },
+      })
+    }
+
     // Side move arrows — two directional arrows at the wall midpoint,
     // pointing outward perpendicular to the wall. Mirrors the 3D
     // `WallMoveSideHandles` arrows so users can grab the wall body
@@ -294,11 +310,10 @@ export function buildWallFloorplan(node: WallNode, ctx: GeometryContext): Floorp
     }
 
     // Curve sagitta handle — teal dot at the wall midpoint that
-    // controls `curveOffset`. Hidden when the wall hosts a door /
-    // window / wall-attached item: bending the wall would tear those
-    // children, so the legacy disables the handle in that case (see
-    // `wallCurveHandles.hasWallChildrenBlockingCurve`).
-    if (!hasCurveBlockingChildren(ctx.children)) {
+    // controls `curveOffset`. Hidden when the wall hosts an opening,
+    // lean-to extension, or wall-attached item because bending the host
+    // would tear the child geometry away from it.
+    if (!hasWallCurveBlockingChildren(ctx.children)) {
       const handle = getWallMidpointHandlePoint(node)
       children.push({
         kind: 'endpoint-handle',
@@ -352,21 +367,4 @@ function wallDimensionDatumPolicy(reference: WallDimensionReference) {
     case 'finished-faces':
       return 'wall-face' as const
   }
-}
-
-/**
- * Doors, windows, and wall-attached items would tear if the wall bent
- * around them, so the curve sagitta handle hides when any of those
- * children exist. Mirrors the legacy
- * `wallCurveHandles.hasWallChildrenBlockingCurve` check.
- */
-function hasCurveBlockingChildren(children: AnyNode[]): boolean {
-  for (const child of children) {
-    if (child.type === 'door' || child.type === 'window') return true
-    if (child.type === 'item') {
-      const attachTo = (child as { asset?: { attachTo?: string } }).asset?.attachTo
-      if (attachTo === 'wall' || attachTo === 'wall-side') return true
-    }
-  }
-  return false
 }

--- a/packages/nodes/src/wall/move-shared.test.ts
+++ b/packages/nodes/src/wall/move-shared.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'bun:test'
+import { type WallMoveBridgePlan, WallNode } from '@pascal-app/core'
+import { buildBridgeWallCreates, type LinkedWallSnapshot } from './move-shared'
+
+test('bridge duplicate detection ignores identical wall segments on other levels', () => {
+  const source = WallNode.parse({
+    id: 'wall_source',
+    parentId: 'level_lower',
+    start: [0, 0],
+    end: [4, 0],
+  })
+  const stackedWall = WallNode.parse({
+    id: 'wall_stacked',
+    parentId: 'level_upper',
+    start: [0, 0],
+    end: [0, 1],
+  })
+  const bridgePlans: Array<WallMoveBridgePlan<LinkedWallSnapshot>> = [
+    {
+      wall: source,
+      originalPoint: [0, 0],
+      movedEndpoint: 'start',
+    },
+  ]
+
+  const creates = buildBridgeWallCreates({
+    bridgePlans,
+    nextStart: [0, 1],
+    nextEnd: [4, 1],
+    existingWalls: [source, stackedWall],
+    wallCount: 2,
+  })
+
+  expect(creates).toHaveLength(1)
+  expect(creates[0]?.parentId).toBe(source.parentId)
+  expect(creates[0]?.node).toMatchObject({ start: [0, 0], end: [0, 1] })
+})

--- a/packages/nodes/src/wall/move-shared.ts
+++ b/packages/nodes/src/wall/move-shared.ts
@@ -100,14 +100,16 @@ export function getLinkedWallSnapshots(args: {
 }
 
 function wallSegmentExists(
-  walls: Array<Pick<WallNode, 'start' | 'end'>>,
+  walls: Array<Pick<WallNode, 'start' | 'end' | 'parentId'>>,
   start: WallPlanPoint,
   end: WallPlanPoint,
+  parentId: WallNode['parentId'],
 ) {
   return walls.some(
     (wall) =>
-      (samePoint(wall.start, start) && samePoint(wall.end, end)) ||
-      (samePoint(wall.start, end) && samePoint(wall.end, start)),
+      wall.parentId === parentId &&
+      ((samePoint(wall.start, start) && samePoint(wall.end, end)) ||
+        (samePoint(wall.start, end) && samePoint(wall.end, start))),
   )
 }
 
@@ -174,7 +176,9 @@ export function buildBridgeWallCreates(args: {
       continue
     }
 
-    if (wallSegmentExists(wallsForDuplicateCheck, plan.originalPoint, nextPoint)) {
+    if (
+      wallSegmentExists(wallsForDuplicateCheck, plan.originalPoint, nextPoint, plan.wall.parentId)
+    ) {
       continue
     }
 
@@ -192,7 +196,7 @@ export function buildBridgeWallCreates(args: {
       node: bridgeWall,
       parentId: (plan.wall.parentId ?? undefined) as AnyNodeId | undefined,
     })
-    wallsForDuplicateCheck.push(bridgeWall)
+    wallsForDuplicateCheck.push({ ...bridgeWall, parentId: plan.wall.parentId })
   }
 
   return creates
@@ -213,7 +217,9 @@ export function buildBridgeWallPreviews(args: {
   existingWalls: WallNode[]
 }): Array<{ ghost: GhostWallPreview; wall: WallNode }> {
   const { bridgePlans, nextStart, nextEnd, existingWalls } = args
-  const wallsForDuplicateCheck: Array<Pick<WallNode, 'start' | 'end'>> = [...existingWalls]
+  const wallsForDuplicateCheck: Array<Pick<WallNode, 'start' | 'end' | 'parentId'>> = [
+    ...existingWalls,
+  ]
   const previews: Array<{ ghost: GhostWallPreview; wall: WallNode }> = []
 
   for (const plan of bridgePlans) {
@@ -223,7 +229,9 @@ export function buildBridgeWallPreviews(args: {
       continue
     }
 
-    if (wallSegmentExists(wallsForDuplicateCheck, plan.originalPoint, nextPoint)) {
+    if (
+      wallSegmentExists(wallsForDuplicateCheck, plan.originalPoint, nextPoint, plan.wall.parentId)
+    ) {
       continue
     }
 

--- a/packages/nodes/src/wall/panel.tsx
+++ b/packages/nodes/src/wall/panel.tsx
@@ -39,6 +39,7 @@ import { useViewer } from '@pascal-app/viewer'
 import { Spline } from 'lucide-react'
 import { useCallback, useMemo, useRef } from 'react'
 import { resolveWallOpeningCeiling } from '../shared/wall-opening-ceiling'
+import { hasWallCurveBlockingChildren } from './curve-eligibility'
 
 /**
  * Base half of the plane-bound repair: a stamped draft offset goes, and a
@@ -111,19 +112,15 @@ export default function WallPanel() {
   }, [sceneNode, liveOverride])
 
   // Boolean selector — re-renders only when this specific wall's child
-  // composition crosses the "has a door/window/wall-item" threshold.
+  // composition crosses the "has an incompatible hosted child" threshold.
   const hasWallChildrenBlockingCurve = useScene((s) => {
     if (!node) return false
-    return (node.children ?? []).some((childId) => {
-      const child = s.nodes[childId as AnyNodeId]
-      if (!child) return false
-      if (child.type === 'door' || child.type === 'window') return true
-      if (child.type === 'item') {
-        const attachTo = child.asset?.attachTo
-        return attachTo === 'wall' || attachTo === 'wall-side'
-      }
-      return false
-    })
+    return hasWallCurveBlockingChildren(
+      (node.children ?? []).flatMap((childId) => {
+        const child = s.nodes[childId as AnyNodeId]
+        return child ? [child] : []
+      }),
+    )
   })
 
   // Existing plane-bound walls have no stored height. Resolve their current


### PR DESCRIPTION
## What does this PR do?

- **Curved triangular rooms**
  - Issue: Slabs and ceilings kept a straight corner after curving a wall.
  - Fixed: Both surfaces now rebuild from the curved room boundary.

- **Wall curve collisions**
  - Issue: An inward curve could cross nearby walls in a small room.
  - Fixed: The curve now stops before it intersects another wall.
  - Square rooms keep the full curve when there is enough clearance.

- **Wall height feedback**
  - Issue: The measurement pill disappeared while changing wall height.
  - Fixed: The H, L, and T values now stay visible during the drag.

- **Wall and fence thickness**
  - Issue: Thickness could only be changed from the settings panel.
  - Fixed: Each face now has a circular thickness handle in 2D and 3D.
  - The centerline stays fixed, and the change uses one undo step.

- **Floor-plan wall movement**
  - Issue: Automatic slabs and ceilings did not preview while moving a wall.
  - Fixed: Their new polygons now appear during the drag and commit with the wall.

- **Walls on different levels**
  - Issue: Matching coordinates could connect or align walls from another level.
  - Fixed: Wall connections, alignment targets, and bridge checks now stay on the active level.

- **Wall curve eligibility**
  - Issue: Walls hosting a lean-to extension could still be curved.
  - Fixed: Hosted openings, lean-to extensions, and wall-attached items now block curving.

- **Roof creation default**
  - Issue: The standard roof tool started with Room selected.
  - Fixed: Standard roofs now start in Draw mode.

- **Duplicate Auto gutters**
  - Issue: The roof segment panel showed Auto gutters twice.
  - Fixed: The duplicate drainage control was removed.

- **Roof accessory painting**
  - Issue: Gutters and roof accessories used unclear or incorrect paint slots.
  - Fixed: Gutters now use a dedicated `gutter` slot, and louvers use their own metallic slots.

- **OpenPR2 descriptions**
  - Issue: The existing PR helper produced descriptions that were too short or too dense.
  - Fixed: OpenPR2 now uses short issue-and-fix entries and records verification clearly.

## How to test

1. Create a triangular room and curve one wall inward.
   - The slab and ceiling should follow the curve.
   - The curve should stop before crossing another wall.

2. Create a square room and curve one wall.
   - The full curve should remain available when there is enough space.

3. Drag the wall height handle.
   - The H, L, and T measurement pill should remain visible and update.

4. Drag either thickness handle on a straight and curved wall.
   - The wall should resize around its fixed centerline.
   - One undo should restore the previous thickness.

5. Repeat the thickness test with a fence in 2D and 3D.
   - Both face handles should follow the fence shape and elevation.

6. Move a wall in the floor plan.
   - Automatic slabs and ceilings should preview their new shapes before release.

7. Select the standard roof tool.
   - Draw should be selected by default.

8. Open the roof segment panel.
   - Auto gutters should appear once.

9. Paint a gutter, cupola louver, and eyebrow vent.
   - Only the selected construction part should change.

10. Invoke `/open-pr2` on a feature branch.
    - The PR body should use short Issue and Fixed sub-lines for each change.

Automated checks:

- Focused tests: 202 passed, 0 failed.
- `bun run check`: passed.
- `bun run check-types`: passed.
- `bun run build`: passed.

## Screenshots / screen recording

Not added yet.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide changes to wall topology, scene updates, and paint-slot migrations affect core editing and saved scenes; coverage is strong in tests but regression risk spans 2D/3D interaction and roof workflows.
> 
> **Overview**
> This PR tightens **wall and fence editing** in 2D and 3D: inward wall curves are **clamped** so they do not cross sibling walls on the same level (slabs and ceilings stay valid in tight triangular rooms), while **face thickness handles** let you resize around a fixed centerline with live measurement feedback. **Floor-plan wall moves** now **preview and commit** automatic slab and ceiling polygons; **endpoint linking, alignment, and bridge-wall logic** no longer treat matching coordinates on **other levels** as the same wall.
> 
> **Editor UX** keeps the floating action menu’s **measurement pill visible during wall height drags** while hiding action buttons, and **lean-to extensions** (with doors, windows, and wall-attached items) **block curving** consistently across panel, floor plan, and tools. Wall curve previews use **live overrides** instead of mutating the scene every frame.
> 
> **Roof tooling** defaults standard roofs to **Draw** footprint mode (order **Draw** then **Room**), removes a **duplicate Auto gutters** control from the roof segment panel, and adjusts footprint parsing so unknown sources fall back to **Draw** instead of **Room**.
> 
> **Roof accessory painting** adds a dedicated **`gutter` slot** (with migration from legacy `surface`), a separate **metallic `louvers` slot** on cupolas (geometry group split), and renames eyebrow vent **front** to **Louvers** in the inspector. Scene load migrates renamed gutter slots and seeds cupola louvers from body when missing.
> 
> Also adds the **OpenPR2** agent skill for opening/updating PRs with structured issue/fix bodies on `pascalorg/editor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae4affd087407bd02e740796f37a74d7ae010bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->