### PR TITLE
editor: capture-mode camera suite — FOV lens, walk/drone framing, keycap hints

### DIFF
--- a/packages/editor/src/components/editor/capture-camera-rig.tsx
+++ b/packages/editor/src/components/editor/capture-camera-rig.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useThree } from '@react-three/fiber'
+import { useEffect, useRef } from 'react'
+import type { PerspectiveCamera } from 'three'
+import useEditor from '../../store/use-editor'
+
+/**
+ * Owns the main camera's field of view while the snapshot capture overlay is
+ * open, and is mounted only for that window. `ThumbnailGenerator` copies the
+ * main camera's fov on every shot, so the value written here is what lands in
+ * the saved image.
+ *
+ * The overlay's slider cannot reach the camera itself (it renders outside the
+ * canvas), so the store carries the value and this rig applies it.
+ */
+export const CaptureCameraRig = () => {
+  const camera = useThree((state) => state.camera)
+  const captureFov = useEditor((state) => state.captureFov)
+  const appliedFovRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const perspectiveCamera = camera as PerspectiveCamera
+    if (!perspectiveCamera.isPerspectiveCamera) {
+      // Orthographic captures have no fov to drive — the overlay hides the
+      // control while the store is disarmed.
+      useEditor.getState().armCaptureFov(null)
+      return
+    }
+
+    const entryFov = perspectiveCamera.fov
+    useEditor.getState().armCaptureFov(entryFov)
+
+    return () => {
+      useEditor.getState().armCaptureFov(null)
+      // Walkthrough restores its own pre-entry fov when it unmounts, which can
+      // happen in the same commit as this rig (leaving capture also leaves
+      // walk/fly). Only put the entry fov back if the camera still holds our
+      // last write — otherwise someone else has already re-owned it.
+      if (appliedFovRef.current !== null && perspectiveCamera.fov === appliedFovRef.current) {
+        perspectiveCamera.fov = entryFov
+        perspectiveCamera.updateProjectionMatrix()
+      }
+      appliedFovRef.current = null
+    }
+  }, [camera])
+
+  useEffect(() => {
+    const perspectiveCamera = camera as PerspectiveCamera
+    if (!perspectiveCamera.isPerspectiveCamera || captureFov === null) return
+
+    appliedFovRef.current = captureFov
+    if (perspectiveCamera.fov === captureFov) return
+    perspectiveCamera.fov = captureFov
+    perspectiveCamera.updateProjectionMatrix()
+  }, [camera, captureFov])
+
+  return null
+}

--- a/packages/editor/src/components/editor/capture-camera-rig.tsx
+++ b/packages/editor/src/components/editor/capture-camera-rig.tsx
@@ -35,7 +35,7 @@ export const CaptureCameraRig = () => {
       useEditor.getState().armCaptureFov(null)
       // Walkthrough restores its own pre-entry fov when it unmounts, which can
       // happen in the same commit as this rig (leaving capture also leaves
-      // walk/fly). Only put the entry fov back if the camera still holds our
+      // walk/drone). Only put the entry fov back if the camera still holds our
       // last write — otherwise someone else has already re-owned it.
       if (appliedFovRef.current !== null && perspectiveCamera.fov === appliedFovRef.current) {
         perspectiveCamera.fov = entryFov

--- a/packages/editor/src/components/editor/first-person-controls.tsx
+++ b/packages/editor/src/components/editor/first-person-controls.tsx
@@ -89,11 +89,11 @@ import {
 
 const CAMERA_EYE_OFFSET = 0.45
 const LOOK_SENSITIVITY = 0.002
-// Fly mode: metres per second, and how hard Shift boosts it. The smoothing
+// Drone mode: metres per second, and how hard Shift boosts it. The smoothing
 // constant is an exponential approach rate, not a linear acceleration.
-const FLY_SPEED = 7
-const FLY_RUN_MULTIPLIER = 3
-const FLY_SMOOTHING = 12
+const DRONE_SPEED = 7
+const DRONE_RUN_MULTIPLIER = 3
+const DRONE_SMOOTHING = 12
 const CONTROLLER_CENTER_FROM_EYE = 0.85
 const DOOR_INTERACTION_DISTANCE = 2.5
 const DOOR_LEAF_INTERACTION_DEPTH = 0.08
@@ -148,10 +148,10 @@ function focusFirstPersonCanvas(canvas: HTMLCanvasElement) {
 
 const cameraOffset = new Vector3()
 const cameraEuler = new Euler(0, 0, 0, 'YXZ')
-const flyEuler = new Euler(0, 0, 0, 'YXZ')
-const flyForward = new Vector3()
-const flyRight = new Vector3()
-const flyDesiredVelocity = new Vector3()
+const droneEuler = new Euler(0, 0, 0, 'YXZ')
+const droneForward = new Vector3()
+const droneRight = new Vector3()
+const droneDesiredVelocity = new Vector3()
 const standClearanceRaycaster = new Raycaster()
 const standClearanceUp = new Vector3(0, 1, 0)
 const centerScreenPoint = new Vector2(0, 0)
@@ -662,7 +662,7 @@ export const FirstPersonControls = () => {
   const { camera, gl } = useThree()
   const selectedLevelId = useViewer((state) => state.selection.levelId)
   const placedSpawnNode = useScene((state) => resolvePlacedSpawnNode(state.nodes, selectedLevelId))
-  const isFlyMode = useEditor((state) => state.firstPersonMovementMode === 'fly')
+  const isDroneMode = useEditor((state) => state.firstPersonMovementMode === 'drone')
   const controllerRef = useRef<BVHEcctrlApi | null>(null)
   const movementInputRef = useRef<MovementInput>({ ...inactiveMovementInput })
   const hadPointerLockRef = useRef(false)
@@ -671,8 +671,9 @@ export const FirstPersonControls = () => {
   const interactableTargetRef = useRef<FirstPersonInteractableTarget | null>(null)
   const hudLabelFrameRef = useRef(HUD_LABEL_SAMPLE_FRAMES - 1)
   const crouchKeyRef = useRef(false)
-  const flyDescendKeyRef = useRef(false)
-  const flyVelocityRef = useRef(new Vector3())
+  const droneAscendKeyRef = useRef(false)
+  const droneDescendKeyRef = useRef(false)
+  const droneVelocityRef = useRef(new Vector3())
   const suspendRef = useRef(false)
   const eyeOffsetRef = useRef(CAMERA_EYE_OFFSET)
   const [crouched, setCrouched] = useState(false)
@@ -949,9 +950,9 @@ export const FirstPersonControls = () => {
   }, [resolveInteractableDoorId, resolveInteractableElevatorTarget, resolveInteractableWindowId])
 
   const toggleInteractableTarget = useCallback(() => {
-    // Fly is a camera, not an avatar: the click that re-acquires pointer lock
+    // Drone is a camera, not an avatar: the click that re-acquires pointer lock
     // must not swing a door open under the shot being framed.
-    if (isFlyMode) return
+    if (isDroneMode) return
 
     const target = interactableTargetRef.current ?? resolveInteractableTarget()
     if (!target) return
@@ -1006,10 +1007,10 @@ export const FirstPersonControls = () => {
     if (node?.type !== 'door' || node.openingKind === 'opening') return
 
     toggleDoorOpenState(doorId, { persist: false })
-  }, [isFlyMode, resolveInteractableTarget])
+  }, [isDroneMode, resolveInteractableTarget])
 
   const closeInteractableTarget = useCallback(() => {
-    if (isFlyMode) return
+    if (isDroneMode) return
 
     const target = interactableTargetRef.current ?? resolveInteractableTarget()
     if (!target) return
@@ -1034,7 +1035,7 @@ export const FirstPersonControls = () => {
     if (node?.type !== 'door' || node.openingKind === 'opening') return
 
     closeDoorOpenState(target.id, { persist: false })
-  }, [isFlyMode, resolveInteractableTarget])
+  }, [isDroneMode, resolveInteractableTarget])
 
   const placedSpawn = useMemo<FirstPersonSpawn | null>(() => {
     if (!(placedSpawnNode && placedSpawnNode.type === 'spawn')) return null
@@ -1066,10 +1067,10 @@ export const FirstPersonControls = () => {
   }, [placedSpawnNode])
 
   useEffect(() => {
-    // Fly has no gravity, no floor and no collision, so the BVH collider world
+    // Drone has no gravity, no floor and no collision, so the BVH collider world
     // (a full-scene traversal, rebuilt on every door/window animation) is pure
     // cost there. Switching modes disposes it and rebuilds on the way back.
-    if (!isFlyMode) rebuildColliderWorld()
+    if (!isDroneMode) rebuildColliderWorld()
 
     return () => {
       worldRef.current?.dispose()
@@ -1079,31 +1080,31 @@ export const FirstPersonControls = () => {
       setElevatorColliderMeshes([])
       setWorld(null)
     }
-  }, [isFlyMode, rebuildColliderWorld])
+  }, [isDroneMode, rebuildColliderWorld])
 
   useEffect(() => {
-    if (isFlyMode) return
+    if (isDroneMode) return
     emitter.on('door:animation-completed', rebuildColliderWorld)
     emitter.on('window:animation-completed', rebuildColliderWorld)
     return () => {
       emitter.off('door:animation-completed', rebuildColliderWorld)
       emitter.off('window:animation-completed', rebuildColliderWorld)
     }
-  }, [isFlyMode, rebuildColliderWorld])
+  }, [isDroneMode, rebuildColliderWorld])
 
-  // A walk session started before a fly detour would otherwise resume at its
+  // A walk session started before a drone detour would otherwise resume at its
   // original spawn; drop it so the next walk re-derives one.
   useEffect(() => {
-    if (isFlyMode) setControllerStart(null)
-  }, [isFlyMode])
+    if (isDroneMode) setControllerStart(null)
+  }, [isDroneMode])
 
