### PR TITLE
editor: keep walk/drone snapshot framing as clean as orbit's

### DIFF
--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -1006,6 +1006,7 @@ const ViewerCanvas = memo(function ViewerCanvas({
   const floorplanPaneRatio = useEditor((s) => s.floorplanPaneRatio)
   const setFloorplanPaneRatio = useEditor((s) => s.setFloorplanPaneRatio)
   const isPreviewMode = useEditor((s) => s.isPreviewMode)
+  const isCaptureMode = useEditor((s) => s.isCaptureMode)
 
   const [isCameraControlsHintVisible, setIsCameraControlsHintVisible] = useState<boolean | null>(
     null,
@@ -1120,7 +1121,10 @@ const ViewerCanvas = memo(function ViewerCanvas({
             renderContext="editor"
             renderPaused={!show3d && !showLoader}
             sceneReadyKey={sceneReadyKey}
-            selectionManager={isFirstPersonMode ? 'default' : 'custom'}
+            // Walk/drone framing during snapshot capture is camera-only: the
+            // viewer's default selection manager would hover-highlight whatever
+            // the cursor crosses, which orbit capture never does.
+            selectionManager={isFirstPersonMode && !isCaptureMode ? 'default' : 'custom'}
           >
             <ViewerSceneContent
               isFirstPersonMode={isFirstPersonMode}

--- a/packages/editor/src/components/viewer-zone-system.tsx
+++ b/packages/editor/src/components/viewer-zone-system.tsx
@@ -13,6 +13,9 @@ export const ViewerZoneSystem = () => {
     const { levelId, zoneId } = useViewer.getState().selection
     const structureLayer = useEditor.getState().structureLayer
     const nodes = useScene.getState().nodes
+    // Snapshot capture is a clean, camera-only surface — zone geometry and
+    // tags stay out of the framed shot (mirrors the editor ZoneSystem's gate).
+    const isCaptureMode = useEditor.getState().isCaptureMode
     // During any active interaction zone labels step back entirely (Sims-light).
     const zoneLabelsHidden =
       resolveOverlayPolicy(useInteractionScope.getState().scope).zoneLabels === 'hidden'
@@ -31,7 +34,8 @@ export const ViewerZoneSystem = () => {
       // The editor ZoneSystem handles the selected zone's opacity animation.
       const isSelected = id === zoneId
       const shouldShowGeometry =
-        (structureLayer === 'zones' && !!levelId && isOnSelectedLevel) || isSelected
+        !isCaptureMode &&
+        ((structureLayer === 'zones' && !!levelId && isOnSelectedLevel) || isSelected)
       if (!obj.visible) obj.visible = true
       obj.traverse((child) => {
         if ((child as Mesh).isMesh) {
@@ -40,7 +44,7 @@ export const ViewerZoneSystem = () => {
       })
 
       // Labels: always visible on the current level (regardless of mode or zone selection)
-      const showLabel = !zoneLabelsHidden && !!levelId && isOnSelectedLevel
+      const showLabel = !isCaptureMode && !zoneLabelsHidden && !!levelId && isOnSelectedLevel
       const targetOpacity = showLabel ? '1' : '0'
       const labelEl = document.getElementById(`${id}-label`)
       if (labelEl && labelEl.style.opacity !== targetOpacity) {


### PR DESCRIPTION
## What does this PR do?

Snapshot capture in walk/drone mode leaked two editing affordances into the framed shot that orbit capture never shows:

- The viewer's **default selection manager** stayed mounted in first-person mode, so whatever the cursor crossed got hover-highlighted while composing. `ViewerCanvas` now falls back to `custom` (i.e. none, since the editor manager is also unmounted in capture) while capture is active.
- **`ViewerZoneSystem`** (the first-person zone system) had no capture gate, unlike the editor `ZoneSystem` — zone geometry and HTML zone tags rendered into the shot. Both are now hidden while `isCaptureMode` is set.

## How to test

1. `bun dev`, open a project with at least one zone, and enter snapshot capture (Studio → snapshot, or the capture button).
2. Switch the capture camera to **Walk** or **Drone**.
3. Zone tags/geometry should not appear, and moving the cursor over walls/items should not hover-highlight anything — identical to Orbit capture.
4. Exit capture into a regular walkthrough (viewer walk mode): zone labels and hover behavior are unchanged there.

## Screenshots / screen recording

N/A — the change removes visual noise (hover outlines + zone tags) from walk/drone capture framing; behavior outside capture is untouched.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gQSsJ7nfdARkNH5PcKUjt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, capture-mode-only UI gating with no auth, persistence, or API changes.
> 
> **Overview**
> Walk and drone snapshot framing now matches orbit capture by stripping editing affordances from the framed shot while `isCaptureMode` is on.
> 
> **`ViewerCanvas`** uses the viewer’s `custom` selection manager (no default hover highlights) whenever capture is active, even in first-person mode—previously only orbit avoided those highlights.
> 
> **`ViewerZoneSystem`** reads `isCaptureMode` and suppresses zone mesh visibility and HTML zone labels during capture, aligning with the editor **`ZoneSystem`** gate that orbit capture already benefited from.
> 
> Normal walkthrough outside capture is unchanged: zones and first-person selection behavior still apply when not capturing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc9e0e281e616fbac26382124a4ae11b60c0dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->