### PR TITLE
core: lazy per-kind compiled node parsers behind a flag

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
     "dev": "tsgo --build --watch",
     "test": "bun test src",
     "bench:registry": "bun run src/registry/__bench__/relations-resolver.bench.ts",
+    "bench:schema": "bun run src/schema/__bench__/node-parsers.bench.ts",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {

--- a/packages/core/src/schema/__bench__/node-parsers.bench.ts
+++ b/packages/core/src/schema/__bench__/node-parsers.bench.ts
@@ -1,0 +1,382 @@
+/**
+ * Bench harness for compiled per-kind node parsers (`z.compile`).
+ *
+ * Answers the four questions the flag exists to settle:
+ *
+ * 1. Does a compiled per-kind parser beat the interpreter on a *monomorphic*
+ *    call site (one kind, parsed over and over)?
+ * 2. Does it still win on a *mixed* call site (all 48 kinds in one loop), and
+ *    how does it compare to the design this rejects — one compiled function for
+ *    the whole union?
+ * 3. What does the first parse of a kind cost (codegen), and what does keeping
+ *    1 / 5 / 48 kinds compiled cost in RSS?
+ * 4. What do the wired call sites actually gain end to end?
+ *
+ * Run via:
+ *   bun run packages/core/src/schema/__bench__/node-parsers.bench.ts
+ *
+ * Every section runs in its own child process. Compiling is irreversible within
+ * a process and a large generated function measurably perturbs everything timed
+ * after it — sharing one process moved these numbers by more than 10x run to
+ * run. `--section <name>` is that child mode.
+ */
+
+import { z } from 'zod'
+import { authoredNodeSchemas, NODE_KINDS, nodeFixtures } from '../__fixtures__/node-fixtures'
+import {
+  compiledNodeSchema,
+  enableCompiledNodeParsers,
+  nodeSchemaForKind,
+  parseNode,
+} from '../compiled-node-parsers'
+import { AnyNode, type AnyNodeOption, type AnyNodeType } from '../types'
+
+const ITERATIONS = 10_000
+
+/** µs per operation, after a warm-up pass that lets the JIT settle. */
+function measure(run: () => void, iterations = ITERATIONS): number {
+  for (let i = 0; i < Math.min(2000, iterations); i++) run()
+  const started = performance.now()
+  for (let i = 0; i < iterations; i++) run()
+  return ((performance.now() - started) / iterations) * 1000
+}
+
+function round(value: number, digits = 2): number {
+  return Number(value.toFixed(digits))
+}
+
+function summarize(values: number[]) {
+  const sorted = [...values].sort((a, b) => a - b)
+  const at = (p: number) =>
+    sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))] ?? 0
+  return { min: round(sorted[0] ?? 0), p50: round(at(50)), p95: round(at(95)), max: round(at(100)) }
+}
+
+function optionsByKind(): Map<AnyNodeType, AnyNodeOption> {
+  return new Map(AnyNode.options.map((option) => [option.shape.type.value, option]))
+}
+
+/**
+ * A parse that *fails* runs the compiled fast path and then the interpreter, so
+ * an invalid fixture understates the win. Assert the batches are clean rather
+ * than measure the fallback by accident.
+ */
+function assertParses(label: string, nodes: unknown[]): void {
+  for (const node of nodes) {
+    if (AnyNode.safeParse(node).success) continue
+    throw new Error(`${label}: fixture does not satisfy AnyNode — bench would measure the fallback`)
+  }
+}
+
+// ── sections ────────────────────────────────────────────────────────────────
+
+function monomorphic() {
+  const fixtures = nodeFixtures()
+  const interpretedByKind = optionsByKind()
+
+  // Every interpreted number is taken before the first `z.compile`, so no kind's
+  // baseline is measured against a process already holding generated code.
+  const baselines = NODE_KINDS.map((kind) => {
+    const interpreted = interpretedByKind.get(kind) as AnyNodeOption
+    const fixture = fixtures.get(kind)
+    return {
+      kind,
+      union_us: round(
+        measure(() => {
+          AnyNode.safeParse(fixture)
+        }),
+      ),
+      interpreted_us: round(
+        measure(() => {
+          interpreted.safeParse(fixture)
+        }),
+      ),
+    }
+  })
+
+  enableCompiledNodeParsers()
+  const rows = baselines.map((baseline) => {
+    const compiled = nodeSchemaForKind(baseline.kind) as AnyNodeOption
+    const fixture = fixtures.get(baseline.kind)
+    const compiled_us = round(
+      measure(() => {
+        compiled.safeParse(fixture)
+      }),
+    )
+    return {
+      ...baseline,
+      compiled_us,
+      vs_interpreted: round(baseline.interpreted_us / compiled_us),
+      vs_union: round(baseline.union_us / compiled_us),
+    }
+  })
+  enableCompiledNodeParsers(false)
+
+  return {
+    rows,
+    vs_union: summarize(rows.map((row) => row.vs_union)),
+    vs_interpreted: summarize(rows.map((row) => row.vs_interpreted)),
+  }
+}
+
+function mixed() {
+  const fixtures = nodeFixtures()
+  const interpretedByKind = optionsByKind()
+
+  const inputs = NODE_KINDS.map((kind) => fixtures.get(kind))
+  let cursor = 0
+  const next = () => {
+    cursor = (cursor + 1) % inputs.length
+    return { kind: NODE_KINDS[cursor] as AnyNodeType, value: inputs[cursor] }
+  }
+
+  // Both interpreted baselines are timed before anything is compiled: 48
+  // resident generated functions are enough instruction-cache pressure to slow
+  // the interpreter down and flatter the compiled lane.
+  const union_us = round(
+    measure(() => {
+      AnyNode.safeParse(next().value)
+    }),
+  )
+  const interpreted_us = round(
+    measure(() => {
+      const { kind, value } = next()
+      ;(interpretedByKind.get(kind) as AnyNodeOption).safeParse(value)
+    }),
+  )
+
+  enableCompiledNodeParsers()
+  const compiledByKind = new Map(
+    NODE_KINDS.map((kind) => [kind, nodeSchemaForKind(kind) as AnyNodeOption]),
+  )
+  enableCompiledNodeParsers(false)
+
+  return {
+    union_us,
+    interpreted_us,
+    compiled_per_kind_us: round(
+      measure(() => {
+        const { kind, value } = next()
+        ;(compiledByKind.get(kind) as AnyNodeOption).safeParse(value)
+      }),
+    ),
+  }
+}
+
+/**
+ * The control this design rejects: one compiled function for the whole union.
+ * Runs alone because the generated code is large enough to perturb anything
+ * timed alongside it.
+ */
+function compiledUnion() {
+  const fixtures = nodeFixtures()
+  const inputs = NODE_KINDS.map((kind) => fixtures.get(kind))
+  let cursor = 0
+
+  const compiled = z.compile(AnyNode)
+  const started = performance.now()
+  z.compile(AnyNode)
+  const compileMs = performance.now() - started
+
+  return {
+    compile_ms: round(compileMs, 1),
+    mixed_us: round(
+      measure(() => {
+        cursor = (cursor + 1) % inputs.length
+        compiled.safeParse(inputs[cursor])
+      }),
+    ),
+    monomorphic_wall_us: round(
+      measure(() => {
+        compiled.safeParse(fixtures.get('wall'))
+      }),
+    ),
+  }
+}
+
+function compileCost() {
+  const byKind = optionsByKind()
+  const costs = NODE_KINDS.map((kind) => {
+    const option = byKind.get(kind) as AnyNodeOption
+    const started = performance.now()
+    z.compile(option)
+    return performance.now() - started
+  })
+
+  return {
+    ...summarize(costs),
+    total_all_48: round(
+      costs.reduce((sum, value) => sum + value, 0),
+      1,
+    ),
+  }
+}
+
+function rss(count: number) {
+  const fixtures = nodeFixtures()
+  enableCompiledNodeParsers()
+
+  for (const kind of NODE_KINDS.slice(0, count)) {
+    const schema = nodeSchemaForKind(kind) as AnyNodeOption
+    schema.safeParse(fixtures.get(kind))
+  }
+
+  Bun.gc(true)
+  return { count, rss: process.memoryUsage().rss }
+}
+
+function sites() {
+  const fixtures = nodeFixtures()
+
+  // Site A — the MCP bridge validates every `create` patch in a batch. Agents
+  // usually omit `id` and let the schema default mint one, so fixtures do too.
+  const CREATE_BATCH = 100
+  const createBatch = Array.from({ length: CREATE_BATCH }, (_, index) => {
+    const kind = NODE_KINDS[index % NODE_KINDS.length] as AnyNodeType
+    const { id: _id, ...node } = fixtures.get(kind) as Record<string, unknown>
+    return node
+  })
+  assertParses('site A', createBatch)
+
+  // Site B — scene-load migration parses one authored schema per node kind it
+  // normalizes. Six of them, each hit monomorphically.
+  const MIGRATE_NODES = 100
+  const authored = authoredNodeSchemas()
+  const migrateKinds = ['door', 'window', 'stair', 'stair-segment', 'shelf', 'elevator']
+  const migrateBatch = Array.from({ length: MIGRATE_NODES }, (_, index) => {
+    const kind = migrateKinds[index % migrateKinds.length] as string
+    return { kind, node: { ...(fixtures.get(kind as AnyNodeType) as Record<string, unknown>) } }
+  })
+  assertParses(
+    'site B',
+    migrateBatch.map(({ node }) => node),
+  )
+
+  // Site C — the store re-parses on every create and every update, so a drag
+  // emits one parse per pointer move.
+  const DRAG_MOVES = 200
+  const dragNode = { ...(fixtures.get('wall') as Record<string, unknown>), id: 'wall_bench' }
+  assertParses('site C', [dragNode])
+
+  const siteA = () => {
+    for (const node of createBatch) parseNode(node)
+  }
+  const siteB = () => {
+    for (const { kind, node } of migrateBatch) {
+      const schema = authored.get(kind)
+      if (schema) compiledNodeSchema(schema).safeParse(node)
+    }
+  }
+  const siteC = () => {
+    for (let move = 0; move < DRAG_MOVES; move++) {
+      parseNode({ ...dragNode, start: [move / 100, 0], end: [4 + move / 100, 0] })
+    }
+  }
+
+  // Interpreted first: the flag is off, so every helper takes its current path.
+  const interpreted = {
+    a: measure(siteA, 200),
+    b: measure(siteB, 200),
+    c: measure(siteC, 100),
+  }
+
+  enableCompiledNodeParsers()
+  siteA()
+  siteB()
+  siteC()
+  const compiled = {
+    a: measure(siteA, 200),
+    b: measure(siteB, 200),
+    c: measure(siteC, 100),
+  }
+
+  return [
+    { site: `A: applyPatch, ${CREATE_BATCH} mixed creates`, ...pair(interpreted.a, compiled.a) },
+    { site: `B: scene load, ${MIGRATE_NODES} migrated nodes`, ...pair(interpreted.b, compiled.b) },
+    { site: `C: wall drag, ${DRAG_MOVES} updates`, ...pair(interpreted.c, compiled.c) },
+  ]
+}
+
+function pair(interpreted: number, compiled: number) {
+  return {
+    interpreted_us: round(interpreted),
+    compiled_us: round(compiled),
+    speedup: round(interpreted / compiled),
+  }
+}
+
+// ── child mode ──────────────────────────────────────────────────────────────
+
+const sectionArg = process.argv.indexOf('--section')
+if (sectionArg !== -1) {
+  const name = process.argv[sectionArg + 1]
+  const count = Number(process.argv[process.argv.indexOf('--count') + 1] ?? 0)
+  const run: Record<string, () => unknown> = {
+    mono: monomorphic,
+    mixed,
+    'compiled-union': compiledUnion,
+    'compile-cost': compileCost,
+    rss: () => rss(count),
+    sites,
+  }
+  const section = run[name ?? '']
+  if (!section) throw new Error(`unknown section "${name}"`)
+
+  console.log(JSON.stringify(section()))
+  process.exit(0)
+}
+
+// ── parent ──────────────────────────────────────────────────────────────────
+
+function child<T>(args: string[]): T {
+  const proc = Bun.spawnSync(['bun', 'run', import.meta.path, ...args])
+  if (proc.exitCode !== 0) {
+    console.error(proc.stderr.toString())
+    throw new Error(`bench child ${args.join(' ')} exited ${proc.exitCode}`)
+  }
+  const out = proc.stdout.toString().trim()
+  return JSON.parse(out.slice(out.lastIndexOf('\n') + 1))
+}
+
+console.log(`[bench] zod ${z.core.version.major}.${z.core.version.minor}.${z.core.version.patch}`)
+console.log(`[bench] ${NODE_KINDS.length} node kinds, ${ITERATIONS} iterations per measurement`)
+console.log('[bench] one child process per section\n')
+
+const mono = child<ReturnType<typeof monomorphic>>(['--section', 'mono'])
+console.log('── 1. warm monomorphic parse (µs/parse, one kind per call site) ──')
+console.table([...mono.rows].sort((a, b) => b.union_us - a.union_us).slice(0, 12))
+console.log('speedup vs union parse:', mono.vs_union)
+console.log('speedup vs per-kind interpreted:', mono.vs_interpreted)
+
+const mixedResult = child<ReturnType<typeof mixed>>(['--section', 'mixed'])
+const unionResult = child<ReturnType<typeof compiledUnion>>(['--section', 'compiled-union'])
+console.log('\n── 2. mixed all-48-kinds loop (µs/parse, megamorphic call site) ──')
+console.table([
+  {
+    ...mixedResult,
+    compiled_union_us: unionResult.mixed_us,
+    per_kind_vs_union: round(mixedResult.union_us / mixedResult.compiled_per_kind_us),
+    per_kind_vs_compiled_union: round(unionResult.mixed_us / mixedResult.compiled_per_kind_us),
+  },
+])
+console.log('compiling the union instead of per kind:', unionResult)
+
+console.log('\n── 3. first-parse compile cost per kind (ms) ──')
+console.log(child(['--section', 'compile-cost']))
+
+const rssRows: { kinds_compiled: number; rss_mb: number; delta_mb: number }[] = []
+let baseline = 0
+for (const count of [0, 1, 5, NODE_KINDS.length]) {
+  const result = child<{ rss: number }>(['--section', 'rss', '--count', String(count)])
+  if (count === 0) baseline = result.rss
+  rssRows.push({
+    kinds_compiled: count,
+    rss_mb: round(result.rss / 1024 / 1024, 1),
+    delta_mb: round((result.rss - baseline) / 1024 / 1024, 1),
+  })
+}
+console.log('\n── 4. RSS after compiling N kinds (fresh process each) ──')
+console.table(rssRows)
+
+console.log('\n── 5. wired call sites, end to end (µs per batch) ──')
+console.table(child(['--section', 'sites']))