-  // Fly picks up wherever the camera currently is — orbit pose or walk eye.
+  // Drone picks up wherever the camera currently is — orbit pose or walk eye.
   useEffect(() => {
-    if (!isFlyMode) return
-    flyEuler.setFromQuaternion(camera.quaternion)
-    yawRef.current = flyEuler.y
-    pitchRef.current = flyEuler.x
-    flyVelocityRef.current.set(0, 0, 0)
+    if (!isDroneMode) return
+    droneEuler.setFromQuaternion(camera.quaternion)
+    yawRef.current = droneEuler.y
+    pitchRef.current = droneEuler.x
+    droneVelocityRef.current.set(0, 0, 0)
 
     // Interaction prompts belong to walk; drop whatever its frame left behind.
     if (useViewer.getState().hoveredId === interactableTargetRef.current?.id) {
@@ -1111,7 +1112,7 @@ export const FirstPersonControls = () => {
     }
     interactableTargetRef.current = null
     useFirstPersonHud.getState().reset()
-  }, [camera, isFlyMode])
+  }, [camera, isDroneMode])
 
   useEffect(() => {
     if (!world) return
@@ -1245,10 +1246,14 @@ export const FirstPersonControls = () => {
         // screenshot) must not toggle it under the user.
         if (!suspendRef.current) crouchKeyRef.current = true
       } else if (event.code === 'KeyQ') {
-        // Fly descend. Space (already bound to jump) is the matching ascend.
+        // Drone descend. Space (already bound to jump) and E are the matching ascend.
         event.preventDefault()
         event.stopPropagation()
-        if (!suspendRef.current) flyDescendKeyRef.current = true
+        if (!suspendRef.current) droneDescendKeyRef.current = true
+      } else if (event.code === 'KeyE' && isDroneMode) {
+        event.preventDefault()
+        event.stopPropagation()
+        if (!suspendRef.current) droneAscendKeyRef.current = true
       } else if (event.code === 'Escape') {
         event.preventDefault()
         event.stopPropagation()
@@ -1286,7 +1291,10 @@ export const FirstPersonControls = () => {
         crouchKeyRef.current = false
       }
       if (event.code === 'KeyQ' && !suspendRef.current) {
-        flyDescendKeyRef.current = false
+        droneDescendKeyRef.current = false
+      }
+      if (event.code === 'KeyE' && !suspendRef.current) {
+        droneAscendKeyRef.current = false
       }
       applyMovementKey(event, false)
     }
@@ -1294,7 +1302,8 @@ export const FirstPersonControls = () => {
     const handleBlur = () => {
       if (!suspendRef.current) {
         crouchKeyRef.current = false
-        flyDescendKeyRef.current = false
+        droneAscendKeyRef.current = false
+        droneDescendKeyRef.current = false
       }
     }
 
@@ -1306,7 +1315,7 @@ export const FirstPersonControls = () => {
       document.removeEventListener('keyup', handleKeyUp, true)
       window.removeEventListener('blur', handleBlur)
     }
-  }, [closeInteractableTarget, gl, toggleInteractableTarget])
+  }, [closeInteractableTarget, gl, isDroneMode, toggleInteractableTarget])
 
   const syncElevatorColliderMeshes = useCallback(() => {
     const nodes = useScene.getState().nodes
@@ -1382,7 +1391,7 @@ export const FirstPersonControls = () => {
   }, [])
 
   useFrame(() => {
-    if (isFlyMode) return
+    if (isDroneMode) return
     syncElevatorColliderMeshes()
   }, -1)
 
@@ -1542,40 +1551,40 @@ export const FirstPersonControls = () => {
     return standClearanceRaycaster.intersectObjects(meshes, false).length === 0
   }, [])
 
