### PR TITLE
viewer: re-resolve dangling library material refs; paint picker defaults to Pascal

### DIFF
--- a/packages/editor/src/components/ui/controls/material-picker.tsx
+++ b/packages/editor/src/components/ui/controls/material-picker.tsx
@@ -17,7 +17,7 @@ import { Plus } from 'lucide-react'
 import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { triggerSFX } from '../../../lib/sfx-bus'
 
-export type MaterialSourceFilter = 'all' | MaterialSource
+export type MaterialSourceFilter = MaterialSource
 
 export type MaterialPickerProps = {
   selectedMaterialPreset?: string
@@ -28,8 +28,9 @@ export type MaterialPickerProps = {
   onCreateMaterialRequest?: () => void
 }
 
+// No 'All': the browse surfaces (Items / Rooms / Build) dropped it and default
+// to the Pascal library — the combined list buried the curated set.
 const SOURCE_FILTERS: { id: MaterialSourceFilter; label: string }[] = [
-  { id: 'all', label: 'All' },
   { id: 'pascal', label: 'Pascal' },
   { id: 'mine', label: 'Mine' },
   { id: 'workspace', label: 'Workspace' },
@@ -41,7 +42,6 @@ function getCategoryLabel(category: (typeof MATERIAL_CATEGORIES)[number]) {
 }
 
 function filterBySource(items: MaterialCatalogItem[], filter: MaterialSourceFilter) {
-  if (filter === 'all') return items
   return items.filter((item) => (item.source ?? 'pascal') === filter)
 }
 
@@ -60,7 +60,7 @@ export function MaterialPicker({
   const [selectedCategory, setSelectedCategory] = useState<(typeof MATERIAL_CATEGORIES)[number]>(
     MATERIAL_CATEGORIES[0],
   )
-  const [sourceFilter, setSourceFilter] = useState<MaterialSourceFilter>('all')
+  const [sourceFilter, setSourceFilter] = useState<MaterialSourceFilter>('pascal')
   // Version counter so host registrations/unregistrations re-render the picker.
   const libraryVersion = useSyncExternalStore(
     subscribeLibraryMaterials,

--- a/packages/nodes/src/wall/renderer.tsx
+++ b/packages/nodes/src/wall/renderer.tsx
@@ -8,7 +8,13 @@ import {
   useScene,
   type WallNode,
 } from '@pascal-app/core'
-import { getVisibleWallMaterials, NodeRenderer, useNodeEvents, useViewer } from '@pascal-app/viewer'
+import {
+  getVisibleWallMaterials,
+  NodeRenderer,
+  useLibraryMaterialsVersion,
+  useNodeEvents,
+  useViewer,
+} from '@pascal-app/viewer'
 import { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import type { Mesh } from 'three'
 import { useShallow } from 'zustand/react/shallow'
@@ -124,6 +130,10 @@ const WallRenderer = ({ node }: { node: WallNode }) => {
   // dirty loop never fires for a material-only edit). `getMaterialsForWall`'s
   // content hash keeps unaffected walls on their cached materials.
   const sceneMaterials = useScene((s) => s.materials)
+  // Same for the dynamic library: AI-generated `library:mtl_*` presets
+  // register after mount, and a dangling ref cached as the slot default must
+  // re-resolve when they land.
+  const libraryMaterialsVersion = useLibraryMaterialsVersion()
   const baseMaterials = getVisibleWallMaterials(
     node,
     shading,
@@ -132,9 +142,10 @@ const WallRenderer = ({ node }: { node: WallNode }) => {
     sceneTheme,
     sceneMaterials,
   )
+  // biome-ignore lint/correctness/useExhaustiveDependencies: libraryMaterialsVersion invalidates the ref resolution inside createWallExtraSlotMaterials
   const extraMaterials = useMemo(
     () => createWallExtraSlotMaterials(node, shading, sceneMaterials),
-    [node, sceneMaterials, shading],
+    [node, sceneMaterials, shading, libraryMaterialsVersion],
   )
   useEffect(
     () => () => {

--- a/packages/viewer/src/hooks/use-library-materials-version.ts
+++ b/packages/viewer/src/hooks/use-library-materials-version.ts
@@ -1,0 +1,15 @@
+import { getLibraryMaterialsVersion, subscribeLibraryMaterials } from '@pascal-app/core'
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Re-render when dynamic library materials (un)register — AI-generated
+ * `library:mtl_*` presets arrive after mount, and material caches keyed on
+ * ref-resolution signatures must recompute once they land.
+ */
+export function useLibraryMaterialsVersion(): number {
+  return useSyncExternalStore(
+    subscribeLibraryMaterials,
+    getLibraryMaterialsVersion,
+    getLibraryMaterialsVersion,
+  )
+}

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -55,6 +55,7 @@ export {
 export { SceneEnvironment } from './components/viewer/scene-environment'
 export { useAssetUrl } from './hooks/use-asset-url'
 export { useGLTFKTX2 } from './hooks/use-gltf-ktx2'
+export { useLibraryMaterialsVersion } from './hooks/use-library-materials-version'
 export { useNodeEvents } from './hooks/use-node-events'
 export { ASSETS_CDN_URL, resolveAssetUrl, resolveCdnUrl } from './lib/asset-url'
 export { backdropGradient, deepSkyColor, horizonHazeColor } from './lib/backdrop'

--- a/packages/viewer/src/lib/materials.ts
+++ b/packages/viewer/src/lib/materials.ts
@@ -589,6 +589,17 @@ export function createMaterial(
 }
 
 /**
+ * Cache-signature fragment for a catalog preset ref. Dynamic library
+ * materials (AI-generated `library:mtl_*`) register asynchronously, so a ref
+ * that fails to resolve is NOT static content: tag it so signature-keyed
+ * material caches re-resolve once the library registers instead of pinning
+ * the dangling-ref fallback for the whole session.
+ */
+export function materialPresetRefSignature(ref: string): string {
+  return getMaterialPresetByRef(ref) ? ref : `${ref}#unresolved`
+}
+
+/**
  * Resolve a MaterialRef ('library:<id>' | 'scene:<id>') to a three.js material.
  * Returns null for an unknown / dangling ref so callers fall back to the
  * slot's default (authored material, then themed default). Never throws.

--- a/packages/viewer/src/systems/wall/wall-cutout.tsx
+++ b/packages/viewer/src/systems/wall/wall-cutout.tsx
@@ -1,6 +1,7 @@
 import {
   type AnyNodeId,
   emitter,
+  getLibraryMaterialsVersion,
   getWallFaceBandConfig,
   getWallPlaneTop,
   resolveLevelId,
@@ -111,6 +112,7 @@ export const WallCutout = () => {
     materials: null as object | null,
     shading: null as unknown,
     wallCount: -1,
+    libraryMaterialsVersion: -1,
   })
   const lastTextures = useRef(useViewer.getState().textures)
   const lastColorPreset = useRef(useViewer.getState().colorPreset)
@@ -160,17 +162,22 @@ export const WallCutout = () => {
     // face bands is a full-scene scan; its inputs are immutable store slices,
     // so identity is enough to know the key cannot have changed.
     const wallCount = sceneRegistry.byType.wall!.size
+    // Dynamic `library:mtl_*` materials register after mount; the version bump
+    // flips the `#unresolved` signature fragments so dangling paint re-resolves.
+    const libraryMaterialsVersion = getLibraryMaterialsVersion()
     const appearanceInputs = wallAppearanceInputs.current
     if (
       appearanceInputs.nodes !== sceneState.nodes ||
       appearanceInputs.materials !== sceneState.materials ||
       appearanceInputs.shading !== shading ||
-      appearanceInputs.wallCount !== wallCount
+      appearanceInputs.wallCount !== wallCount ||
+      appearanceInputs.libraryMaterialsVersion !== libraryMaterialsVersion
     ) {
       appearanceInputs.nodes = sceneState.nodes
       appearanceInputs.materials = sceneState.materials
       appearanceInputs.shading = shading
       appearanceInputs.wallCount = wallCount
+      appearanceInputs.libraryMaterialsVersion = libraryMaterialsVersion
       wallAppearanceKeyRef.current = Array.from(sceneRegistry.byType.wall!)
         .sort()
         .map((wallId) => {

--- a/packages/viewer/src/systems/wall/wall-materials.ts
+++ b/packages/viewer/src/systems/wall/wall-materials.ts
@@ -24,6 +24,7 @@ import {
   createMaterial,
   createMaterialFromPresetRef,
   createSurfaceRoleMaterial,
+  materialPresetRefSignature,
   type RenderShading,
   resolveMaterialRef,
   resolveSurfaceColor,
@@ -153,8 +154,10 @@ function resolveWallSlotMaterial(
 
 // Cache-key fragment for one face: the slot ref plus, for a `scene:` ref, the
 // referenced material's *content* — so editing a scene material assigned to a
-// wall invalidates the cache (a `library:` ref is static catalog content, so
-// its id alone is enough). Falls back to the legacy signature when unmigrated.
+// wall invalidates the cache. A `library:` ref carries its resolution state
+// instead: AI-generated materials register asynchronously, and a dangling ref
+// resolved to the slot default must not stay cached once the library lands.
+// Falls back to the legacy signature when unmigrated.
 function wallFaceMaterialSignature(
   wallNode: WallNode,
   side: WallSurfaceSide,
@@ -169,7 +172,7 @@ function wallFaceMaterialSignature(
         material: sceneMaterials?.[parsed.id as SceneMaterialId]?.material ?? null,
       })
     }
-    return JSON.stringify({ ref })
+    return JSON.stringify({ ref: materialPresetRefSignature(ref) })
   }
   return getWallSurfaceMaterialSignature(getEffectiveWallSurfaceMaterial(wallNode, side))
 }
@@ -188,7 +191,7 @@ function wallSlotMaterialSignature(
         material: sceneMaterials?.[parsed.id as SceneMaterialId]?.material ?? null,
       })
     }
-    return JSON.stringify({ ref })
+    return JSON.stringify({ ref: materialPresetRefSignature(ref) })
   }
 
   const side = getWallSurfaceSideFromBandSlot(slotId)


### PR DESCRIPTION
## What does this PR do?

Fixes the prod bug where walls painted with AI-generated materials looked unpainted after a reload. The paint was saved fine — the editor route resolved `library:mtl_*` refs through a client fetch that races the first render, and the wall material cache's signature assumed library refs are static catalog content, so a lost race pinned the slot-default fallback for the whole session.

- Library-ref cache signatures carry an `#unresolved` tag while the ref dangles; the wall renderer and cutout loop watch the dynamic library version, so a late registration flips the signature and recomputes the materials.
- The paint picker drops its combined "All" source tab and defaults to Pascal — parity with the Items / Rooms / Build browse surfaces.

The host-side half (serving referenced materials with the scene so registration precedes first render) lands in private-editor.

## How to test

1. `bun dev`, open a scene with walls painted from a dynamic library material (`library:mtl_*`).
2. Delay/skip the host's library registration (or register materials after first render): walls first show the default, then snap to the painted material as soon as `registerLibraryMaterials` runs — previously they stayed default until reload.
3. Open the paint panel: source tabs read Pascal / Mine / Community (no All), with Pascal preselected.

## Screenshots / screen recording

N/A — cache/resolution fix + a tab removal; behavior verified via the private-editor e2e paint specs.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wall material caching and per-frame cutout invalidation; behavior is localized but affects all wall rendering when dynamic library materials load asynchronously.
> 
> **Overview**
> Fixes walls that stay on the default finish when **`library:mtl_*`** presets register after the first paint resolve (e.g. reload races the dynamic library fetch). Library refs in wall material cache signatures now use **`materialPresetRefSignature`**, appending **`#unresolved`** until **`getMaterialPresetByRef`** succeeds, so a one-time fallback is not cached for the whole session.
> 
> **`useLibraryMaterialsVersion`** (viewer hook over **`subscribeLibraryMaterials`**) invalidates wall extra-slot materials in the node renderer and feeds **`WallCutout`**’s appearance key so batched wall meshes refresh when registration lands.
> 
> In the editor **`MaterialPicker`**, the combined **All** source tab is removed and the default filter is **Pascal**, matching Items / Rooms / Build browse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946f9cbf0926c840e6e4816f097a5f89ea35c263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->