--- a/packages/core/src/schema/__fixtures__/node-fixtures.ts
+++ b/packages/core/src/schema/__fixtures__/node-fixtures.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod'
+import * as schema from '../index'
+import { AnyNode, type AnyNodeType, nodeKindOf } from '../types'
+
+/**
+ * Minimal valid instances of every node kind, built from the kinds' own
+ * schemas. Shared by the `AnyNode` contract test, the compiled-parser parity
+ * test, and the schema bench so all three cover the same 48 kinds without
+ * three copies of the table drifting apart.
+ */
+
+/** Fields a kind requires beyond the defaults its own schema fills in. */
+export const NODE_REQUIRED_FIELDS: Record<string, Record<string, unknown>> = {
+  ceiling: {
+    polygon: [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+    ],
+  },
+  'duct-segment': {
+    path: [
+      [0, 0, 0],
+      [1, 0, 0],
+    ],
+  },
+  fence: { start: [0, 0], end: [4, 0] },
+  guide: { url: 'asset://guide.png' },
+  item: {
+    asset: {
+      id: 'asset-1',
+      category: 'furniture',
+      name: 'Chair',
+      thumbnail: 'asset://chair.png',
+      src: 'asset://chair.glb',
+    },
+  },
+  lineset: {
+    path: [
+      [0, 0, 0],
+      [1, 0, 0],
+    ],
+  },
+  'liquid-line': {
+    path: [
+      [0, 0, 0],
+      [1, 0, 0],
+    ],
+  },
+  measurement: {
+    measurement: {
+      kind: 'distance',
+      points: [
+        [0, 0, 0],
+        [1, 0, 0],
+      ],
+    },
+  },
+  'pipe-segment': {
+    path: [
+      [0, 0, 0],
+      [1, 0, 0],
+    ],
+  },
+  slab: {
+    polygon: [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+    ],
+  },
+  wall: { start: [0, 0], end: [4, 0] },
+  zone: {
+    name: 'Kitchen',
+    polygon: [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+    ],
+  },
+}
+
+/** Every kind `AnyNode` discriminates on. */
+export const NODE_KINDS: AnyNodeType[] = AnyNode.options.map(nodeKindOf)
+
+/** A node schema as authored — discriminator still wrapped by `nodeType()`. */
+export type AuthoredNodeSchema = z.ZodObject<
+  { type: z.ZodDefault<z.ZodLiteral<string>> } & z.core.$ZodLooseShape
+>
+
+export function isAuthoredNodeSchema(value: unknown): value is AuthoredNodeSchema {
+  if (!(value instanceof z.ZodObject)) return false
+  const discriminator = (value.shape as Record<string, unknown>).type
+  return discriminator instanceof z.ZodDefault && discriminator.unwrap() instanceof z.ZodLiteral
+}
+
+let authored: Map<string, AuthoredNodeSchema> | undefined
+
+/** kind → the per-kind schema the package exports, keyed off its own default. */
+export function authoredNodeSchemas(): Map<string, AuthoredNodeSchema> {
+  if (authored) return authored
+
+  authored = new Map()
+  for (const exported of Object.values(schema)) {
+    if (!isAuthoredNodeSchema(exported)) continue
+    authored.set(exported.shape.type.unwrap().value, exported)
+  }
+  return authored
+}
+
+let fixtures: Map<AnyNodeType, Record<string, unknown>> | undefined
+
+/**
+ * kind → a minimal valid node with every schema default materialized.
+ *
+ * Always parsed through the raw authored schema, which `z.compile` leaves
+ * untouched (it returns a clone), so the fixtures are an interpreted baseline
+ * regardless of whether compiled parsers are enabled.
+ */
+export function nodeFixtures(): Map<AnyNodeType, Record<string, unknown>> {
+  if (fixtures) return fixtures
+
+  const schemas = authoredNodeSchemas()
+  fixtures = new Map()
+  for (const kind of NODE_KINDS) {
+    const perKind = schemas.get(kind)
+    if (!perKind) throw new Error(`no per-kind schema exported for "${kind}"`)
+
+    const parsed = perKind.safeParse({ ...NODE_REQUIRED_FIELDS[kind] })
+    if (!parsed.success) {
+      throw new Error(
+        `fixture for "${kind}" does not satisfy its own schema: ${parsed.error.message}`,
+      )
+    }
+    fixtures.set(kind, parsed.data as Record<string, unknown>)
+  }
+  return fixtures
+}