-  // Fly: a free camera driven straight from the look angles — no controller, no
-  // gravity, no collision clamping. WASD move along the view axes, Space rises,
-  // Q (or Ctrl) sinks, Shift boosts.
+  // Drone: a free camera driven straight from the look angles — no controller,
+  // no gravity or collision clamping. WASD move along the view axes, Space or E
+  // rises, Q (or Ctrl) sinks, and Shift boosts.
   useFrame((_, delta) => {
-    if (!isFlyMode) return
+    if (!isDroneMode) return
 
     const step = Math.min(delta, 0.1)
     const movement = movementInputRef.current
 
-    flyEuler.set(pitchRef.current, yawRef.current, 0, 'YXZ')
-    camera.quaternion.setFromEuler(flyEuler)
-    flyForward.set(0, 0, -1).applyEuler(flyEuler)
-    flyRight.set(1, 0, 0).applyEuler(flyEuler)
+    droneEuler.set(pitchRef.current, yawRef.current, 0, 'YXZ')
+    camera.quaternion.setFromEuler(droneEuler)
+    droneForward.set(0, 0, -1).applyEuler(droneEuler)
+    droneRight.set(1, 0, 0).applyEuler(droneEuler)
 
-    flyDesiredVelocity.set(0, 0, 0)
-    if (movement.forward) flyDesiredVelocity.add(flyForward)
-    if (movement.backward) flyDesiredVelocity.sub(flyForward)
-    if (movement.rightward) flyDesiredVelocity.add(flyRight)
-    if (movement.leftward) flyDesiredVelocity.sub(flyRight)
-    if (movement.jump) flyDesiredVelocity.y += 1
-    if (flyDescendKeyRef.current || crouchKeyRef.current) flyDesiredVelocity.y -= 1
-    if (flyDesiredVelocity.lengthSq() > 0) {
-      flyDesiredVelocity
+    droneDesiredVelocity.set(0, 0, 0)
+    if (movement.forward) droneDesiredVelocity.add(droneForward)
+    if (movement.backward) droneDesiredVelocity.sub(droneForward)
+    if (movement.rightward) droneDesiredVelocity.add(droneRight)
+    if (movement.leftward) droneDesiredVelocity.sub(droneRight)
+    if (movement.jump || droneAscendKeyRef.current) droneDesiredVelocity.y += 1
+    if (droneDescendKeyRef.current || crouchKeyRef.current) droneDesiredVelocity.y -= 1
+    if (droneDesiredVelocity.lengthSq() > 0) {
+      droneDesiredVelocity
         .normalize()
-        .multiplyScalar(FLY_SPEED * (movement.run ? FLY_RUN_MULTIPLIER : 1))
+        .multiplyScalar(DRONE_SPEED * (movement.run ? DRONE_RUN_MULTIPLIER : 1))
     }
 
-    flyVelocityRef.current.lerp(flyDesiredVelocity, 1 - Math.exp(-step * FLY_SMOOTHING))
-    camera.position.addScaledVector(flyVelocityRef.current, step)
+    droneVelocityRef.current.lerp(droneDesiredVelocity, 1 - Math.exp(-step * DRONE_SMOOTHING))
+    camera.position.addScaledVector(droneVelocityRef.current, step)
     camera.updateMatrixWorld(true)
   }, 2.5)
 
   useFrame((_, delta) => {
-    if (isFlyMode) return
+    if (isDroneMode) return
     if (!controllerRef.current?.group) return
 
     const group = controllerRef.current.group
@@ -1657,7 +1666,7 @@ export const FirstPersonControls = () => {
     [world, elevatorColliderMeshes],
   )
 
-  if (isFlyMode || !world) {
+  if (isDroneMode || !world) {
     return null
   }
 

--- a/packages/editor/src/components/editor/first-person-controls.tsx
+++ b/packages/editor/src/components/editor/first-person-controls.tsx
@@ -89,6 +89,11 @@ import {
 
 const CAMERA_EYE_OFFSET = 0.45
 const LOOK_SENSITIVITY = 0.002
+// Fly mode: metres per second, and how hard Shift boosts it. The smoothing
+// constant is an exponential approach rate, not a linear acceleration.
+const FLY_SPEED = 7
+const FLY_RUN_MULTIPLIER = 3
+const FLY_SMOOTHING = 12
 const CONTROLLER_CENTER_FROM_EYE = 0.85
 const DOOR_INTERACTION_DISTANCE = 2.5
 const DOOR_LEAF_INTERACTION_DEPTH = 0.08
@@ -143,6 +148,10 @@ function focusFirstPersonCanvas(canvas: HTMLCanvasElement) {
 
 const cameraOffset = new Vector3()
 const cameraEuler = new Euler(0, 0, 0, 'YXZ')
+const flyEuler = new Euler(0, 0, 0, 'YXZ')
+const flyForward = new Vector3()
+const flyRight = new Vector3()
+const flyDesiredVelocity = new Vector3()
 const standClearanceRaycaster = new Raycaster()
 const standClearanceUp = new Vector3(0, 1, 0)
 const centerScreenPoint = new Vector2(0, 0)
@@ -653,6 +662,7 @@ export const FirstPersonControls = () => {
   const { camera, gl } = useThree()
   const selectedLevelId = useViewer((state) => state.selection.levelId)
   const placedSpawnNode = useScene((state) => resolvePlacedSpawnNode(state.nodes, selectedLevelId))
+  const isFlyMode = useEditor((state) => state.firstPersonMovementMode === 'fly')
   const controllerRef = useRef<BVHEcctrlApi | null>(null)
   const movementInputRef = useRef<MovementInput>({ ...inactiveMovementInput })
   const hadPointerLockRef = useRef(false)
@@ -661,6 +671,8 @@ export const FirstPersonControls = () => {
   const interactableTargetRef = useRef<FirstPersonInteractableTarget | null>(null)
   const hudLabelFrameRef = useRef(HUD_LABEL_SAMPLE_FRAMES - 1)
   const crouchKeyRef = useRef(false)
+  const flyDescendKeyRef = useRef(false)
+  const flyVelocityRef = useRef(new Vector3())
   const suspendRef = useRef(false)
   const eyeOffsetRef = useRef(CAMERA_EYE_OFFSET)
   const [crouched, setCrouched] = useState(false)
@@ -692,13 +704,19 @@ export const FirstPersonControls = () => {
     }
   }, [])
 
+  // While a snapshot is being framed the capture rig owns the fov (the user is
+  // driving it from the overlay's slider), so walkthrough neither applies its
+  // own nor restores one underneath it. Read imperatively: this must not re-run
+  // — and therefore restore — when capture mode toggles mid-walkthrough.
   useEffect(() => {
     const perspectiveCamera = camera as PerspectiveCamera
     if (!perspectiveCamera.isPerspectiveCamera) return
+    if (useEditor.getState().isCaptureMode) return
     const previousFov = perspectiveCamera.fov
     perspectiveCamera.fov = WALKTHROUGH_FOV
     perspectiveCamera.updateProjectionMatrix()
     return () => {
+      if (useEditor.getState().isCaptureMode) return
       perspectiveCamera.fov = previousFov
       perspectiveCamera.updateProjectionMatrix()
     }
@@ -931,6 +949,10 @@ export const FirstPersonControls = () => {
   }, [resolveInteractableDoorId, resolveInteractableElevatorTarget, resolveInteractableWindowId])
 
   const toggleInteractableTarget = useCallback(() => {
+    // Fly is a camera, not an avatar: the click that re-acquires pointer lock
+    // must not swing a door open under the shot being framed.
+    if (isFlyMode) return
+
     const target = interactableTargetRef.current ?? resolveInteractableTarget()
     if (!target) return
 
@@ -984,9 +1006,11 @@ export const FirstPersonControls = () => {
     if (node?.type !== 'door' || node.openingKind === 'opening') return
 
     toggleDoorOpenState(doorId, { persist: false })
-  }, [resolveInteractableTarget])
+  }, [isFlyMode, resolveInteractableTarget])
 
   const closeInteractableTarget = useCallback(() => {
+    if (isFlyMode) return
+
     const target = interactableTargetRef.current ?? resolveInteractableTarget()
     if (!target) return
 
@@ -1010,7 +1034,7 @@ export const FirstPersonControls = () => {
     if (node?.type !== 'door' || node.openingKind === 'opening') return
 
     closeDoorOpenState(target.id, { persist: false })
-  }, [resolveInteractableTarget])
+  }, [isFlyMode, resolveInteractableTarget])
 
   const placedSpawn = useMemo<FirstPersonSpawn | null>(() => {
     if (!(placedSpawnNode && placedSpawnNode.type === 'spawn')) return null
@@ -1042,7 +1066,10 @@ export const FirstPersonControls = () => {
   }, [placedSpawnNode])
 
   useEffect(() => {
-    rebuildColliderWorld()
+    // Fly has no gravity, no floor and no collision, so the BVH collider world
+    // (a full-scene traversal, rebuilt on every door/window animation) is pure
+    // cost there. Switching modes disposes it and rebuilds on the way back.
+    if (!isFlyMode) rebuildColliderWorld()
 
     return () => {
       worldRef.current?.dispose()
@@ -1052,16 +1079,39 @@ export const FirstPersonControls = () => {
       setElevatorColliderMeshes([])
       setWorld(null)
     }
-  }, [rebuildColliderWorld])
+  }, [isFlyMode, rebuildColliderWorld])
 
   useEffect(() => {
+    if (isFlyMode) return
     emitter.on('door:animation-completed', rebuildColliderWorld)
     emitter.on('window:animation-completed', rebuildColliderWorld)
     return () => {
       emitter.off('door:animation-completed', rebuildColliderWorld)
       emitter.off('window:animation-completed', rebuildColliderWorld)
     }
-  }, [rebuildColliderWorld])
+  }, [isFlyMode, rebuildColliderWorld])
+
+  // A walk session started before a fly detour would otherwise resume at its
+  // original spawn; drop it so the next walk re-derives one.
+  useEffect(() => {
+    if (isFlyMode) setControllerStart(null)
+  }, [isFlyMode])
+
+  // Fly picks up wherever the camera currently is — orbit pose or walk eye.
+  useEffect(() => {
+    if (!isFlyMode) return
+    flyEuler.setFromQuaternion(camera.quaternion)
+    yawRef.current = flyEuler.y
+    pitchRef.current = flyEuler.x
+    flyVelocityRef.current.set(0, 0, 0)
+
+    // Interaction prompts belong to walk; drop whatever its frame left behind.
+    if (useViewer.getState().hoveredId === interactableTargetRef.current?.id) {
+      useViewer.getState().setHoveredId(null)
+    }
+    interactableTargetRef.current = null
+    useFirstPersonHud.getState().reset()
+  }, [camera, isFlyMode])
 
   useEffect(() => {
     if (!world) return
@@ -1194,6 +1244,11 @@ export const FirstPersonControls = () => {
         // While paused (P), crouch is frozen as-is — ⌃⇧⌘4 (clipboard
         // screenshot) must not toggle it under the user.
         if (!suspendRef.current) crouchKeyRef.current = true
+      } else if (event.code === 'KeyQ') {
+        // Fly descend. Space (already bound to jump) is the matching ascend.
+        event.preventDefault()
+        event.stopPropagation()
+        if (!suspendRef.current) flyDescendKeyRef.current = true
       } else if (event.code === 'Escape') {
         event.preventDefault()
         event.stopPropagation()
@@ -1230,11 +1285,17 @@ export const FirstPersonControls = () => {
       if ((event.code === 'ControlLeft' || event.code === 'ControlRight') && !suspendRef.current) {
         crouchKeyRef.current = false
       }
+      if (event.code === 'KeyQ' && !suspendRef.current) {
+        flyDescendKeyRef.current = false
+      }
       applyMovementKey(event, false)
     }
 
     const handleBlur = () => {
-      if (!suspendRef.current) crouchKeyRef.current = false
+      if (!suspendRef.current) {
+        crouchKeyRef.current = false
+        flyDescendKeyRef.current = false
+      }
     }
 
     document.addEventListener('keydown', handleKeyDown, true)
@@ -1321,6 +1382,7 @@ export const FirstPersonControls = () => {
   }, [])
 
   useFrame(() => {
+    if (isFlyMode) return
     syncElevatorColliderMeshes()
   }, -1)
 
@@ -1480,7 +1542,40 @@ export const FirstPersonControls = () => {
     return standClearanceRaycaster.intersectObjects(meshes, false).length === 0
   }, [])
 
+  // Fly: a free camera driven straight from the look angles — no controller, no
+  // gravity, no collision clamping. WASD move along the view axes, Space rises,
+  // Q (or Ctrl) sinks, Shift boosts.
   useFrame((_, delta) => {
+    if (!isFlyMode) return
+
+    const step = Math.min(delta, 0.1)
+    const movement = movementInputRef.current
+
+    flyEuler.set(pitchRef.current, yawRef.current, 0, 'YXZ')
+    camera.quaternion.setFromEuler(flyEuler)
+    flyForward.set(0, 0, -1).applyEuler(flyEuler)
+    flyRight.set(1, 0, 0).applyEuler(flyEuler)
+
+    flyDesiredVelocity.set(0, 0, 0)
+    if (movement.forward) flyDesiredVelocity.add(flyForward)
+    if (movement.backward) flyDesiredVelocity.sub(flyForward)
+    if (movement.rightward) flyDesiredVelocity.add(flyRight)
+    if (movement.leftward) flyDesiredVelocity.sub(flyRight)
+    if (movement.jump) flyDesiredVelocity.y += 1
+    if (flyDescendKeyRef.current || crouchKeyRef.current) flyDesiredVelocity.y -= 1
+    if (flyDesiredVelocity.lengthSq() > 0) {
+      flyDesiredVelocity
+        .normalize()
+        .multiplyScalar(FLY_SPEED * (movement.run ? FLY_RUN_MULTIPLIER : 1))
+    }
+
+    flyVelocityRef.current.lerp(flyDesiredVelocity, 1 - Math.exp(-step * FLY_SMOOTHING))
+    camera.position.addScaledVector(flyVelocityRef.current, step)
+    camera.updateMatrixWorld(true)
+  }, 2.5)
+
+  useFrame((_, delta) => {
+    if (isFlyMode) return
     if (!controllerRef.current?.group) return
 
     const group = controllerRef.current.group
@@ -1562,7 +1657,7 @@ export const FirstPersonControls = () => {
     [world, elevatorColliderMeshes],
   )
 
-  if (!world) {
+  if (isFlyMode || !world) {
     return null
   }
 

--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -62,6 +62,7 @@ import type { SidebarTab } from '../ui/sidebar/tab-bar'
 import { useHostPanels } from '../ui/sidebar/use-plugin-panels'
 import { ViewerStage } from '../viewer/viewer-stage'
 import type { ViewerStageMode } from '../viewer/viewer-stage-modes'
+import { CaptureCameraRig } from './capture-camera-rig'
 import { CustomCameraControls } from './custom-camera-controls'
 import { DeleteConfirmationDialog } from './delete-confirmation-dialog'
 import { EditorLayoutV2 } from './editor-layout-v2'
@@ -796,6 +797,7 @@ const ViewerSceneContent = memo(function ViewerSceneContent({
       {!(isLoading || isFirstPersonMode) && <SnapAwareGrid />}
       {!(isLoading || noEditing) && <ToolManager />}
       {isFirstPersonMode && <FirstPersonControls />}
+      {isCaptureMode && <CaptureCameraRig />}
       <CustomCameraControls />
       <ThumbnailGenerator onThumbnailCapture={onThumbnailCapture} />
       {!isFirstPersonMode && <SiteEdgeLabels />}
@@ -1539,7 +1541,10 @@ export default function Editor({
                       <HelperManager />
                     </div>
                   )}
-                  {isFirstPersonMode && (
+                  {/* Capture mode drives walk / fly from its own overlay, which
+                      owns the framing chrome — the walkthrough HUD would both
+                      clutter the frame and offer a second, conflicting exit. */}
+                  {isFirstPersonMode && !isCaptureMode && (
                     <FirstPersonOverlay
                       onExit={() => useEditor.getState().setFirstPersonMode(false)}
                     />

--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -1541,7 +1541,7 @@ export default function Editor({
                       <HelperManager />
                     </div>
                   )}
-                  {/* Capture mode drives walk / fly from its own overlay, which
+                  {/* Capture mode drives walk / drone from its own overlay, which
                       owns the framing chrome — the walkthrough HUD would both
                       clutter the frame and offer a second, conflicting exit. */}
                   {isFirstPersonMode && !isCaptureMode && (

--- a/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
+++ b/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
@@ -117,7 +117,7 @@ function CornerAccents() {
 }
 
 const HUD_CHIP_CLASS =
-  'flex flex-col gap-px rounded-lg border border-white/10 bg-neutral-950/85 px-3 py-1.5 backdrop-blur-md'
+  'flex flex-col gap-px rounded-lg border border-white/10 bg-neutral-950/85 px-3 py-1.5'
 
 const CROP_LABELS: Record<CropMode, string> = {
   standard: 'Standard',
@@ -537,7 +537,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
               has a pre-staged square, so we never show it there. */}
           {!selectionStyle && !isPreset && (
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-              <span className="rounded-full border border-white/10 bg-neutral-950/80 px-4 py-2 text-sm text-white backdrop-blur-md">
+              <span className="rounded-full border border-white/10 bg-neutral-950/80 px-4 py-2 text-sm text-white">
                 {cameraOwnsPointer
                   ? 'Switch back to orbit to drag a capture area'
                   : 'Drag the area you want to capture'}
@@ -622,7 +622,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
       <div className="pointer-events-auto absolute top-4 right-4">
         <button
           aria-label="Close capture mode"
-          className="flex items-center gap-1.5 rounded-lg border border-white/10 bg-neutral-950/85 px-3 py-1.5 text-white/80 text-xs backdrop-blur-md transition-colors hover:bg-neutral-950 hover:text-white"
+          className="flex items-center gap-1.5 rounded-lg border border-white/10 bg-neutral-950/85 px-3 py-1.5 text-white/80 text-xs transition-colors hover:bg-neutral-950 hover:text-white"
           onClick={dismiss}
           type="button"
         >
@@ -641,7 +641,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
         {(showCameraNav || fovValue !== null) && (
           <div className="pointer-events-auto flex items-center gap-2">
             {showCameraNav && (
-              <div className="flex items-center gap-1 rounded-full border border-white/10 bg-neutral-950/85 px-1.5 py-1.5 shadow-xl backdrop-blur-md">
+              <div className="flex items-center gap-1 rounded-full border border-white/10 bg-neutral-950/85 px-1.5 py-1.5 shadow-xl">
                 <ModeButton
                   active={cameraNav === 'orbit'}
                   icon={<Orbit className="h-3.5 w-3.5" />}
@@ -663,7 +663,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
               </div>
             )}
             {fovValue !== null && (
-              <div className="flex items-center gap-2.5 rounded-full border border-white/10 bg-neutral-950/85 py-1.5 pr-1.5 pl-3 shadow-xl backdrop-blur-md">
+              <div className="flex items-center gap-2.5 rounded-full border border-white/10 bg-neutral-950/85 py-1.5 pr-1.5 pl-3 shadow-xl">
                 <span className="font-mono text-[8.5px] text-white/50 uppercase tracking-[0.14em]">
                   Lens
                 </span>
@@ -698,7 +698,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
         )}
 
         {!isCropLocked && (
-          <div className="pointer-events-auto relative flex items-center gap-1 rounded-full border border-white/10 bg-neutral-950/85 px-1.5 py-1.5 shadow-xl backdrop-blur-md">
+          <div className="pointer-events-auto relative flex items-center gap-1 rounded-full border border-white/10 bg-neutral-950/85 px-1.5 py-1.5 shadow-xl">
             {/* Clicking Standard while it's active opens the aspect picker */}
             <ModeButton
               active={mode === 'standard'}
@@ -713,7 +713,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
               }}
             />
             {aspectMenuOpen && mode === 'standard' && (
-              <div className="absolute bottom-[calc(100%+8px)] left-0 flex gap-1 rounded-full border border-white/10 bg-neutral-950/90 p-1.5 shadow-xl backdrop-blur-md">
+              <div className="absolute bottom-[calc(100%+8px)] left-0 flex gap-1 rounded-full border border-white/10 bg-neutral-950/90 p-1.5 shadow-xl">
                 {(Object.keys(STANDARD_SIZES) as StandardAspect[]).map((aspect) => (
                   <button
                     className={`rounded-full px-2.5 py-1 font-mono text-[11px] transition-colors ${
@@ -765,7 +765,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
         {!isMobile &&
           !isPreset &&
           (cameraHint ? (
-            <div className="pointer-events-none flex max-w-lg flex-wrap items-center justify-center gap-x-2.5 gap-y-1 rounded-lg border border-white/10 bg-neutral-950/85 px-3 py-1.5 text-[10px] backdrop-blur-md">
+            <div className="pointer-events-none flex max-w-lg flex-wrap items-center justify-center gap-x-2.5 gap-y-1 rounded-lg border border-white/10 bg-neutral-950/85 px-3 py-1.5 text-[10px]">
               {cameraHint.map(({ keys, action }) => (
                 <span className="inline-flex items-center gap-1 whitespace-nowrap" key={action}>
                   <span className="inline-flex items-center gap-0.5">
@@ -783,7 +783,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
               ))}
             </div>
           ) : (
-            <span className="pointer-events-none max-w-90 rounded-lg border border-white/10 bg-neutral-950/85 px-3.5 py-1.5 text-center text-[11.5px] text-white/85 leading-relaxed backdrop-blur-md">
+            <span className="pointer-events-none max-w-90 rounded-lg border border-white/10 bg-neutral-950/85 px-3.5 py-1.5 text-center text-[11.5px] text-white/85 leading-relaxed">
               A <b className="font-semibold text-white">snapshot</b>
               {' freezes this exact camera angle as a reusable reference for renders & videos.'}
             </span>

--- a/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
+++ b/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
@@ -5,12 +5,12 @@ import { SNAPSHOT_MAX_EDGE } from '@pascal-app/viewer'
 import {
   Check,
   Crop,
+  Drone,
   Footprints,
   Loader2,
   Maximize2,
   Monitor,
   Orbit,
-  Plane,
   RotateCcw,
   X,
 } from 'lucide-react'
@@ -129,10 +129,27 @@ const CROP_LABELS: Record<CropMode, string> = {
 const FOV_SLIDER_CLASS =
   'w-24 [&_[data-slot=slider-track]]:h-1 [&_[data-slot=slider-track]]:bg-white/20 [&_[data-slot=slider-range]]:bg-white [&_[data-slot=slider-thumb]]:size-3 [&_[data-slot=slider-thumb]]:border-white/50 [&_[data-slot=slider-thumb]]:bg-white [&_[data-slot=slider-thumb]]:ring-white/30'
 
-const CAMERA_NAV_HINTS: Record<CaptureCameraNav, string | null> = {
+type CameraNavHint = {
+  action: string
+  keys: readonly string[]
+}
+
+const CAMERA_NAV_HINTS: Record<CaptureCameraNav, readonly CameraNavHint[] | null> = {
   orbit: null,
-  walk: 'Click the scene to look around · WASD to walk · Space to jump · P frees the cursor · Enter to shoot',
-  fly: 'Click the scene to look around · WASD to fly · Space up · Q down · Shift to boost · Enter to shoot',
+  walk: [
+    { keys: ['WASD'], action: 'move' },
+    { keys: ['Space'], action: 'jump' },
+    { keys: ['P'], action: 'free cursor' },
+    { keys: ['Enter'], action: 'shoot' },
+  ],
+  drone: [
+    { keys: ['WASD'], action: 'move' },
+    { keys: ['Space', 'E'], action: 'up' },
+    { keys: ['Q'], action: 'down' },
+    { keys: ['Shift'], action: 'boost' },
+    { keys: ['P'], action: 'free cursor' },
+    { keys: ['Enter'], action: 'shoot' },
+  ],
 }
 
 export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
@@ -390,7 +407,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
     })
   }, [captureState, mode, drag, projectId, isPreset, standardAspect])
 
-  // Esc dismisses. Enter fires the shutter: walk and fly hold a pointer lock, so
+  // Esc dismisses. Enter fires the shutter: walk and drone hold a pointer lock, so
   // a keyboard shutter is the only way to shoot without leaving the camera first.
   useEffect(() => {
     if (!isCaptureMode) return
@@ -411,13 +428,13 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
   if (!isCaptureMode) return null
 
   const resolution = getResolution(mode, overlayRef.current, drag, standardAspect)
-  // Walk and fly need the canvas to receive the click that grants pointer lock,
+  // Walk and drone need the canvas to receive the click that grants pointer lock,
   // so the area-drag surface steps aside — same treatment as preset mode, whose
   // frame is fixed and camera-driven.
   const cameraOwnsPointer = cameraNav !== 'orbit'
   const frameLocked = isPreset || cameraOwnsPointer
   // Preset captures are a constrained flow (fixed square, host-owned banner);
-  // they keep the plain orbit camera. Walk / fly need a keyboard, so they stay
+  // they keep the plain orbit camera. Walk / drone need a keyboard, so they stay
   // off touch. The fov control is armed by the capture rig only on a
   // perspective camera — orthographic captures have no lens to drive.
   const showCameraNav = !(isPreset || isMobile)
@@ -547,7 +564,7 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
               <CornerAccents />
               {/* Corner handles — preset mode locks the frame to the
                   auto-staged centered square; the user adjusts the
-                  camera instead. Walk / fly lock it for the same reason. */}
+                  camera instead. Walk / drone lock it for the same reason. */}
               {!frameLocked &&
                 (
                   [
@@ -638,10 +655,10 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
                   onClick={() => setCameraNav('walk')}
                 />
                 <ModeButton
-                  active={cameraNav === 'fly'}
-                  icon={<Plane className="h-3.5 w-3.5" />}
-                  label="Fly"
-                  onClick={() => setCameraNav('fly')}
+                  active={cameraNav === 'drone'}
+                  icon={<Drone className="h-3.5 w-3.5" />}
+                  label="Drone"
+                  onClick={() => setCameraNav('drone')}
                 />
               </div>
             )}
@@ -745,16 +762,32 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
 
         {/* Preset captures carry their own "Frame your item" banner — the
             snapshot pitch only applies to the studio/reference flow. */}
-        {!isMobile && !isPreset && (
-          <span className="pointer-events-none max-w-90 rounded-lg border border-white/10 bg-neutral-950/85 px-3.5 py-1.5 text-center text-[11.5px] text-white/85 leading-relaxed backdrop-blur-md">
-            {cameraHint ?? (
-              <>
-                A <b className="font-semibold text-white">snapshot</b>
-                {' freezes this exact camera angle as a reusable reference for renders & videos.'}
-              </>
-            )}
-          </span>
-        )}
+        {!isMobile &&
+          !isPreset &&
+          (cameraHint ? (
+            <div className="pointer-events-none flex max-w-lg flex-wrap items-center justify-center gap-x-2.5 gap-y-1 rounded-lg border border-white/10 bg-neutral-950/85 px-3 py-1.5 text-[10px] backdrop-blur-md">
+              {cameraHint.map(({ keys, action }) => (
+                <span className="inline-flex items-center gap-1 whitespace-nowrap" key={action}>
+                  <span className="inline-flex items-center gap-0.5">
+                    {keys.map((key, index) => (
+                      <span className="inline-flex items-center gap-0.5" key={key}>
+                        {index > 0 && <span className="text-white/25">/</span>}
+                        <kbd className="rounded border border-white/15 bg-white/5 px-1.5 py-0.5 font-mono text-[9px] text-white/80 leading-none shadow-sm">
+                          {key}
+                        </kbd>
+                      </span>
+                    ))}
+                  </span>
+                  <span className="text-white/55">{action}</span>
+                </span>
+              ))}
+            </div>
+          ) : (
+            <span className="pointer-events-none max-w-90 rounded-lg border border-white/10 bg-neutral-950/85 px-3.5 py-1.5 text-center text-[11.5px] text-white/85 leading-relaxed backdrop-blur-md">
+              A <b className="font-semibold text-white">snapshot</b>
+              {' freezes this exact camera angle as a reusable reference for renders & videos.'}
+            </span>
+          ))}
 
         <button
           aria-label={isPreset ? 'Capture' : 'Take snapshot'}

--- a/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
+++ b/packages/editor/src/components/editor/snapshot-capture-overlay.tsx
@@ -2,14 +2,29 @@
 
 import { emitter } from '@pascal-app/core'
 import { SNAPSHOT_MAX_EDGE } from '@pascal-app/viewer'
-import { Check, Crop, Loader2, Maximize2, Monitor, X } from 'lucide-react'
+import {
+  Check,
+  Crop,
+  Footprints,
+  Loader2,
+  Maximize2,
+  Monitor,
+  Orbit,
+  Plane,
+  RotateCcw,
+  X,
+} from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useIsMobile } from '../../hooks/use-mobile'
 import { triggerSFX } from '../../lib/sfx-bus'
 import useEditor, {
+  CAPTURE_FOV_MAX,
+  CAPTURE_FOV_MIN,
+  type FirstPersonMovementMode,
   type SnapshotCropMode,
   type SnapshotStandardAspect,
 } from '../../store/use-editor'
+import { Slider } from '../ui/slider'
 
 // Local alias — distinct from `useEditor.captureMode` (which describes *why*
 // a capture is happening, e.g. `preset`). This one says HOW the captured
@@ -17,6 +32,9 @@ import useEditor, {
 // user-dragged area. Hosts can preselect it via `captureMode.crop`.
 type CropMode = SnapshotCropMode
 type CaptureState = 'idle' | 'capturing' | 'saved'
+/** Which camera the shot is framed with: the editor's orbit camera, or one of
+ *  the two first-person controllers. */
+type CaptureCameraNav = 'orbit' | FirstPersonMovementMode
 
 interface DragPoint {
   x: number
@@ -107,6 +125,16 @@ const CROP_LABELS: Record<CropMode, string> = {
   area: 'Area',
 }
 
+// Dark-HUD skin for the shared slider, which is themed for the light editor chrome.
+const FOV_SLIDER_CLASS =
+  'w-24 [&_[data-slot=slider-track]]:h-1 [&_[data-slot=slider-track]]:bg-white/20 [&_[data-slot=slider-range]]:bg-white [&_[data-slot=slider-thumb]]:size-3 [&_[data-slot=slider-thumb]]:border-white/50 [&_[data-slot=slider-thumb]]:bg-white [&_[data-slot=slider-thumb]]:ring-white/30'
+
+const CAMERA_NAV_HINTS: Record<CaptureCameraNav, string | null> = {
+  orbit: null,
+  walk: 'Click the scene to look around · WASD to walk · Space to jump · P frees the cursor · Enter to shoot',
+  fly: 'Click the scene to look around · WASD to fly · Space up · Q down · Shift to boost · Enter to shoot',
+}
+
 export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
   const isCaptureMode = useEditor((s) => s.isCaptureMode)
   const captureMode = useEditor((s) => s.captureMode)
@@ -121,6 +149,25 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
   // A host-preselected crop means the host needs that exact output shape
   // (e.g. the publish-cover capture) — hide the crop/aspect switcher.
   const isCropLocked = isPreset || requestedCrop !== undefined
+
+  const isFirstPersonMode = useEditor((s) => s.isFirstPersonMode)
+  const firstPersonMovementMode = useEditor((s) => s.firstPersonMovementMode)
+  const captureFov = useEditor((s) => s.captureFov)
+  const captureFovBaseline = useEditor((s) => s.captureFovBaseline)
+  const setCaptureFov = useEditor((s) => s.setCaptureFov)
+  // Orbit is just "first person off", so deriving the segmented control's value
+  // from the walkthrough flag keeps the two from drifting when walkthrough ends
+  // on its own (Esc, or a lost pointer lock).
+  const cameraNav: CaptureCameraNav = isFirstPersonMode ? firstPersonMovementMode : 'orbit'
+  const setCameraNav = useCallback((next: CaptureCameraNav) => {
+    const editor = useEditor.getState()
+    if (next === 'orbit') {
+      editor.setFirstPersonMode(false)
+      return
+    }
+    editor.setFirstPersonMovementMode(next)
+    if (!editor.isFirstPersonMode) editor.setFirstPersonMode(true)
+  }, [])
 
   const [mode, setMode] = useState<CropMode>('standard')
   const [standardAspect, setStandardAspect] = useState<StandardAspect>('16:9')
@@ -142,16 +189,6 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
     observer.observe(el)
     return () => observer.disconnect()
   }, [isCaptureMode])
-
-  // Dismiss on Esc
-  useEffect(() => {
-    if (!isCaptureMode) return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setCaptureMode(false)
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [isCaptureMode, setCaptureMode])
 
   // Reset local state when entering capture mode. Preset mode also
   // auto-stages a centered square crop sized to ~75% of the shorter
@@ -353,9 +390,39 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
     })
   }, [captureState, mode, drag, projectId, isPreset, standardAspect])
 
+  // Esc dismisses. Enter fires the shutter: walk and fly hold a pointer lock, so
+  // a keyboard shutter is the only way to shoot without leaving the camera first.
+  useEffect(() => {
+    if (!isCaptureMode) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setCaptureMode(false)
+        return
+      }
+      if (e.key !== 'Enter') return
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      e.preventDefault()
+      handleCapture()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [handleCapture, isCaptureMode, setCaptureMode])
+
   if (!isCaptureMode) return null
 
   const resolution = getResolution(mode, overlayRef.current, drag, standardAspect)
+  // Walk and fly need the canvas to receive the click that grants pointer lock,
+  // so the area-drag surface steps aside — same treatment as preset mode, whose
+  // frame is fixed and camera-driven.
+  const cameraOwnsPointer = cameraNav !== 'orbit'
+  const frameLocked = isPreset || cameraOwnsPointer
+  // Preset captures are a constrained flow (fixed square, host-owned banner);
+  // they keep the plain orbit camera. Walk / fly need a keyboard, so they stay
+  // off touch. The fov control is armed by the capture rig only on a
+  // perspective camera — orthographic captures have no lens to drive.
+  const showCameraNav = !(isPreset || isMobile)
+  const fovValue = isPreset ? null : captureFov
+  const cameraHint = CAMERA_NAV_HINTS[cameraNav]
 
   // Standard mode framing: the output is a center-crop of the canvas to the
   // chosen aspect (see ThumbnailGenerator) — show exactly that region as a
@@ -421,13 +488,13 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
       {mode === 'area' && (
         <div
           className={
-            isPreset
+            frameLocked
               ? 'pointer-events-none absolute inset-0'
               : 'pointer-events-auto absolute inset-0 bg-black/30'
           }
-          onPointerDown={isPreset ? undefined : onPointerDown}
+          onPointerDown={frameLocked ? undefined : onPointerDown}
           onPointerMove={
-            isPreset
+            frameLocked
               ? undefined
               : (e) => {
                   onPointerMove(e)
@@ -445,8 +512,8 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
                   }
                 }
           }
-          onPointerUp={isPreset ? undefined : onPointerUp}
-          style={isPreset ? undefined : { cursor: 'crosshair' }}
+          onPointerUp={frameLocked ? undefined : onPointerUp}
+          style={frameLocked ? undefined : { cursor: 'crosshair' }}
         >
           {/* "No selection" hint — only when the user has to draw the
               area themselves (`standard` capture). Preset mode always
@@ -454,7 +521,9 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
           {!selectionStyle && !isPreset && (
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
               <span className="rounded-full border border-white/10 bg-neutral-950/80 px-4 py-2 text-sm text-white backdrop-blur-md">
-                Drag the area you want to capture
+                {cameraOwnsPointer
+                  ? 'Switch back to orbit to drag a capture area'
+                  : 'Drag the area you want to capture'}
               </span>
             </div>
           )}
@@ -478,8 +547,8 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
               <CornerAccents />
               {/* Corner handles — preset mode locks the frame to the
                   auto-staged centered square; the user adjusts the
-                  camera instead. */}
-              {!isPreset &&
+                  camera instead. Walk / fly lock it for the same reason. */}
+              {!frameLocked &&
                 (
                   [
                     { pos: { top: -5, left: -5 }, cursor: 'nwse-resize' },
@@ -548,8 +617,69 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
       {/* Subtle scrim so the bottom controls stay readable on bright scenes */}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-black/45 via-black/15 to-transparent" />
 
-      {/* Bottom-center: crop switcher, caption + shutter */}
+      {/* Bottom-center: camera row, crop switcher, caption + shutter */}
       <div className="pointer-events-none absolute right-0 bottom-5 left-0 flex flex-col items-center gap-2.5">
+        {/* How you move while composing, and the lens. Both are capture-scoped:
+            leaving capture puts the camera back on orbit at its entry fov. */}
+        {(showCameraNav || fovValue !== null) && (
+          <div className="pointer-events-auto flex items-center gap-2">
+            {showCameraNav && (
+              <div className="flex items-center gap-1 rounded-full border border-white/10 bg-neutral-950/85 px-1.5 py-1.5 shadow-xl backdrop-blur-md">
+                <ModeButton
+                  active={cameraNav === 'orbit'}
+                  icon={<Orbit className="h-3.5 w-3.5" />}
+                  label="Orbit"
+                  onClick={() => setCameraNav('orbit')}
+                />
+                <ModeButton
+                  active={cameraNav === 'walk'}
+                  icon={<Footprints className="h-3.5 w-3.5" />}
+                  label="Walk"
+                  onClick={() => setCameraNav('walk')}
+                />
+                <ModeButton
+                  active={cameraNav === 'fly'}
+                  icon={<Plane className="h-3.5 w-3.5" />}
+                  label="Fly"
+                  onClick={() => setCameraNav('fly')}
+                />
+              </div>
+            )}
+            {fovValue !== null && (
+              <div className="flex items-center gap-2.5 rounded-full border border-white/10 bg-neutral-950/85 py-1.5 pr-1.5 pl-3 shadow-xl backdrop-blur-md">
+                <span className="font-mono text-[8.5px] text-white/50 uppercase tracking-[0.14em]">
+                  Lens
+                </span>
+                <Slider
+                  aria-label="Field of view"
+                  className={FOV_SLIDER_CLASS}
+                  max={CAPTURE_FOV_MAX}
+                  min={CAPTURE_FOV_MIN}
+                  onValueChange={([next]) => {
+                    if (next !== undefined) setCaptureFov(next)
+                  }}
+                  step={1}
+                  value={[fovValue]}
+                />
+                <span className="w-8 text-right font-semibold text-white text-xs tabular-nums">
+                  {fovValue}°
+                </span>
+                <button
+                  aria-label="Reset field of view"
+                  className="grid h-6 w-6 place-items-center rounded-full text-white/50 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-white/50"
+                  disabled={captureFovBaseline === null || fovValue === captureFovBaseline}
+                  onClick={() => {
+                    if (captureFovBaseline !== null) setCaptureFov(captureFovBaseline)
+                  }}
+                  type="button"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
         {!isCropLocked && (
           <div className="pointer-events-auto relative flex items-center gap-1 rounded-full border border-white/10 bg-neutral-950/85 px-1.5 py-1.5 shadow-xl backdrop-blur-md">
             {/* Clicking Standard while it's active opens the aspect picker */}
@@ -617,8 +747,12 @@ export function SnapshotCaptureOverlay({ projectId }: { projectId: string }) {
             snapshot pitch only applies to the studio/reference flow. */}
         {!isMobile && !isPreset && (
           <span className="pointer-events-none max-w-90 rounded-lg border border-white/10 bg-neutral-950/85 px-3.5 py-1.5 text-center text-[11.5px] text-white/85 leading-relaxed backdrop-blur-md">
-            A <b className="font-semibold text-white">snapshot</b>
-            {' freezes this exact camera angle as a reusable reference for renders & videos.'}
+            {cameraHint ?? (
+              <>
+                A <b className="font-semibold text-white">snapshot</b>
+                {' freezes this exact camera angle as a reusable reference for renders & videos.'}
+              </>
+            )}
           </span>
         )}
 

--- a/packages/editor/src/components/editor/thumbnail-generator.tsx
+++ b/packages/editor/src/components/editor/thumbnail-generator.tsx
@@ -36,6 +36,9 @@ interface ThumbnailGeneratorProps {
   onThumbnailCapture?: (blob: Blob, cameraData: SnapshotCameraData) => void
 }
 
+/** Metres ahead of a controls-less camera to place the stored snapshot target. */
+const FIRST_PERSON_TARGET_DISTANCE = 8
+
 function clampSnapshotSize(width: number, height: number): { w: number; h: number } {
   const maxEdge = Math.max(width, height)
   if (maxEdge <= SNAPSHOT_MAX_EDGE) return { w: width, h: height }
@@ -143,6 +146,15 @@ export const ThumbnailGenerator = ({ onThumbnailCapture }: ThumbnailGeneratorPro
           const v = new THREE.Vector3()
           ;(controls as any).getTarget(v)
           tgt = [v.x, v.y, v.z]
+        } else {
+          // Walk / fly captures run without orbit controls, so there is no orbit
+          // target to read. Synthesize one down the view axis — otherwise the
+          // saved snapshot carries no framing to return to.
+          const look = new THREE.Vector3(0, 0, -1)
+            .applyQuaternion(mainCamera.quaternion)
+            .multiplyScalar(FIRST_PERSON_TARGET_DISTANCE)
+            .add(pos)
+          tgt = [look.x, look.y, look.z]
         }
         const isOrtho = mainCamera instanceof THREE.OrthographicCamera
         const cameraData: SnapshotCameraData = {

--- a/packages/editor/src/components/editor/thumbnail-generator.tsx
+++ b/packages/editor/src/components/editor/thumbnail-generator.tsx
@@ -147,7 +147,7 @@ export const ThumbnailGenerator = ({ onThumbnailCapture }: ThumbnailGeneratorPro
           ;(controls as any).getTarget(v)
           tgt = [v.x, v.y, v.z]
         } else {
-          // Walk / fly captures run without orbit controls, so there is no orbit
+          // Walk / drone captures run without orbit controls, so there is no orbit
           // target to read. Synthesize one down the view axis — otherwise the
           // saved snapshot carries no framing to return to.
           const look = new THREE.Vector3(0, 0, -1)

--- a/packages/editor/src/store/use-editor.tsx
+++ b/packages/editor/src/store/use-editor.tsx
@@ -97,6 +97,18 @@ export type CaptureMode =
       }
     }
 
+/**
+ * How the first-person camera moves. `walk` is the grounded street-view
+ * controller (gravity, collision, door interaction); `fly` is a free camera
+ * with no gravity or collision, offered by the snapshot capture overlay so a
+ * shot can be framed from anywhere in the scene.
+ */
+export type FirstPersonMovementMode = 'walk' | 'fly'
+
+/** Degrees. Range of the capture-mode field-of-view control. */
+export const CAPTURE_FOV_MIN = 15
+export const CAPTURE_FOV_MAX = 110
+
 export type Phase = 'site' | 'structure' | 'furnish'
 
 /**
@@ -446,6 +458,20 @@ type EditorState = {
   isFirstPersonMode: boolean
   _viewModeBeforeFirstPerson: ViewMode | null
   setFirstPersonMode: (enabled: boolean) => void
+  // Which first-person controller runs while `isFirstPersonMode` is on. Reset to
+  // `walk` whenever first person is left, so the grounded controller stays the
+  // default entry point; only the capture overlay arms `fly`.
+  firstPersonMovementMode: FirstPersonMovementMode
+  setFirstPersonMovementMode: (mode: FirstPersonMovementMode) => void
+  // Perspective field of view (degrees) the snapshot capture overlay is driving,
+  // and the value its reset affordance returns to. Both are `null` unless the
+  // capture camera rig has armed them — i.e. unless capture mode is open on a
+  // perspective camera. The rig owns the lifecycle; the overlay only writes
+  // `captureFov` through `setCaptureFov`.
+  captureFov: number | null
+  captureFovBaseline: number | null
+  setCaptureFov: (fov: number) => void
+  armCaptureFov: (fov: number | null) => void
   // Workspace mode: 'edit' is the full editing surface; 'studio' is the
   // render/snapshot surface (clean canvas, no editing chrome or selection).
   // Entering studio forces a 3D-only view and restores the prior view on exit.
@@ -1193,6 +1219,12 @@ const useEditor = create<EditorState>()(
         const resolved: CaptureMode =
           typeof next === 'boolean' ? { mode: next ? 'standard' : 'idle' } : next
         const entering = resolved.mode !== 'idle'
+        // Walk / fly framing is a capture-only camera, so leaving capture always
+        // lands back on orbit. Run it first: it restores its own view mode, and
+        // the capture restore below has the final say.
+        if (!entering && get().isFirstPersonMode) {
+          get().setFirstPersonMode(false)
+        }
         set((state) => {
           if (entering) {
             // Force 3D for the shot. Remember the prior mode only on the first
@@ -1333,11 +1365,26 @@ const useEditor = create<EditorState>()(
           const prevMode = get()._viewModeBeforeFirstPerson
           set({
             isFirstPersonMode: false,
+            firstPersonMovementMode: 'walk',
             _viewModeBeforeFirstPerson: null,
             ...(prevMode ? { viewMode: prevMode, isFloorplanOpen: prevMode !== '3d' } : {}),
           })
         }
       },
+      firstPersonMovementMode: 'walk' as FirstPersonMovementMode,
+      setFirstPersonMovementMode: (mode) => set({ firstPersonMovementMode: mode }),
+      captureFov: null,
+      captureFovBaseline: null,
+      setCaptureFov: (fov) =>
+        set({
+          captureFov: Math.min(Math.max(Math.round(fov), CAPTURE_FOV_MIN), CAPTURE_FOV_MAX),
+        }),
+      armCaptureFov: (fov) =>
+        set(
+          fov === null
+            ? { captureFov: null, captureFovBaseline: null }
+            : { captureFov: fov, captureFovBaseline: fov },
+        ),
       workspaceMode: 'edit' as WorkspaceMode,
       _viewModeBeforeStudio: null as ViewMode | null,
       setWorkspaceMode: (mode) => {

--- a/packages/editor/src/store/use-editor.tsx
+++ b/packages/editor/src/store/use-editor.tsx
@@ -99,11 +99,11 @@ export type CaptureMode =
 
 /**
  * How the first-person camera moves. `walk` is the grounded street-view
- * controller (gravity, collision, door interaction); `fly` is a free camera
+ * controller (gravity, collision, door interaction); `drone` is a free camera
  * with no gravity or collision, offered by the snapshot capture overlay so a
  * shot can be framed from anywhere in the scene.
  */
-export type FirstPersonMovementMode = 'walk' | 'fly'
+export type FirstPersonMovementMode = 'walk' | 'drone'
 
 /** Degrees. Range of the capture-mode field-of-view control. */
 export const CAPTURE_FOV_MIN = 15
@@ -460,7 +460,7 @@ type EditorState = {
   setFirstPersonMode: (enabled: boolean) => void
   // Which first-person controller runs while `isFirstPersonMode` is on. Reset to
   // `walk` whenever first person is left, so the grounded controller stays the
-  // default entry point; only the capture overlay arms `fly`.
+  // default entry point; only the capture overlay arms `drone`.
   firstPersonMovementMode: FirstPersonMovementMode
   setFirstPersonMovementMode: (mode: FirstPersonMovementMode) => void
   // Perspective field of view (degrees) the snapshot capture overlay is driving,
@@ -1219,7 +1219,7 @@ const useEditor = create<EditorState>()(
         const resolved: CaptureMode =
           typeof next === 'boolean' ? { mode: next ? 'standard' : 'idle' } : next
         const entering = resolved.mode !== 'idle'
-        // Walk / fly framing is a capture-only camera, so leaving capture always
+        // Walk / drone framing is a capture-only camera, so leaving capture always
         // lands back on orbit. Run it first: it restores its own view mode, and
         // the capture restore below has the final say.
         if (!entering && get().isFirstPersonMode) {


### PR DESCRIPTION
## What does this PR do?

Gives snapshot capture a real camera toolkit so users can frame the perfect shot for studio renders:

- **Lens (FOV) control**: a slider in the capture overlay (15–110°) drives the main camera live; the entry FOV is restored on every exit path. Hidden on orthographic cameras. Owned by a new `CaptureCameraRig` mounted only during capture.
- **Orbit / Walk / Drone framing cameras**: Walk reuses first-person; Drone is a new no-gravity/no-collision variant on the same controls (WASD move, Space/E up, Q/Ctrl down, Shift boost). Enter fires the shutter (pointer lock makes the button unclickable). Walk/drone snapshots synthesize a stored target down the view axis so they stay revisitable.
- **Keycap hint pills** instead of sentence hints; walkthrough HUD hidden while capture owns the frame.
- **Flicker fix**: removed `backdrop-blur` from the capture pills — backdrop-filter over the WebGPU canvas flashes black on ProMotion/XDR displays (same class of bug as the community July gallery fix).

## How to test

1. `bun dev`, open a project, enter capture (Studio capbar → Capture, or the Snapshot menu item).
2. Drag the Lens slider — projection changes live; reset returns to 50°; Esc out of capture and confirm the editor camera is back to its original FOV.
3. Switch to Walk, click the scene, move with WASD, press Enter — the snapshot saves from the first-person view. Esc returns to Orbit (still in capture).
4. Switch to Drone — fly freely through walls, Space/E up, Q down, Shift boost; Enter shoots.
5. On a MacBook built-in display, hover the capture pills — no black flicker.

## Screenshots / screen recording

Will add a short clip; meanwhile the overlay shows the Orbit/Walk/Drone control + Lens pill bottom-center with per-mode keycap hints.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared camera state, first-person controls, and capture lifecycle across multiple exit paths; regressions could affect walkthrough FOV, pointer lock, or saved snapshot framing.
> 
> **Overview**
> Snapshot capture gets a **camera toolkit** so studio shots can be framed beyond orbit pan/zoom.
> 
> **Orbit / Walk / Drone** toggles in the capture overlay switch between the editor orbit camera and first-person modes. **Drone** is a new collision-free free camera (WASD, Space/E up, Q/Ctrl down, Shift boost) on the same `FirstPersonControls` path; walk keeps grounded physics. Leaving capture always returns to orbit; walk/drone hide the normal walkthrough HUD and use overlay keycap hints instead. **Enter** triggers capture while pointer lock is active; walk/drone lock area-crop dragging so the canvas can receive pointer-lock clicks.
> 
> **Lens (FOV)** is driven from the overlay (15–110°) via new editor store fields and **`CaptureCameraRig`**, which applies FOV to the main camera only while capture is open and restores entry FOV on exit (with coordination so walkthrough FOV does not fight capture). The control is hidden for orthographic cameras and preset capture.
> 
> **Persistence:** `ThumbnailGenerator` synthesizes a look-at target down the view axis when orbit controls are absent, so walk/drone snapshots remain revisitable.
> 
> **Polish:** `backdrop-blur` removed from capture HUD pills to avoid WebGPU canvas flicker on high-refresh displays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e0df5c21b66a72983c95ca549a62215b36d20e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->