### PR TITLE
core: type node metadata as a record instead of z.json()

### DIFF
--- a/apps/ifc-converter/components/IfcConverter.tsx
+++ b/apps/ifc-converter/components/IfcConverter.tsx
@@ -13,7 +13,7 @@ const PascalViewer = dynamic(() => import('./PascalSceneViewer'), { ssr: false }
 type Status = 'idle' | 'loading' | 'converting' | 'ready' | 'error'
 
 // The converter writes a fixed shape into BaseNode.metadata, but the
-// underlying type is z.json() — a loose JSON value. This helper gives
+// underlying type is an open `Record<string, unknown>`. This helper gives
 // the UI dot-access on the fields the converter actually writes.
 type ConverterMetadata = {
   ifcType?: string

--- a/packages/core/src/schema/base.test.ts
+++ b/packages/core/src/schema/base.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { BaseNode } from './base'
+import { ZoneNode } from './nodes/zone'
+
+const zoneInput = {
+  id: 'zone_meta',
+  name: 'Office',
+  polygon: [
+    [0, 0],
+    [4, 0],
+    [4, 3],
+  ],
+}
+
+describe('node metadata contract', () => {
+  test('defaults to an empty object when absent', () => {
+    expect(BaseNode.parse({ id: 'node_1' }).metadata).toEqual({})
+    expect(ZoneNode.parse(zoneInput).metadata).toEqual({})
+  })
+
+  test('carries arbitrary nested values under string keys', () => {
+    const metadata = { ifcType: 'IfcWall', expressID: 42, layers: [{ name: 'gypsum' }] }
+
+    expect(BaseNode.parse({ id: 'node_1', metadata }).metadata).toEqual(metadata)
+    expect(ZoneNode.parse({ ...zoneInput, metadata }).metadata).toEqual(metadata)
+  })
+
+  // The contract is object-only, narrower than the JSON value it replaced —
+  // see the note on `BaseNode.metadata` for why the recursive schema had to go.
+  // Each case is tuple-wrapped so `test.each` passes the array case as one
+  // argument instead of spreading it into none.
+  test.each([[null], [[]], ['note'], [7], [true]])('rejects the non-object %p', (metadata) => {
+    expect(BaseNode.safeParse({ id: 'node_1', metadata }).success).toBe(false)
+    expect(ZoneNode.safeParse({ ...zoneInput, metadata }).success).toBe(false)
+  })
+
+  test('drops keys whose value is undefined', () => {
+    expect(BaseNode.parse({ id: 'node_1', metadata: { a: 1, b: undefined } }).metadata).toEqual({
+      a: 1,
+    })
+  })
+})

--- a/packages/core/src/schema/base.ts
+++ b/packages/core/src/schema/base.ts
@@ -26,7 +26,14 @@ export const BaseNode = z.object({
   parentId: z.string().nullable().default(null),
   visible: z.boolean().optional().default(true),
   camera: CameraSchema.optional(),
-  metadata: z.json().optional().default({}),
+  // Deliberately a record, not `z.json()`. The recursive JSON schema is the
+  // most expensive member of every node that embeds it (`WallNode.parse` runs
+  // ~1.5x faster without it) and, being self-referential, it also denies the
+  // whole node tree zod 4.5's compiled parser: measured on `WallNode`,
+  // `z.compile()` bought 1.0x with `z.json()` and 2.2x with this record.
+  // Metadata is a flat bag of per-node extras, so an open object with
+  // unchecked values is the whole contract we need.
+  metadata: z.record(z.string(), z.unknown()).optional().default({}),
 })
 
 export type BaseNode = z.infer<typeof BaseNode>

--- a/packages/core/src/schema/nodes/zone.ts
+++ b/packages/core/src/schema/nodes/zone.ts
@@ -25,7 +25,7 @@ export const ZoneNode = BaseNode.extend({
   clearDimensionPolicy: z.enum(['none', 'inside-faces', 'finish-faces']).default('none'),
   // Visual styling
   color: z.string().default('#3b82f6'), // Default blue
-  metadata: z.json().optional().default({}),
+  metadata: z.record(z.string(), z.unknown()).optional().default({}),
 }).describe(
   dedent`
   Zone schema - a polygon zone attached to a level

--- a/packages/ifc-converter/src/index.ts
+++ b/packages/ifc-converter/src/index.ts
@@ -31,10 +31,11 @@ export interface PascalSceneGraph {
   collections?: Record<string, unknown>
 }
 
-// Pascal's BaseNode.metadata is typed as `JSONType` (z.json()) — a loose
-// JSON value. The converter writes a fixed shape; this typed accessor
-// keeps dot-access ergonomics without spraying `as any` through the
-// post-processing loops. Read-side only — writes still inline literals.
+// Pascal's BaseNode.metadata is typed as `Record<string, unknown>` — an
+// open object with unchecked values. The converter writes a fixed shape;
+// this typed accessor keeps dot-access ergonomics without spraying `as any`
+// through the post-processing loops. Read-side only — writes still inline
+// literals.
 type ConverterMetadata = {
   ifcType?: string
   expressID?: number
@@ -51,11 +52,10 @@ function meta(node: { metadata?: unknown } | null | undefined): ConverterMetadat
   return (node?.metadata ?? {}) as ConverterMetadata
 }
 
-// Pascal's `BaseNode.metadata` is `z.json()` — a recursive JSON value
-// type that doesn't accept `undefined` (JSON has `null`, not undefined).
-// The converter pulls many fields from optional IFC properties that
-// often return `undefined`; stripping them at the boundary keeps the
-// schemas happy without spraying `?? null` through every assignment.
+// The converter pulls many metadata fields from optional IFC properties
+// that often return `undefined`. Those keys vanish the moment the graph is
+// serialized, so stripping them here keeps the in-memory scene identical to
+// the persisted one instead of spraying `?? null` through every assignment.
 function buildMetadata(input: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(input)) {

--- a/packages/nodes/src/cabinet/run-ops.ts
+++ b/packages/nodes/src/cabinet/run-ops.ts
@@ -2489,7 +2489,7 @@ export function addCornerRun({
   })
   const selectionRootId = cornerSelectionRootId(sourceRun, baseLeg.runId)
   const linkedRunIds: AnyNodeId[] = [baseLeg.runId]
-  const baseLegLiveMetadata = sceneApi.get<CabinetNode>(baseLeg.runId)?.metadata ?? null
+  const baseLegLiveMetadata = sceneApi.get<CabinetNode>(baseLeg.runId)?.metadata ?? {}
   const baseLegMetadata = cabinetMetadataRecord(baseLegLiveMetadata)
   sceneApi.update(baseLeg.runId, {
     metadata: {
@@ -2561,7 +2561,7 @@ export function addCornerRun({
         sourceRun,
       })
       linkedRunIds.push(bridgeRun.runId)
-      const bridgeRunLiveMetadata = sceneApi.get<CabinetNode>(bridgeRun.runId)?.metadata ?? null
+      const bridgeRunLiveMetadata = sceneApi.get<CabinetNode>(bridgeRun.runId)?.metadata ?? {}
       const bridgeRunMetadata = cabinetMetadataRecord(bridgeRunLiveMetadata)
       sceneApi.update(bridgeRun.runId, {
         metadata: {
@@ -2613,8 +2613,7 @@ export function addCornerRun({
       sourceRun,
     })
     linkedRunIds.push(wallFillerRun.runId)
-    const wallFillerRunLiveMetadata =
-      sceneApi.get<CabinetNode>(wallFillerRun.runId)?.metadata ?? null
+    const wallFillerRunLiveMetadata = sceneApi.get<CabinetNode>(wallFillerRun.runId)?.metadata ?? {}
     const wallFillerRunMetadata = cabinetMetadataRecord(wallFillerRunLiveMetadata)
     sceneApi.update(wallFillerRun.runId, {
       metadata: {
@@ -2651,7 +2650,7 @@ export function addCornerRun({
   }
 
   const liveSourceMetadata =
-    sceneApi.get<CabinetModuleNode>(sourceModule.id as AnyNodeId)?.metadata ?? null
+    sceneApi.get<CabinetModuleNode>(sourceModule.id as AnyNodeId)?.metadata ?? {}
   const sourceMetadata = cabinetMetadataRecord(liveSourceMetadata)
   const existingSourceLink = cornerSourceLink(liveSourceMetadata)
   sceneApi.update(

--- a/packages/nodes/src/dormer/csg-geometry.ts
+++ b/packages/nodes/src/dormer/csg-geometry.ts
@@ -93,7 +93,7 @@ export function generateDormerGeometry(
     type: 'roof-segment',
     parentId: null,
     visible: true,
-    metadata: null,
+    metadata: {},
     children: [],
     position: [0, 0, 0],
     rotation: 0,


### PR DESCRIPTION
## What does this PR do?

Types node `metadata` as `z.record(z.string(), z.unknown())` instead of `z.json()`, in the two places that declared it — `BaseNode.metadata` and `ZoneNode`'s redeclaration of the same field. `.optional().default({})` is unchanged.

`z.json()` is zod's recursive JSON value. Being self-referential is disqualifying twice over: it is the most expensive member of every node schema that embeds it, and it is exactly what zod 4.5's `z.compile()` refuses to compile — so it doesn't just cost per-parse time, it denies the entire node tree the compiled parser.

Measured on the real `WallNode`, 200k parses, steady state (3 runs, first discarded as warm-up):

| `metadata` schema | zod 4.4.3 (shipped) | 4.5.4 interpreted | 4.5.4 `z.compile()` |
| --- | --- | --- | --- |
| `z.json()` | 125ms | 127ms | 133ms (**1.0x** — no gain) |
| `z.record(z.string(), z.unknown())` | 81ms | 68ms | 31ms (**2.2x**) |

That is ~1.5x faster per-node parse today on the zod we ship, and a 4x gap between the two once the compiled parser is available. Nothing in this PR upgrades zod; the 4.5.4 column was measured with a throwaway install and reverted (`package.json`/`bun.lock` untouched — the diff is 7 files, all source).

⚠️ **Contract change.** This narrows the published `@pascal-app/core` input contract for `metadata`: it accepted any JSON value (`null`, `[…]`, `"str"`, `42`, `true`) and now accepts objects only. Founder-approved 2026-09-01. Two secondary notes on the new shape: `null` is now rejected (it used to be a legal JSON value, and `.optional()` only covers `undefined`), and `{ a: undefined }` is now accepted with the key dropped (it used to fail, since JSON has no `undefined`).

### Call sites that leaned on the looser type

Repo-wide grep for non-object metadata writes turned up exactly two, both trivial:

- `packages/nodes/src/cabinet/run-ops.ts` — four `sceneApi.get(...)?.metadata ?? null` fallbacks → `?? {}`. Both consumers (`cabinetMetadataRecord`, `withSelectionProxyMetadata`) already normalized `null` to `{}`, so behavior is identical.
- `packages/nodes/src/dormer/csg-geometry.ts` — the in-memory virtual roof segment's `metadata: null` → `{}`. Never persisted.

Everything else already treated metadata as an object bag: every reader in the repo guards with `typeof === 'object' && !Array.isArray()` (`use-scene`, `roof-system`, `door-system`, `placement-metadata`, `cabinetMetadataRecord`, the IFC converter's `meta()`), and every writer spreads an object literal.

### ifc-converter findings

No code change needed — the converter's `buildMetadata()` already returns `Record<string, unknown>`, and every write goes through it. Three comments described the field as `z.json()`/`JSONType` and are now updated: two in `packages/ifc-converter/src/index.ts`, one in `apps/ifc-converter/components/IfcConverter.tsx`. `buildMetadata()`'s `undefined`-stripping stays (its comment's *why* changed: no longer "the schema rejects `undefined`" but "those keys vanish on serialize, so strip them to keep the in-memory graph equal to the persisted one").

### Not changed, worth knowing

- `ZoneNode` redeclares `metadata` identically to `BaseNode`'s — a pre-existing redundancy. Left alone; it's why this touches two schema lines rather than one.
- No fixture, template, test, or installed plugin (`plugin-trees`, `plugin-bones`, `plugin-streetscape`, `@mint/pascal-plugin`) writes a non-object metadata value, so no data migration is implied. A hand-edited or third-party scene JSON carrying `"metadata": null` would newly fail `AnyNode.safeParse`; Load Build reports that as a schema issue rather than crashing.

## How to test

```bash
bun run check-types   # 11/11 tasks
bun run check         # biome, 1955 files clean
bun run test          # 16/16 tasks, 4368 pass / 0 fail
```

New: `packages/core/src/schema/base.test.ts` (8 tests) pins the contract — defaults to `{}`, carries nested values, rejects `null`/array/string/number/boolean on both `BaseNode` and `ZoneNode`, drops `undefined`-valued keys. Core went 1106 → 1114 pass; every other package's count is unchanged from `main`.

## Screenshots / screen recording

n/a — schema-only change.

## Checklist

- [ ] I've tested this locally with `bun dev` — schema-only change, verified through `bun run test` / `check-types` / `check` instead
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable) — the rationale lives on `BaseNode.metadata`; the two IFC-converter comments that described the field as `z.json()` are corrected
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