--- a/packages/core/src/schema/compiled-node-parsers.test.ts
+++ b/packages/core/src/schema/compiled-node-parsers.test.ts
@@ -1,0 +1,311 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { z } from 'zod'
+import { authoredNodeSchemas, NODE_KINDS, nodeFixtures } from './__fixtures__/node-fixtures'
+import {
+  compiledNodeParsersEnabled,
+  compiledNodeSchema,
+  enableCompiledNodeParsers,
+  nodeSchemaForKind,
+} from './compiled-node-parsers'
+import { AnyNode, type AnyNodeOption, type AnyNodeType, nodeKindOf } from './types'
+
+/**
+ * The compiled lane is only safe if it is *invisible*: for every node kind a
+ * compiled parser must return the same value on valid input and the same issues
+ * on invalid input as the interpreted schema it clones. These tests assert that
+ * across all 48 kinds, in both flag states, and under `jitless` (the CSP
+ * profile) where compilation must silently decline.
+ */
+
+const fixtures = nodeFixtures()
+const authoredByKind = authoredNodeSchemas()
+const optionByKind = new Map<AnyNodeType, AnyNodeOption>(
+  AnyNode.options.map((option) => [nodeKindOf(option), option]),
+)
+
+/** Mutations of a valid fixture that every kind rejects, via its `BaseNode` fields. */
+function invalidVariants(fixture: Record<string, unknown>): { label: string; value: unknown }[] {
+  return [
+    { label: 'id: number', value: { ...fixture, id: 42 } },
+    { label: 'visible: string', value: { ...fixture, visible: 'yes' } },
+    { label: 'parentId: number', value: { ...fixture, parentId: 7 } },
+    { label: 'metadata: string', value: { ...fixture, metadata: 'nope' } },
+    { label: 'object: wrong literal', value: { ...fixture, object: 'not-a-node' } },
+    { label: 'name: number', value: { ...fixture, name: 5 } },
+    { label: 'root: null', value: null },
+    { label: 'root: number', value: 42 },
+    { label: 'root: array', value: [] },
+  ]
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Deep equality that also pins the own-key list, in order.
+ *
+ * `toEqual` ignores keys whose value is `undefined`, but the store depends on
+ * their presence: `wall.height` and `stair.totalRise` encode a mode by key
+ * absence, and `safeParse` echoing an explicit `key: undefined` is what
+ * `mergeNodeUpdate`/`normalizeStairNode` compensate for. Key *order* is pinned
+ * too so a compiled parser can't silently change a node's serialized form.
+ */
+function expectSameValue(actual: unknown, expected: unknown, path = '$'): void {
+  if (isPlainRecord(expected)) {
+    expect(isPlainRecord(actual), `${path}: expected a plain object`).toBe(true)
+    const actualRecord = actual as Record<string, unknown>
+    expect(Object.keys(actualRecord), `${path}: own keys`).toEqual(Object.keys(expected))
+    for (const key of Object.keys(expected)) {
+      expectSameValue(actualRecord[key], expected[key], `${path}.${key}`)
+    }
+    return
+  }
+
+  if (Array.isArray(expected)) {
+    expect(Array.isArray(actual), `${path}: expected an array`).toBe(true)
+    const actualArray = actual as unknown[]
+    expect(actualArray.length, `${path}: length`).toBe(expected.length)
+    for (const [index, item] of expected.entries()) {
+      expectSameValue(actualArray[index], item, `${path}[${index}]`)
+    }
+    return
+  }
+
+  expect(Object.is(actual, expected), `${path}: ${String(actual)} !== ${String(expected)}`).toBe(
+    true,
+  )
+}
+
+describe('compiled node parsers — flag off', () => {
+  test('is off by default', () => {
+    expect(compiledNodeParsersEnabled()).toBe(false)
+  })
+
+  test('hands back the very schema it was given', () => {
+    for (const kind of NODE_KINDS) {
+      const authored = authoredByKind.get(kind)
+      const option = optionByKind.get(kind)
+      expect(compiledNodeSchema(authored as never)).toBe(authored)
+      expect(nodeSchemaForKind(kind)).toBe(option)
+    }
+  })
+})
+
+describe('compiled node parsers — lookup contract', () => {
+  test('returns null for anything the union does not discriminate on', () => {
+    expect(nodeSchemaForKind('not-a-node')).toBeNull()
+    expect(nodeSchemaForKind(undefined)).toBeNull()
+    expect(nodeSchemaForKind(null)).toBeNull()
+    expect(nodeSchemaForKind(42)).toBeNull()
+    expect(nodeSchemaForKind({ type: 'wall' })).toBeNull()
+    // A prototype key must not resolve to a schema.
+    expect(nodeSchemaForKind('toString')).toBeNull()
+    expect(nodeSchemaForKind('__proto__')).toBeNull()
+  })
+
+  test('covers every union kind', () => {
+    const missing = NODE_KINDS.filter((kind) => nodeSchemaForKind(kind) === null)
+    expect(missing).toEqual([])
+  })
+})
+
+describe('compiled node parsers — flag on', () => {
+  beforeAll(() => {
+    enableCompiledNodeParsers()
+  })
+  afterAll(() => {
+    enableCompiledNodeParsers(false)
+  })
+
+  test('is on', () => {
+    expect(compiledNodeParsersEnabled()).toBe(true)
+  })
+
+  test('memoizes one compiled clone per schema', () => {
+    const first = nodeSchemaForKind('wall')
+    expect(nodeSchemaForKind('wall')).toBe(first)
+    expect(first).not.toBe(optionByKind.get('wall'))
+  })
+
+  test('leaves the interpreted schema instance untouched', () => {
+    const option = optionByKind.get('wall') as AnyNodeOption
+    nodeSchemaForKind('wall')
+    // `z.compile` clones; the original must still be the union's member.
+    expect(AnyNode.options.includes(option)).toBe(true)
+    expect(option.safeParse(fixtures.get('wall')).success).toBe(true)
+  })
+
+  test('every kind actually compiles', () => {
+    // A kind that comes back identical means `z.compile` declined it. That is
+    // safe but silently drops the whole point, so surface it here instead.
+    const declined = NODE_KINDS.filter((kind) => nodeSchemaForKind(kind) === optionByKind.get(kind))
+    expect(declined).toEqual([])
+  })
+
+  test.each(NODE_KINDS)('%s: compiled output matches interpreted', (kind) => {
+    const interpreted = optionByKind.get(kind) as AnyNodeOption
+    const compiled = nodeSchemaForKind(kind) as AnyNodeOption
+    const fixture = fixtures.get(kind) as Record<string, unknown>
+
+    const viaInterpreted = interpreted.safeParse(fixture)
+    const viaCompiled = compiled.safeParse(fixture)
+
+    expect(viaInterpreted.success).toBe(true)
+    expect(viaCompiled.success).toBe(true)
+    expectSameValue(viaCompiled.data, viaInterpreted.data)
+  })
+
+  test.each(NODE_KINDS)('%s: compiled errors match interpreted', (kind) => {
+    const interpreted = optionByKind.get(kind) as AnyNodeOption
+    const compiled = nodeSchemaForKind(kind) as AnyNodeOption
+    const fixture = fixtures.get(kind) as Record<string, unknown>
+
+    for (const { label, value } of invalidVariants(fixture)) {
+      const viaInterpreted = interpreted.safeParse(value)
+      const viaCompiled = compiled.safeParse(value)
+
+      expect(viaInterpreted.success, `${kind} / ${label}: fixture must be rejected`).toBe(false)
+      expect(viaCompiled.success, `${kind} / ${label}`).toBe(false)
+      expect(viaCompiled.error?.issues, `${kind} / ${label}: issues`).toEqual(
+        viaInterpreted.error?.issues,
+      )
+      expect(viaCompiled.error?.message, `${kind} / ${label}: message`).toBe(
+        viaInterpreted.error?.message,
+      )
+    }
+  })
+
+  // Site A surfaces `error.message` to the MCP caller and sites A/C swap the
+  // union parse for a per-kind parse, so the two must report failures the same.
+  test.each(NODE_KINDS)('%s: per-kind errors match the union', (kind) => {
+    const compiled = nodeSchemaForKind(kind) as AnyNodeOption
+    const fixture = fixtures.get(kind) as Record<string, unknown>
+
+    for (const { label, value } of invalidVariants(fixture)) {
+      if (!isPlainRecord(value)) continue // a non-object root can only reach the union
+
+      const viaUnion = AnyNode.safeParse(value)
+      const viaCompiled = compiled.safeParse(value)
+
+      expect(viaUnion.success, `${kind} / ${label}`).toBe(false)
+      expect(viaCompiled.error?.issues, `${kind} / ${label}: issues`).toEqual(
+        viaUnion.error?.issues,
+      )
+      expect(viaCompiled.error?.message, `${kind} / ${label}: message`).toBe(
+        viaUnion.error?.message,
+      )
+    }
+  })
+
+  test.each(NODE_KINDS)('%s: compiled output matches the union', (kind) => {
+    const compiled = nodeSchemaForKind(kind) as AnyNodeOption
+    const fixture = fixtures.get(kind) as Record<string, unknown>
+
+    expectSameValue(compiled.safeParse(fixture).data, AnyNode.safeParse(fixture).data)
+  })
+
+  // `normalizeStairNode` strips `totalRise` back off precisely because
+  // `safeParse` echoes the explicit-undefined key it was handed. The compiled
+  // parser has to echo it too, or absence would start meaning something else.
+  test('echoes explicit-undefined keys like the interpreter', () => {
+    const authored = authoredByKind.get('stair')
+    if (!authored) throw new Error('no stair schema')
+    const compiled = compiledNodeSchema(authored as never) as typeof authored
+
+    const withUndefined = { ...(fixtures.get('stair') as Record<string, unknown>) }
+    withUndefined.totalRise = undefined
+
+    const viaInterpreted = authored.safeParse(withUndefined)
+    const viaCompiled = compiled.safeParse(withUndefined)
+
+    expect(viaInterpreted.success).toBe(true)
+    expect(viaCompiled.success).toBe(true)
+    expect('totalRise' in (viaInterpreted.data as object)).toBe(true)
+    expectSameValue(viaCompiled.data, viaInterpreted.data)
+  })
+
+  // Site B compiles the *authored* schemas, whose discriminator keeps its
+  // `.default()`, so `type` may be absent from the input.
+  test.each(NODE_KINDS)('%s: authored schema compiles and fills its own type', (kind) => {
+    const authored = authoredByKind.get(kind)
+    if (!authored) throw new Error(`no per-kind schema exported for "${kind}"`)
+    const compiled = compiledNodeSchema(authored as never) as typeof authored
+
+    const typeless = { ...(fixtures.get(kind) as Record<string, unknown>) }
+    delete typeless.type
+
+    const viaInterpreted = authored.safeParse(typeless)
+    const viaCompiled = compiled.safeParse(typeless)
+
+    expect(viaInterpreted.success).toBe(true)
+    expect(viaCompiled.success).toBe(true)
+    expect((viaCompiled.data as { type?: string }).type).toBe(kind)
+    expectSameValue(viaCompiled.data, viaInterpreted.data)
+  })
+})
+
+describe('compiled node parsers — jitless (CSP) profile', () => {
+  // `z.config({ jitless: true })` is the switch a CSP-restricted embedder sets,
+  // and zod's `allowsEval` probe is one-shot per process — so this has to run in
+  // a fresh one, with the config set before any schema module is imported.
+  test('declines to compile and keeps parsing correctly', () => {
+    const dir = import.meta.dir
+    const source = `
+      import { z } from 'zod'
+      z.config({ jitless: true })
+
+      const parsers = await import(${JSON.stringify(`${dir}/compiled-node-parsers.ts`)})
+      const fx = await import(${JSON.stringify(`${dir}/__fixtures__/node-fixtures.ts`)})
+      const { AnyNode, nodeKindOf } = await import(${JSON.stringify(`${dir}/types.ts`)})
+
+      parsers.enableCompiledNodeParsers()
+
+      const optionByKind = new Map(AnyNode.options.map((o) => [nodeKindOf(o), o]))
+      const fixtures = fx.nodeFixtures()
+      const compiledAnyway = []
+      const parseFailures = []
+
+      for (const kind of fx.NODE_KINDS) {
+        const option = optionByKind.get(kind)
+        if (parsers.nodeSchemaForKind(kind) !== option) compiledAnyway.push(kind)
+
+        const authored = fx.authoredNodeSchemas().get(kind)
+        if (parsers.compiledNodeSchema(authored) !== authored) compiledAnyway.push(kind + ' (authored)')
+
+        if (!parsers.nodeSchemaForKind(kind).safeParse(fixtures.get(kind)).success) {
+          parseFailures.push(kind)
+        }
+      }
+
+      console.log(JSON.stringify({
+        allowsEval: z.core.util.allowsEval.value,
+        enabled: parsers.compiledNodeParsersEnabled(),
+        kinds: fx.NODE_KINDS.length,
+        compiledAnyway,
+        parseFailures,
+      }))
+    `
+
+    const proc = Bun.spawnSync(['bun', '-e', source], { cwd: dir })
+    const stdout = proc.stdout.toString().trim()
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0)
+
+    const result = JSON.parse(stdout.slice(stdout.lastIndexOf('{')))
+    expect(result.allowsEval).toBe(false)
+    expect(result.enabled).toBe(true)
+    expect(result.kinds).toBe(NODE_KINDS.length)
+    expect(result.compiledAnyway).toEqual([])
+    expect(result.parseFailures).toEqual([])
+  }, 60_000)
+})
+
+describe('zod compile contract', () => {
+  // The whole design rests on `z.compile` never throwing and never mutating its
+  // input. Pin both so a zod bump that changes either fails here, not in prod.
+  test('declines unsupported schemas without throwing', () => {
+    const cyclic: z.ZodType = z.lazy(() => z.object({ next: cyclic.optional() }))
+    expect(z.compile(cyclic)).toBe(cyclic)
+    expect(() => z.compile(cyclic, { strict: true })).toThrow()
+  })
+})

