### PR TITLE
core: make AnyNode discriminated union zod-4.5-proof (bare-literal projection)

### DIFF
--- a/apps/editor/lib/graph-schema.ts
+++ b/apps/editor/lib/graph-schema.ts
@@ -1,4 +1,4 @@
-import { AnyNode, AssetUrl, BaseNode, SceneMaterial } from '@pascal-app/core/schema'
+import { AnyNode, AssetUrl, BaseNode, nodeKindOf, SceneMaterial } from '@pascal-app/core/schema'
 import { z } from 'zod'
 
 /**
@@ -24,9 +24,7 @@ import { z } from 'zod'
  * hostile scheme where `AssetUrl` already enumerates the safe ones.
  */
 
-const KNOWN_TYPES = new Set<string>(
-  AnyNode.options.map((o) => o.shape.type.parse(undefined) as string),
-)
+const KNOWN_TYPES = new Set<string>(AnyNode.options.map(nodeKindOf))
 
 /** The envelope every persisted node satisfies, builtin or foreign. */
 const ForeignNodeEnvelope = BaseNode.extend({

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -344,6 +344,6 @@ export {
 export { ZoneNode } from './nodes/zone'
 export { generateSceneMaterialId, SceneMaterial, type SceneMaterialId } from './scene-material'
 export { MAX_TERRAIN_SIDE, TerrainData } from './terrain'
-export type { AnyNodeId, AnyNodeType } from './types'
+export type { AnyNodeId, AnyNodeOption, AnyNodeType } from './types'
 // Union types
-export { AnyNode } from './types'
+export { AnyNode, nodeKindOf } from './types'

--- a/packages/core/src/schema/node-union.test.ts
+++ b/packages/core/src/schema/node-union.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from 'bun:test'
+import { z } from 'zod'
+import { nodeType } from './base'
+import * as schema from './index'
+import { AnyNode, type AnyNodeOption, nodeKindOf, nodeUnion } from './types'
+
+/**
+ * `nodeType()` wraps every node's discriminator in `.default()`. Zod 4.5 made a
+ * wrapped discriminator additionally claim `undefined`, which collides across
+ * members and throws `Duplicate discriminator value "undefined"` out of
+ * `safeParse` at the union's first parse. `nodeUnion()` projects each member's
+ * discriminator down to its bare literal to keep that unrepresentable; these
+ * tests fail in CI if the projection regresses or a zod upgrade breaks it.
+ */
+
+const UNION_KINDS = AnyNode.options.map(nodeKindOf)
+
+/** Fields a kind requires beyond the defaults its own schema fills in. */
+const REQUIRED_FIELDS: Record<string, Record<string, unknown>> = {
+  ceiling: {
+    polygon: [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+    ],
+  },
+  'duct-segment': {
+    path: [
+      [0, 0, 0],
+      [1, 0, 0],
+    ],
+  },
+  fence: { start: [0, 0], end: [4, 0] },
+  guide: { url: 'asset://guide.png' },
+  item: {
+    asset: {
+      id: 'asset-1',
+      category: 'furniture',
+      name: 'Chair',
+      thumbnail: 'asset://chair.png',
+      src: 'asset://chair.glb',
+    },
+  },
+  lineset: {
+    path: [
+      [0, 0, 0],
+      [1, 0, 0],
+    ],
+  },
+  'liquid-line': {
+    path: [
+      [0, 0, 0],
+      [1, 0, 0],
+    ],
+  },
+  measurement: {
+    measurement: {
+      kind: 'distance',
+      points: [
+        [0, 0, 0],
+        [1, 0, 0],
+      ],
+    },
+  },
+  'pipe-segment': {
+    path: [
+      [0, 0, 0],
+      [1, 0, 0],
+    ],
+  },
+  slab: {
+    polygon: [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+    ],
+  },
+  wall: { start: [0, 0], end: [4, 0] },
+  zone: {
+    name: 'Kitchen',
+    polygon: [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+    ],
+  },
+}
+
+/** Node schemas as authored — discriminator still wrapped by `nodeType()`. */
+type AuthoredNode = z.ZodObject<
+  { type: z.ZodDefault<z.ZodLiteral<string>> } & z.core.$ZodLooseShape
+>
+
+function isAuthoredNode(value: unknown): value is AuthoredNode {
+  if (!(value instanceof z.ZodObject)) return false
+  const discriminator = (value.shape as Record<string, unknown>).type
+  return discriminator instanceof z.ZodDefault && discriminator.unwrap() instanceof z.ZodLiteral
+}
+
+/** kind → the per-kind schema the package exports, keyed off its own default. */
+const authoredByKind = new Map<string, AuthoredNode>()
+for (const exported of Object.values(schema)) {
+  if (!isAuthoredNode(exported)) continue
+  authoredByKind.set(exported.shape.type.unwrap().value, exported)
+}
+
+describe('nodeUnion', () => {
+  test('assembles a parsable union from nodeType() members', () => {
+    const Alpha = z.object({ id: z.string(), type: nodeType('alpha'), size: z.number().default(1) })
+    const Beta = z.object({ id: z.string(), type: nodeType('beta') }).describe('a beta node')
+    const Union = nodeUnion([Alpha, Beta])
+
+    expect(Union.parse({ id: 'a_1', type: 'alpha' })).toEqual({
+      id: 'a_1',
+      type: 'alpha',
+      size: 1,
+    })
+    expect(Union.parse({ id: 'b_1', type: 'beta' })).toEqual({ id: 'b_1', type: 'beta' })
+
+    const unknownKind = Union.safeParse({ id: 'c_1', type: 'gamma' })
+    expect(unknownKind.success).toBe(false)
+    expect(unknownKind.error?.issues[0]?.path).toEqual(['type'])
+  })
+
+  test('carries member metadata onto the projected clone', () => {
+    const Beta = z.object({ id: z.string(), type: nodeType('beta') }).describe('a beta node')
+    const Union = nodeUnion([z.object({ id: z.string(), type: nodeType('alpha') }), Beta])
+
+    expect(Union.options[1].description).toBe('a beta node')
+  })
+
+  test('projects the discriminator to a bare literal', () => {
+    for (const option of AnyNode.options) {
+      expect(option.shape.type).toBeInstanceOf(z.ZodLiteral)
+    }
+  })
+
+  test('keeps the descriptions the node schemas were authored with', () => {
+    const described = AnyNode.options.filter((option) => option.description !== undefined)
+    expect(described.length).toBeGreaterThan(40)
+
+    for (const option of AnyNode.options) {
+      const authored = authoredByKind.get(nodeKindOf(option))
+      expect(authored?.description).toBe(option.description)
+    }
+  })
+})
+
+describe('AnyNode', () => {
+  test('rejects a type-less node without throwing', () => {
+    const result = AnyNode.safeParse({ id: 'wall_1', start: [0, 0], end: [4, 0] })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toEqual([
+      expect.objectContaining({ code: 'invalid_union', path: ['type'] }),
+    ])
+  })
+
+  test('rejects an unknown kind at the discriminator', () => {
+    const result = AnyNode.safeParse({ id: 'x_1', type: 'not-a-node' })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toEqual([
+      expect.objectContaining({ code: 'invalid_union', path: ['type'] }),
+    ])
+  })
+
+  test('reports member issues at the member path', () => {
+    const result = AnyNode.safeParse({ id: 'wall_1', type: 'wall', start: 'nope', end: [4, 0] })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toEqual([
+      expect.objectContaining({ code: 'invalid_type', expected: 'tuple', path: ['start'] }),
+    ])
+  })
+
+  test('exposes every union kind as a per-kind schema', () => {
+    const missing = UNION_KINDS.filter((kind) => !authoredByKind.has(kind))
+    expect(missing).toEqual([])
+  })
+
+  test('REQUIRED_FIELDS lists no kind outside the union', () => {
+    const stale = Object.keys(REQUIRED_FIELDS).filter(
+      (kind) => !UNION_KINDS.includes(kind as (typeof UNION_KINDS)[number]),
+    )
+    expect(stale).toEqual([])
+  })
+
+  // The projection only changes the union's view of `type`, so the two-step
+  // authoring path has to keep working for every kind: parse a type-less
+  // fixture through the per-kind schema (its `.default()` fills `type` in),
+  // then parse that output through the union.
+  test.each(UNION_KINDS)('round-trips a %s through per-kind then union', (kind) => {
+    const authored = authoredByKind.get(kind)
+    if (!authored) throw new Error(`no per-kind schema exported for "${kind}"`)
+
+    const perKind = authored.safeParse({ ...REQUIRED_FIELDS[kind] })
+    expect(perKind.error?.issues ?? []).toEqual([])
+    expect((perKind.data as { type?: string } | undefined)?.type).toBe(kind)
+
+    const viaUnion = AnyNode.safeParse(perKind.data)
+    expect(viaUnion.error?.issues ?? []).toEqual([])
+    expect(viaUnion.data).toEqual(perKind.data)
+  })
+
+  test('nodeKindOf reads the kind off any option', () => {
+    const options: AnyNodeOption[] = [...AnyNode.options]
+    expect(new Set(options.map(nodeKindOf)).size).toBe(options.length)
+    expect(UNION_KINDS).toContain('wall')
+  })
+})

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -47,7 +47,40 @@ import { WallNode } from './nodes/wall'
 import { WindowNode } from './nodes/window'
 import { ZoneNode } from './nodes/zone'
 
-export const AnyNode = z.discriminatedUnion('type', [
+/** A node schema as authored: `type` is a literal wrapped by `nodeType()`'s `.default()`. */
+type NodeMember = z.ZodObject<{ type: z.ZodDefault<z.ZodLiteral<string>> } & z.core.$ZodLooseShape>
+
+/** The same schema with the discriminator narrowed back to its bare literal. */
+type BareDiscriminator<T extends NodeMember> = z.ZodObject<
+  Omit<T['shape'], 'type'> & { type: ReturnType<T['shape']['type']['unwrap']> }
+>
+
+/**
+ * Assembles the node union on discriminators that claim exactly one value.
+ *
+ * `nodeType()` defaults the literal so a per-kind schema can fill `type` in
+ * (`WallNode.parse({ start, end })`), but a `.default()`-wrapped discriminator
+ * also claims `undefined` from zod 4.5 on (upstream #6432). With 48 members
+ * doing it, the union's lazily-built discriminator map collides on
+ * `undefined` and throws `Duplicate discriminator value` — as a plain Error,
+ * so it escapes `safeParse` and surfaces as a crash at the first parse.
+ *
+ * Each member is therefore projected to a clone whose `type` is the bare
+ * literal. Per-kind schemas keep their default; only the union's view of the
+ * discriminator narrows. Metadata lives in zod's global registry keyed by
+ * instance, so `.describe()` text has to be carried over to the clone by hand.
+ */
+export const nodeUnion = <const T extends readonly [NodeMember, ...NodeMember[]]>(members: T) =>
+  z.discriminatedUnion(
+    'type',
+    members.map((member) => {
+      const projected = member.extend({ type: member.shape.type.unwrap() })
+      const meta = z.globalRegistry.get(member)
+      return meta ? projected.meta(meta) : projected
+    }) as { [K in keyof T]: BareDiscriminator<T[K]> },
+  )
+
+export const AnyNode = nodeUnion([
   SiteNode,
   BuildingNode,
   ElevatorNode,
@@ -101,3 +134,9 @@ export const AnyNode = z.discriminatedUnion('type', [
 export type AnyNode = z.infer<typeof AnyNode>
 export type AnyNodeType = AnyNode['type']
 export type AnyNodeId = AnyNode['id']
+
+/** One member schema of `AnyNode`, discriminator already projected to a bare literal. */
+export type AnyNodeOption = (typeof AnyNode)['options'][number]
+
+/** The node kind a union member accepts, read off its bare-literal discriminator. */
+export const nodeKindOf = (option: AnyNodeOption): AnyNodeType => option.shape.type.value

--- a/packages/core/src/validation/validate-build-json.ts
+++ b/packages/core/src/validation/validate-build-json.ts
@@ -1,6 +1,6 @@
 import { nodeRegistry } from '../registry'
 import { SceneMaterial } from '../schema/scene-material'
-import { AnyNode, type AnyNodeType } from '../schema/types'
+import { AnyNode, type AnyNodeType, nodeKindOf } from '../schema/types'
 import { healSceneNodes } from '../utils/heal-scene-graph'
 
 export type ValidationSeverity = 'error' | 'warning'
@@ -46,9 +46,7 @@ export type ValidateBuildJsonResult = {
   schemaIssueCount: number
 }
 
-const KNOWN_TYPES = new Set<string>(
-  AnyNode.options.map((o) => o.shape.type.parse(undefined) as string),
-)
+const KNOWN_TYPES = new Set<string>(AnyNode.options.map(nodeKindOf))
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/packages/nodes/src/index.test.ts
+++ b/packages/nodes/src/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
-import { AnyNode, loadPlugin, nodeRegistry } from '@pascal-app/core'
+import { AnyNode, loadPlugin, nodeKindOf, nodeRegistry } from '@pascal-app/core'
 import { builtinPlugin } from './index'
 
 describe('builtinPlugin', () => {
@@ -31,19 +31,7 @@ describe('builtinPlugin', () => {
     // (the union) and `nodes/src/index.ts` (the plugin), and this test
     // will keep them honest.
     await loadPlugin(builtinPlugin)
-    const unionKinds = new Set(
-      AnyNode.options.map((option) => {
-        // zod v4: the `type` field is a literal, often wrapped in
-        // ZodDefault. Unwrap to the innermost def and read its literal
-        // value from `_zod.def.values` (the v3 `.value` getter is gone).
-        let def = (option as unknown as { shape: Record<string, { _zod: { def: any } }> }).shape
-          .type._zod.def
-        while (def.innerType) {
-          def = def.innerType._zod.def
-        }
-        return def.values?.[0] as string
-      }),
-    )
+    const unionKinds = new Set(AnyNode.options.map(nodeKindOf))
     const registryKinds = new Set(Array.from(nodeRegistry.entries(), ([kind]) => kind))
     const missingFromRegistry = [...unionKinds].filter((k) => !registryKinds.has(k))
     const missingFromUnion = [...registryKinds].filter((k) => !unionKinds.has(k))


### PR DESCRIPTION
## What does this PR do?

Makes the `AnyNode` discriminated union survive zod 4.5.x, so the pending zod cap (`<4.5.0`) can later be lifted on the schema's own terms.

`packages/core/src/schema/base.ts` defines the node discriminator as `nodeType(t) = z.literal(t).default(t)`, so a per-kind schema can fill `type` in (`WallNode.parse({ start, end })`). From zod 4.5.0 ([#6432](https://github.com/colinhacks/zod/pull/6432)) a `.default()`-wrapped discriminator additionally claims `undefined`. All 48 members of `AnyNode` do that, so the union's lazily-built discriminator map collides on the `undefined` key and throws `Duplicate discriminator value "undefined"` — a plain `Error`, thrown out of `safeParse`, on the **first parse**. That is every path that validates a node: scene load, the `/api/scenes` boundary, the MCP bridge, build-JSON import.

The fix is at the union's assembly point only:

- `nodeUnion(members)` in `packages/core/src/schema/types.ts` projects each member to a clone whose `type` is the bare literal (`m.extend({ type: m.shape.type.unwrap() })`) before handing it to `z.discriminatedUnion`. Zod 4 keeps schema metadata in a global registry keyed by instance and `.extend()` returns a fresh instance, so the member's `.meta()` is copied onto the clone — 44 of the 48 members carry a `.describe()` block that feeds the MCP tool descriptions.
- The 48 node files and `nodeType()` are **byte-identical**. Per-kind schemas keep their `.default()`, so the ~2,554 `WallNode.parse({...})`-style sites are untouched.
- `nodeKindOf(option)` is exported from core and replaces the two production sites that read the kind by parsing the defaulted literal (`AnyNode.options.map(o => o.shape.type.parse(undefined))`) in `packages/core/src/validation/validate-build-json.ts` and `apps/editor/lib/graph-schema.ts`, plus the `_zod.def` unwrap loop in `packages/nodes/src/index.test.ts`. A repo-wide grep found no other `shape.type.parse(undefined)`.

### Consequences

- **Runtime behavior is unchanged on zod 4.4.3.** The old union already rejected a type-less node (the discriminator map was built from the inner literal values), so this only narrows what the union *claims*, not what it accepts. Error issue paths and codes are identical before/after — asserted in the new tests.
- **`z.input<typeof AnyNode>` now truthfully requires `type`.** Nothing in the workspace referenced that input type; `bun run check-types` is clean across all 15 packages.
- **`nodeUnion` is exported from `schema/types.ts` but deliberately not re-exported from the package barrel** — the canary test needs it; the published surface only gains `nodeKindOf` and the `AnyNodeOption` type.

### Interior discriminated unions — checked, all clean

Every other discriminated union in the repo discriminates on a **bare** `z.literal(...)`, so none needed the projection:

| Union | Discriminator | Verdict |
|---|---|---|
| `schema/nodes/cabinet.ts:32` `CabinetCompartment` | `type: z.literal(...)` | bare, left alone |
| `schema/nodes/item.ts:35` `controlSchema` | `kind: z.literal(...)` | bare, left alone |
| `schema/nodes/item.ts:60` `effectSchema` | `kind: z.literal(...)` | bare, left alone |
| `schema/nodes/roof.ts:15` `RoofSupport` | `kind: z.literal(...)` | bare — the `.default({ kind: 'level' })` wraps the *union*, not the discriminator, which is harmless |
| `schema/nodes/measurement.ts:90` `MeasurementPayload` | `kind: z.literal(...)` | bare, left alone |
| `packages/mcp/src/tools/schemas.ts:46` `PatchSchema` | `op: z.literal(...)` | bare, left alone |

Also verified while implementing: none of the 48 members carries an object-level `.refine()`/`.check()`, so `.extend()` can't silently drop a check (zod 4.4.3 throws rather than dropping — the projection would have failed loudly).

## How to test

1. `bun install && bun run check-types` — 11/11 tasks pass.
2. `cd packages/core && bun test src` — 1164 pass / 0 fail (1106 on `main` + 58 new).
3. `cd packages/nodes && bun test` — 1830 pass / 0 fail. `cd packages/mcp && bun test` — 341 pass / 0 fail.
4. `bun x biome check` on the changed files — clean.

New tests in `packages/core/src/schema/node-union.test.ts`:

- **Canary** — builds a two-member union through `nodeUnion()` from `nodeType()`-authored schemas, asserts both kinds parse, an unknown kind fails at `['type']`, and the projected clone keeps its `.describe()` text. If a future zod release changes discriminator semantics again, this fails in CI instead of crashing production at first parse.
- **No-throw guarantee** — `AnyNode.safeParse` of a type-less object returns a normal failure result.
- **Error-shape parity** — invalid-node cases assert the same issue codes/paths as before the projection (`invalid_union` at `['type']`, `invalid_type`/`tuple` at `['start']`).
- **Generated contract test** — for all 48 kinds: parse a minimal type-omitted fixture through the per-kind schema (its `.default()` fills `type`), then parse that output through `AnyNode` and assert the result round-trips unchanged. Per-kind schemas are discovered programmatically off the package exports (which also asserts every union kind is exported), and a small `REQUIRED_FIELDS` map covers the 12 kinds that need more than their own defaults; a guard test fails if that map ever names a kind outside the union.

### Smoke-tested green on zod 4.5.4

Temporarily installed `zod@4.5.4` at the worktree root (`package.json` / `bun.lock` restored to the committed 4.4.3 state before committing — the diff carries no dependency change):

- `packages/core`: **1164 pass / 0 fail**, schema + validation subset 221/221.
- Direct proof of the failure mode this PR removes: an *unprojected* two-member `z.discriminatedUnion('type', [SiteNode, WallNode])` throws `Duplicate discriminator value "undefined"` past `safeParse`, while `AnyNode.safeParse` succeeds, rejects a type-less node as a normal failure, and keeps both `nodeKindOf`'s `.value` read and the member descriptions working.
- `packages/nodes`: 1830 pass / 0 fail.
- `packages/mcp`: **27 fail on this branch vs 109 fail on `main`** under 4.5.4. The 82 recovered tests are the `AnyNode` crash. The remaining 27 are an unrelated zod 4.5 regression in the MCP SDK's argument validation — a `.default()` field now reports `expected "nonoptional"` (`Invalid arguments for tool generate_variants: expected nonoptional, received undefined` for `save`) — plus one JSON-schema emission expectation. Out of scope here; worth noting that lifting the zod cap will need that addressed separately.

## Screenshots / screen recording

No visual change — schema assembly only.

## Checklist

- [ ] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable) — n/a, the rationale lives in the `nodeUnion` doc comment
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches central schema validation used at API boundaries, import, and MCP; behavior is intended to be identical on current Zod but any union/projection bug could break all node parsing.
> 
> **Overview**
> Fixes **`AnyNode`** so it no longer crashes on the first parse under Zod 4.5, where `.default()`-wrapped `type` discriminators all claim `undefined` and blow up the discriminated union with `Duplicate discriminator value "undefined"` (an error that escapes `safeParse`).
> 
> Assembly now goes through **`nodeUnion()`**, which clones each member with a **bare literal** `type` (and copies `.describe()` metadata) while per-kind schemas still use `nodeType()` defaults unchanged. **`nodeKindOf`** replaces the old `shape.type.parse(undefined)` / internal Zod def unwrapping when building `KNOWN_TYPES` in scene graph validation and build-JSON validation, and in the builtin plugin drift test.
> 
> Adds **`node-union.test.ts`** as a CI canary: projection shape, metadata preservation, `safeParse` without throws, error paths, and per-kind → union round-trips for all union kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0351f32a93bee8ca478a89845f6c5d09c025b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->