--- a/packages/core/src/schema/compiled-node-parsers.ts
+++ b/packages/core/src/schema/compiled-node-parsers.ts
@@ -1,0 +1,107 @@
+import z from 'zod'
+import { AnyNode, type AnyNodeOption, nodeKindOf } from './types'
+
+/**
+ * AOT-compiled per-kind node parsers.
+ *
+ * `z.compile()` trades a one-off codegen pass for a faster warm parse. Two
+ * properties of that trade decide the shape of this module:
+ *
+ * - **Per kind, never the union.** One compiled function covering all 48
+ *   `AnyNode` members is megamorphic at the call site and can run slower than
+ *   the interpreter. Each kind gets its own compiled clone instead, and
+ *   dispatch stays a `Map` lookup on the discriminator.
+ * - **Lazily.** Compiling every kind up front pays codegen for kinds a session
+ *   never touches and retains their generated code for the process lifetime. A
+ *   kind is compiled on its first parse and only then.
+ *
+ * Off by default; a host opts in via {@link enableCompiledNodeParsers}. While
+ * off — and in any environment without a usable `Function` constructor (a
+ * CSP-restricted embedder) or with `z.config({ jitless: true })` set — every
+ * entry point returns the interpreted schema it was handed, so parses behave
+ * exactly as they do without this module.
+ */
+
+let enabled = false
+
+/**
+ * Opt this process into compiled per-kind node parsers. Call at host startup.
+ *
+ * Compiled and interpreted parsers agree on both successful output and error
+ * issues (`compiled-node-parsers.test.ts` asserts that for every node kind), so
+ * this only ever changes throughput.
+ */
+export function enableCompiledNodeParsers(value = true): void {
+  enabled = value
+}
+
+/** Whether {@link enableCompiledNodeParsers} is currently on. */
+export function compiledNodeParsersEnabled(): boolean {
+  return enabled
+}
+
+/**
+ * `z.core.util.allowsEval` is zod's own cached `new Function` probe. Reusing it
+ * rather than probing ourselves means a CSP-restricted page reports at most one
+ * `securitypolicyviolation` for the whole process, and `jitless` short-circuits
+ * before any probe runs at all.
+ */
+function canCompile(): boolean {
+  return z.core.util.allowsEval.value
+}
+
+const compiledBySchema = new WeakMap<z.ZodType, z.ZodType>()
+
+/**
+ * The compiled clone of a single node kind's schema, or `schema` itself when
+ * compilation is off or unavailable.
+ *
+ * Memoized per schema instance, so the codegen for a kind runs once per
+ * process. Never pass `AnyNode` — see the module note on megamorphism.
+ */
+export function compiledNodeSchema<T extends z.ZodType>(schema: T): T {
+  if (!(enabled && canCompile())) return schema
+
+  const memo = compiledBySchema.get(schema)
+  if (memo) return memo as T
+
+  // `z.compile` never throws by default: a schema its codegen cannot model
+  // comes back as the original, which memoizes as "do not try again".
+  const compiled = z.compile(schema)
+  compiledBySchema.set(schema, compiled)
+  return compiled
+}
+
+let optionsByKind: Map<string, AnyNodeOption> | undefined
+
+/**
+ * The `AnyNode` member that accepts `kind`, compiled when enabled.
+ *
+ * Returns `null` for anything the union does not discriminate on — an unknown
+ * kind, a plugin-registered kind, a missing or non-string `type`. Callers fall
+ * back to parsing the union so the failure path (and its `invalid_union` issue
+ * at `['type']`) stays byte-identical.
+ */
+export function nodeSchemaForKind(kind: unknown): AnyNodeOption | null {
+  if (typeof kind !== 'string') return null
+
+  optionsByKind ??= new Map(AnyNode.options.map((option) => [nodeKindOf(option), option]))
+  const option = optionsByKind.get(kind)
+
+  return option ? compiledNodeSchema(option) : null
+}
+
+/**
+ * Parse a node against the member for its own `type`, or against the whole
+ * union when the kind is one `AnyNode` does not discriminate on.
+ *
+ * Drop-in for `AnyNode.safeParse(node)`: a discriminated union delegates to the
+ * member anyway, so success values and failure issues are the same either way —
+ * and the union fallback keeps the `invalid_union` issue at `['type']` for a
+ * missing, unknown, or plugin-registered kind.
+ */
+export function parseNode(node: unknown): z.ZodSafeParseResult<AnyNode> {
+  const schema = nodeSchemaForKind((node as { type?: unknown } | null | undefined)?.type)
+
+  return (schema ?? AnyNode).safeParse(node) as z.ZodSafeParseResult<AnyNode>
+}

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -13,6 +13,12 @@ export { BaseNode, generateId, Material, nodeType, objectId } from './base'
 export { CameraSchema } from './camera'
 // Collections
 export { type Collection, type CollectionId, generateCollectionId } from './collections'
+// Compiled per-kind parsers (opt-in)
+export {
+  compiledNodeParsersEnabled,
+  enableCompiledNodeParsers,
+  parseNode,
+} from './compiled-node-parsers'
 export type {
   MaterialMapProperties,
   MaterialMaps,

--- a/packages/core/src/schema/node-union.test.ts
+++ b/packages/core/src/schema/node-union.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { z } from 'zod'
+import { authoredNodeSchemas, NODE_KINDS, NODE_REQUIRED_FIELDS } from './__fixtures__/node-fixtures'
 import { nodeType } from './base'
-import * as schema from './index'
 import { AnyNode, type AnyNodeOption, nodeKindOf, nodeUnion } from './types'
 
 /**
@@ -13,96 +13,7 @@ import { AnyNode, type AnyNodeOption, nodeKindOf, nodeUnion } from './types'
  * tests fail in CI if the projection regresses or a zod upgrade breaks it.
  */
 
-const UNION_KINDS = AnyNode.options.map(nodeKindOf)
-
-/** Fields a kind requires beyond the defaults its own schema fills in. */
-const REQUIRED_FIELDS: Record<string, Record<string, unknown>> = {
-  ceiling: {
-    polygon: [
-      [0, 0],
-      [4, 0],
-      [4, 4],
-    ],
-  },
-  'duct-segment': {
-    path: [
-      [0, 0, 0],
-      [1, 0, 0],
-    ],
-  },
-  fence: { start: [0, 0], end: [4, 0] },
-  guide: { url: 'asset://guide.png' },
-  item: {
-    asset: {
-      id: 'asset-1',
-      category: 'furniture',
-      name: 'Chair',
-      thumbnail: 'asset://chair.png',
-      src: 'asset://chair.glb',
-    },
-  },
-  lineset: {
-    path: [
-      [0, 0, 0],
-      [1, 0, 0],
-    ],
-  },
-  'liquid-line': {
-    path: [
-      [0, 0, 0],
-      [1, 0, 0],
-    ],
-  },
-  measurement: {
-    measurement: {
-      kind: 'distance',
-      points: [
-        [0, 0, 0],
-        [1, 0, 0],
-      ],
-    },
-  },
-  'pipe-segment': {
-    path: [
-      [0, 0, 0],
-      [1, 0, 0],
-    ],
-  },
-  slab: {
-    polygon: [
-      [0, 0],
-      [4, 0],
-      [4, 4],
-    ],
-  },
-  wall: { start: [0, 0], end: [4, 0] },
-  zone: {
-    name: 'Kitchen',
-    polygon: [
-      [0, 0],
-      [4, 0],
-      [4, 4],
-    ],
-  },
-}
-
-/** Node schemas as authored — discriminator still wrapped by `nodeType()`. */
-type AuthoredNode = z.ZodObject<
-  { type: z.ZodDefault<z.ZodLiteral<string>> } & z.core.$ZodLooseShape
->
-
-function isAuthoredNode(value: unknown): value is AuthoredNode {
-  if (!(value instanceof z.ZodObject)) return false
-  const discriminator = (value.shape as Record<string, unknown>).type
-  return discriminator instanceof z.ZodDefault && discriminator.unwrap() instanceof z.ZodLiteral
-}
-
-/** kind → the per-kind schema the package exports, keyed off its own default. */
-const authoredByKind = new Map<string, AuthoredNode>()
-for (const exported of Object.values(schema)) {
-  if (!isAuthoredNode(exported)) continue
-  authoredByKind.set(exported.shape.type.unwrap().value, exported)
-}
+const authoredByKind = authoredNodeSchemas()
 
 describe('nodeUnion', () => {
   test('assembles a parsable union from nodeType() members', () => {
@@ -172,13 +83,13 @@ describe('AnyNode', () => {
   })
 
   test('exposes every union kind as a per-kind schema', () => {
-    const missing = UNION_KINDS.filter((kind) => !authoredByKind.has(kind))
+    const missing = NODE_KINDS.filter((kind) => !authoredByKind.has(kind))
     expect(missing).toEqual([])
   })
 
-  test('REQUIRED_FIELDS lists no kind outside the union', () => {
-    const stale = Object.keys(REQUIRED_FIELDS).filter(
-      (kind) => !UNION_KINDS.includes(kind as (typeof UNION_KINDS)[number]),
+  test('NODE_REQUIRED_FIELDS lists no kind outside the union', () => {
+    const stale = Object.keys(NODE_REQUIRED_FIELDS).filter(
+      (kind) => !NODE_KINDS.includes(kind as (typeof NODE_KINDS)[number]),
     )
     expect(stale).toEqual([])
   })
@@ -187,11 +98,11 @@ describe('AnyNode', () => {
   // authoring path has to keep working for every kind: parse a type-less
   // fixture through the per-kind schema (its `.default()` fills `type` in),
   // then parse that output through the union.
-  test.each(UNION_KINDS)('round-trips a %s through per-kind then union', (kind) => {
+  test.each(NODE_KINDS)('round-trips a %s through per-kind then union', (kind) => {
     const authored = authoredByKind.get(kind)
     if (!authored) throw new Error(`no per-kind schema exported for "${kind}"`)
 
-    const perKind = authored.safeParse({ ...REQUIRED_FIELDS[kind] })
+    const perKind = authored.safeParse({ ...NODE_REQUIRED_FIELDS[kind] })
     expect(perKind.error?.issues ?? []).toEqual([])
     expect((perKind.data as { type?: string } | undefined)?.type).toBe(kind)
 
@@ -203,6 +114,6 @@ describe('AnyNode', () => {
   test('nodeKindOf reads the kind off any option', () => {
     const options: AnyNodeOption[] = [...AnyNode.options]
     expect(new Set(options.map(nodeKindOf)).size).toBe(options.length)
-    expect(UNION_KINDS).toContain('wall')
+    expect(NODE_KINDS).toContain('wall')
   })
 })

--- a/packages/core/src/store/actions/node-actions.ts
+++ b/packages/core/src/store/actions/node-actions.ts
@@ -20,6 +20,7 @@ import {
   isDefaultDownspoutNode,
   isDefaultGutterNode,
   isDefaultRidgeVentNode,
+  parseNode,
   planAutomaticDownspouts,
   type RoofSegmentNode,
   resolveAutomaticDownspoutLength,
@@ -529,7 +530,7 @@ function warnSanitizedNodeMutation(
 
 function parseCreatedNode(node: AnyNode, parentId: AnyNodeId | null): AnyNode {
   const candidate = { ...node, parentId }
-  const parsed = AnyNodeSchema.safeParse(candidate)
+  const parsed = parseNode(candidate)
   if (parsed.success) return parsed.data
 
   const schema = getNodeSchemaForType(candidate.type)
@@ -559,7 +560,7 @@ function mergeNodeUpdate(currentNode: AnyNode, patch: Partial<AnyNode>): AnyNode
 
 function parseUpdatedNode(currentNode: AnyNode, data: Partial<AnyNode>): AnyNode {
   const candidate = mergeNodeUpdate(currentNode, data)
-  const parsed = AnyNodeSchema.safeParse(candidate)
+  const parsed = parseNode(candidate)
   if (parsed.success) return parsed.data
 
   const schema = getNodeSchemaForType(candidate.type)

--- a/packages/core/src/store/use-scene.ts
+++ b/packages/core/src/store/use-scene.ts
@@ -8,6 +8,7 @@ import { getNodePluginId, isNodeKindEnabled, nodeRegistry } from '../registry/re
 import { BuildingNode } from '../schema'
 import type { Collection, CollectionId } from '../schema/collections'
 import { generateCollectionId } from '../schema/collections'
+import { compiledNodeSchema } from '../schema/compiled-node-parsers'
 import { DoorNode as DoorNodeSchema } from '../schema/nodes/door'
 import {
   createDormerDefaultWindow,
@@ -124,7 +125,7 @@ function normalizeStairNode(node: Record<string, unknown>) {
     children: getStringArray(node.children),
   }
 
-  const parsed = StairNodeSchema.safeParse(sanitized)
+  const parsed = compiledNodeSchema(StairNodeSchema).safeParse(sanitized)
   if (!parsed.success) return null
   if (hasTotalRise) return parsed.data
   // Absent `totalRise` means "rise derives from the storey height" and must
@@ -149,12 +150,12 @@ function normalizeStairSegmentNode(node: Record<string, unknown>) {
     thickness: getFiniteNumber(node.thickness, 0.25),
   }
 
-  const parsed = StairSegmentNodeSchema.safeParse(sanitized)
+  const parsed = compiledNodeSchema(StairSegmentNodeSchema).safeParse(sanitized)
   return parsed.success ? parsed.data : null
 }
 
 function normalizeDoorNode(node: Record<string, unknown>) {
-  const parsed = DoorNodeSchema.safeParse(node)
+  const parsed = compiledNodeSchema(DoorNodeSchema).safeParse(node)
   return parsed.success ? { ...node, ...parsed.data } : null
 }
 
@@ -162,7 +163,7 @@ function normalizeDoorNode(node: Record<string, unknown>) {
 // `frameThickness`) load without it; the mesh builder then reads undefined and
 // throws every frame. Zod-parse on load so schema defaults land, like doors.
 function normalizeWindowNode(node: Record<string, unknown>) {
-  const parsed = WindowNodeSchema.safeParse(node)
+  const parsed = compiledNodeSchema(WindowNodeSchema).safeParse(node)
   return parsed.success ? { ...node, ...parsed.data } : null
 }
 
@@ -193,7 +194,7 @@ function normalizeShelfNode(node: Record<string, unknown>) {
     ),
   }
 
-  const parsed = ShelfNodeSchema.safeParse(sanitized)
+  const parsed = compiledNodeSchema(ShelfNodeSchema).safeParse(sanitized)
   return parsed.success ? parsed.data : null
 }
 
@@ -222,7 +223,7 @@ function normalizeElevatorNode(node: Record<string, unknown>) {
     dwellMs: getFiniteNumber(node.dwellMs, 1400),
   }
 
-  const parsed = ElevatorNodeSchema.safeParse(sanitized)
+  const parsed = compiledNodeSchema(ElevatorNodeSchema).safeParse(sanitized)
   return parsed.success ? parsed.data : null
 }
 

--- a/packages/mcp/src/bridge/scene-bridge.ts
+++ b/packages/mcp/src/bridge/scene-bridge.ts
@@ -3,7 +3,12 @@ import './node-shims'
 
 import type { SceneGraph } from '@pascal-app/core/clone-scene-graph'
 import type { AnyNode } from '@pascal-app/core/schema'
-import { type AnyNodeId, AnyNode as AnyNodeSchema, type AnyNodeType } from '@pascal-app/core/schema'
+import {
+  type AnyNodeId,
+  AnyNode as AnyNodeSchema,
+  type AnyNodeType,
+  parseNode,
+} from '@pascal-app/core/schema'
 // Per PLAN §0.6: `useScene` is the DEFAULT export from `@pascal-app/core/store`.
 import useScene from '@pascal-app/core/store'
 import type { SceneMeta } from '../storage/types'
@@ -351,7 +356,7 @@ export class SceneBridge {
       const p = patches[i]
       if (!p) throw new Error(`invalid patch: patches[${i}] is undefined`)
       if (p.op === 'create') {
-        const res = AnyNodeSchema.safeParse(p.node)
+        const res = parseNode(p.node)
         if (!res.success) {
           throw new Error(
             `invalid patch: patches[${i}] create node failed schema: ${res.error.message}`,


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in lane that runs node schema parses through `z.compile()` (zod 4.5's AOT codegen) **per node kind**, lazily, and wires it at the three long-lived call sites that re-parse the same handful of kinds for the lifetime of a tab.

Follow-up to #745 (projected discriminators, which made per-kind schemas addressable) and #746, whose `metadata` comment already recorded the motivation: `z.compile()` bought 1.0x with `z.json()` and 2.2x with the record.

### Design

**Per kind, never the union.** Compiling `AnyNode` itself is the trade this PR rejects — measured below: 41ms of codegen in one hit, and *no faster* than the per-kind map on mixed input (0.98x). Compiling all 48 kinds eagerly costs +44MB RSS. So it is one lazy `Map<nodeType, compiled>`, one clone per kind, populated on the first parse of that kind.

**Explicit `z.compile()` only.** No `import "zod/compile"` auto-mode anywhere — that hook is module-evaluation-order dependent. `z.compile()` returns a *clone*; the schema in `AnyNode.options` stays interpreted and untouched (asserted).

**Off by default.** `enableCompiledNodeParsers()` is a setter a host app calls at startup. With the flag off, `compiledNodeSchema(s) === s` by identity and `parseNode` is the union parse — byte-identical to today.

**CSP / capability safe.** The probe is `z.core.util.allowsEval` — zod's own one-shot cached `new Function` check. Reusing it (rather than probing ourselves) means a CSP-restricted page emits at most one `securitypolicyviolation` report for the whole process, and `z.config({ jitless: true })` short-circuits it *before* any probe runs, so no report at all. On refusal every schema stays interpreted, silently. `z.compile()` also never throws by default: a schema its codegen cannot model comes back as the original, which memoizes as "do not try again".

### Wired call sites

| | Where | Why it qualifies |
|---|---|---|
| A | `packages/mcp/src/bridge/scene-bridge.ts` — `applyPatch` `create` | Long-lived browser bridge; one parse per create patch, batches of tens |
| B | `packages/core/src/store/use-scene.ts` — `migrate*Node` (6 sites) | Per-node parse on every scene load, 6 kinds, monomorphic each |
| C | `packages/core/src/store/actions/node-actions.ts` — `parseCreatedNode` / `parseUpdatedNode` | One parse per create *and per update*, so a drag emits one per pointer move |

**C is in.** Its three parity risks were discharged rather than assumed:

1. *Union dispatch failure for unknown/missing `type`* — `parseNode` falls back to `AnyNode` on any lookup miss, so a missing, unknown, or plugin-registered kind keeps its exact `invalid_union` issue at `['type']`.
2. *The repair path* (`getNodeSchemaForType` + `sanitizeNumericValue`, which reads zod internals) is untouched and still reached identically; `parsed.error` was never read at either site.
3. *`.default()` materialization and explicit-`undefined` keys* — asserted equal for all 48 kinds including **key order**, because `mergeNodeUpdate` encodes a mode in key absence (`wall.height`, `stair.totalRise`). `toEqual` ignores `undefined`-valued keys, so the parity helper walks own-key lists in order instead.

Site B compiles the *authored* schemas it already imports (via `compiledNodeSchema`), not the projected union options, so `type`'s `.default()` still fills in. Sites A and C go through `parseNode`.

`validateScene` (`scene-bridge.ts:475`) is deliberately left interpreted: it is a whole-scene mixed-kind sweep, i.e. exactly the megamorphic shape that this design does not target.

## How to test

1. `cd packages/core && bun test src` — 1423 pass (251 of them the new parity suite, 8332 assertions).
2. `cd packages/core && bun run bench:schema` — reproduces the table below. Every section runs in its own child process; sharing one moved numbers by >10x run to run, because a resident generated function perturbs anything timed after it.
3. `cd packages/mcp && bun test src` (341 pass) and `cd packages/nodes && bun test src` (1830 pass, 1 skip).
4. `bun run check` (biome, 1960 files clean) and `bun run check-types` (11/11 turbo tasks).

## Bench

Bun 1.3.14, zod 4.5.4, 48 kinds, 10 000 iterations per measurement, warm.

**1 — warm monomorphic parse (µs/parse, one kind per call site).** The shape the flag exists for.

| kind | union | interpreted | compiled | vs interpreted | vs union |
|---|---|---|---|---|---|
| block | 9.12 | 8.37 | 3.73 | 2.24x | 2.45x |
| column | 4.45 | 3.97 | 0.95 | 4.18x | 4.68x |
| lean-to-extension | 3.42 | 2.85 | 0.84 | 3.39x | 4.07x |
| roof-segment | 2.67 | 1.93 | 0.58 | 3.33x | 4.60x |
| door | 2.20 | 2.02 | 0.65 | 3.11x | 3.38x |
| cabinet | 1.65 | 1.35 | 0.40 | 3.38x | 4.12x |

Across all 48 — **vs union**: min 1.85x, p50 3.38x, p95 4.77x, max 5.43x. **vs per-kind interpreted**: min 1.52x, p50 2.77x, p95 4.18x, max 5.55x.

**2 — mixed all-48-kinds loop (µs/parse, megamorphic).** The shape the flag does *not* target, plus the rejected control.

| union | per-kind interpreted | per-kind compiled | compiled union | per-kind vs union | per-kind vs compiled union |
|---|---|---|---|---|---|
| 6.25 | 4.32 | 2.93 | 2.86 | 2.13x | 0.98x |

Two readings worth flagging. First, the compiled lane still *wins* here (1.47x over per-kind interpreted) — the megamorphic-slowdown risk the design anticipated did not reproduce on Bun/JSC. Laziness is still the right default, but it is now justified by compile cost and RSS rather than by a mixed-input regression. Second, compiling the union is 0.98x — it buys nothing over the per-kind map while costing 41ms up front, which is the whole case for "never compile `AnyNode`".

**3 — first-parse compile cost per kind (ms).** min 0.24, p50 0.79, p95 2.42, max 3.69, **all 48 = 50.5ms**. Compiled union in one hit: 40.9ms.

**4 — RSS after compiling N kinds (fresh process each).**

| kinds compiled | RSS | delta |
|---|---|---|
| 0 | 102.7 MB | — |
| 1 | 102.9 MB | +0.1 MB |
| 5 | 115.4 MB | +12.7 MB |
| 48 | 146.5 MB | +43.8 MB |

**5 — wired call sites, end to end (µs per batch).**

| site | interpreted | compiled | speedup |
|---|---|---|---|
| A: `applyPatch`, 100 mixed creates | 568.65 | 218.09 | 2.61x |
| B: scene load, 100 migrated nodes | 142.53 | 52.09 | 2.74x |
| C: wall drag, 200 updates | 127.41 | 53.05 | 2.40x |

Bench fixtures are asserted to satisfy `AnyNode` before timing: a *failing* parse runs the compiled fast path and *then* the interpreter, so one invalid fixture silently understates the win. (This bit — `objectId(prefix)` uses a prefix that differs from the kind name for 7 kinds, so a naive `${kind}_bench` id invalidates them.)

**Chrome: pending.** No browser or Playwright harness exists in this repo and this PR does not add one. All numbers are Bun/JSC.

## Parity proof

`compiled-node-parsers.test.ts` — 251 tests, 8332 assertions:

- **flag off** — off by default; `compiledNodeSchema` and `nodeSchemaForKind` return the *same object* for all 48 kinds.
- **lookup contract** — `nodeSchemaForKind` returns `null` for `'not-a-node'`, `undefined`, `null`, `42`, an object, and the prototype-pollution probes `'toString'` / `'__proto__'`; non-null for every union kind.
- **flag on**, `test.each` over all 48 kinds × 4: compiled output ≡ interpreted output; compiled issues *and* `error.message` ≡ interpreted, over 9 invalid mutations per kind; per-kind errors ≡ union errors; compiled output ≡ union output. Plus: one clone memoized per schema, the interpreted instance still in `AnyNode.options`, explicit-`undefined` `totalRise` echoed identically, and the authored schema still filling its own `type` when `type` is deleted.
- **every kind actually compiles** — zero `z.compile` refusals on 4.5.4.
- **jitless (CSP) profile** — a child process sets `z.config({ jitless: true })` *before* importing the schema modules, enables the flag, and asserts `allowsEval === false`, zero schemas replaced (identity for both projected and authored), and zero parse failures.
- **zod compile contract** — a cyclic `z.lazy` schema returns itself from `z.compile()` and throws only under `{ strict: true }`, pinning the fallback behavior this utility relies on.

`node-union.test.ts` (58 pass) is unchanged in substance; its 48-kind fixture table moved to `src/schema/__fixtures__/node-fixtures.ts` so the #745 contract test, the parity suite, and the bench all cover the same kinds from one source.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core node validation on every create/update and MCP patch apply; behavior is guarded by default-off flag and large parity suite, but a compiled/interpreter mismatch would affect persisted node shape and error reporting.
> 
> **Overview**
> Adds an **opt-in** path that memoizes **per-kind** Zod parsers via `z.compile()`, with lazy compilation on first use and a union fallback when `type` is missing or unknown. The feature is **off by default**; hosts call `enableCompiledNodeParsers()` at startup to turn it on. When compilation is unavailable (CSP / `jitless`), helpers return the original interpreted schemas unchanged.
> 
> **Wiring:** `parseNode` replaces `AnyNode.safeParse` for MCP create patches and store create/update parsing; scene-load migrations use `compiledNodeSchema` on six authored node schemas. Shared `node-fixtures` centralize all 48 kinds for union tests, parity tests, and a new `bench:schema` harness.
> 
> **Tests** assert byte-identical success output, error issues/messages, key order, and explicit-`undefined` echoing across every kind, plus a jitless child-process check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad8744fc0ca3fdd0d485f2d5b0aa035ff9fd5ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->