### PR TITLE
editor: single-writer ToolMode FSM for mode/tool

### DIFF
--- a/packages/editor/src/components/editor/editor-layout-mobile.tsx
+++ b/packages/editor/src/components/editor/editor-layout-mobile.tsx
@@ -83,18 +83,18 @@ export function EditorLayoutMobile({
   //   desktop "Furnish" action which itself opens the Items panel).
   // - Leaving Items while still furnishing exits the build mode.
   useEffect(() => {
-    const { phase, mode, setMode, setPhase } = useEditor.getState()
+    const { armToolMode, phase, mode, setPhase } = useEditor.getState()
     if (activePanel === 'ai' && mode === 'build') {
-      setMode('select')
+      armToolMode({ mode: 'select' })
       return
     }
     if (activePanel === 'items') {
       if (phase !== 'furnish') setPhase('furnish')
-      if (mode !== 'build') setMode('build')
+      if (mode !== 'build') armToolMode({ mode: 'build', tool: 'item' })
       return
     }
     if (phase === 'furnish' && mode === 'build') {
-      setMode('select')
+      armToolMode({ mode: 'select' })
     }
   }, [activePanel])
 
@@ -160,9 +160,9 @@ export function EditorLayoutMobile({
       if (current > expandedThreshold) {
         sheetRef.current?.snapTo(SHEET_HANDLE_PX)
         // Closing the sheet disarms any build tool back to select
-        const { mode, setMode } = useEditor.getState()
+        const { armToolMode, mode } = useEditor.getState()
         if (mode === 'build') {
-          setMode('select')
+          armToolMode({ mode: 'select' })
         }
       } else {
         sheetRef.current?.snapTo(defaultPx)

--- a/packages/editor/src/components/editor/floorplan-panel.tsx
+++ b/packages/editor/src/components/editor/floorplan-panel.tsx
@@ -10551,9 +10551,11 @@ export function FloorplanPanel({
       }
 
       if (useEditor.getState().phase !== 'site') {
-        useEditor.setState({ catalogCategory: null, mode: 'select', phase: 'site', tool: null })
+        useEditor.getState().setPhase('site')
+        useEditor.getState().armToolMode({ mode: 'select' })
+      } else {
+        selectSiteFloorplanContext()
       }
-      selectSiteFloorplanContext()
 
       const nextDraft = {
         siteId,
@@ -10635,9 +10637,11 @@ export function FloorplanPanel({
       ]
 
       if (useEditor.getState().phase !== 'site') {
-        useEditor.setState({ catalogCategory: null, mode: 'select', phase: 'site', tool: null })
+        useEditor.getState().setPhase('site')
+        useEditor.getState().armToolMode({ mode: 'select' })
+      } else {
+        selectSiteFloorplanContext()
       }
-      selectSiteFloorplanContext()
 
       const nextDraft = {
         siteId,

--- a/packages/editor/src/components/ui/action-menu/control-modes.tsx
+++ b/packages/editor/src/components/ui/action-menu/control-modes.tsx
@@ -54,7 +54,7 @@ export function ControlModes() {
   const mode = useEditor((state) => state.mode)
   const phase = useEditor((state) => state.phase)
   const selectionTool = useEditor((state) => state.floorplanSelectionTool)
-  const setMode = useEditor((state) => state.setMode)
+  const armToolMode = useEditor((state) => state.armToolMode)
   const setPhase = useEditor((state) => state.setPhase)
   const setStructureLayer = useEditor((state) => state.setStructureLayer)
   const setSelectionTool = useEditor((state) => state.setFloorplanSelectionTool)
@@ -82,21 +82,21 @@ export function ControlModes() {
     }
 
     if (id === 'select') {
-      setMode('select')
+      armToolMode({ mode: 'select' })
       setSelectionTool('click')
     } else if (id === 'box-select') {
-      setMode('select')
+      armToolMode({ mode: 'select' })
       setSelectionTool('marquee')
     } else if (id === 'zone') {
       if (getIsActive('zone')) {
-        setMode('select')
+        armToolMode({ mode: 'select' })
       } else {
         setPhase('structure')
         setStructureLayer('zones')
-        setMode('build')
+        armToolMode({ mode: 'build', tool: 'zone' })
       }
     } else {
-      setMode(id)
+      armToolMode({ mode: id })
     }
   }
 

--- a/packages/editor/src/components/ui/command-palette/editor-commands.tsx
+++ b/packages/editor/src/components/ui/command-palette/editor-commands.tsx
@@ -49,10 +49,9 @@ export function EditorCommands() {
   const { navigateTo, setInputValue, setOpen } = useCommandPalette()
 
   const setPhase = useEditor((s) => s.setPhase)
-  const setMode = useEditor((s) => s.setMode)
-  const setTool = useEditor((s) => s.setTool)
+  const armToolMode = useEditor((s) => s.armToolMode)
+  const armMaterialPaint = useEditor((s) => s.armMaterialPaint)
   const setStructureLayer = useEditor((s) => s.setStructureLayer)
-  const primeMaterialPaintFromSelection = useEditor((s) => s.primeMaterialPaintFromSelection)
   const isPreviewMode = useEditor((s) => s.isPreviewMode)
   const setPreviewMode = useEditor((s) => s.setPreviewMode)
 
@@ -68,9 +67,9 @@ export function EditorCommands() {
     const activateTool = (tool: StructureTool) => {
       run(() => {
         setPhase('structure')
-        setMode('build')
         if (tool === 'zone') setStructureLayer('zones')
-        setTool(tool)
+        else setStructureLayer('elements')
+        armToolMode({ mode: 'build', tool })
       })
     }
 
@@ -163,10 +162,9 @@ export function EditorCommands() {
         shortcut: ['P'],
         execute: () =>
           run(() => {
-            primeMaterialPaintFromSelection()
             setPhase('structure')
             setStructureLayer('elements')
-            setMode('material-paint')
+            armMaterialPaint()
           }),
       },
       {
@@ -176,9 +174,8 @@ export function EditorCommands() {
         icon: <Mountain className="h-4 w-4" />,
         keywords: ['terrain', 'ground', 'elevation', 'sculpt', 'hill', 'slope', 'grade', 'dig'],
         shortcut: ['G'],
-        // No `setPhase`: `setMode` moves to the site phase itself, and doing it
-        // here would set the phase twice with a mode reset in between.
-        execute: () => run(() => setMode('terrain-sculpt')),
+        // The ToolMode transition moves to the site phase itself.
+        execute: () => run(() => armToolMode({ mode: 'terrain-sculpt' })),
       },
 
       // ── Levels ───────────────────────────────────────────────────────────
@@ -428,8 +425,8 @@ export function EditorCommands() {
     setInputValue,
     setOpen,
     setPhase,
-    setMode,
-    setTool,
+    armToolMode,
+    armMaterialPaint,
     setStructureLayer,
     isPreviewMode,
     setPreviewMode,

--- a/packages/editor/src/components/ui/controls/material-paint-panel.tsx
+++ b/packages/editor/src/components/ui/controls/material-paint-panel.tsx
@@ -35,7 +35,7 @@ export type MaterialPaintPanelProps = {
 export function MaterialPaintPanel({ onCreateMaterialRequest }: MaterialPaintPanelProps) {
   const activePaintMaterial = useEditor((state) => state.activePaintMaterial)
   const activePaintTarget = useEditor((state) => state.activePaintTarget)
-  const setActivePaintMaterial = useEditor((state) => state.setActivePaintMaterial)
+  const armMaterialPaint = useEditor((state) => state.armMaterialPaint)
   const setActivePaintTarget = useEditor((state) => state.setActivePaintTarget)
   const paintEraser = useEditor((state) => state.paintEraser)
   const setPaintEraser = useEditor((state) => state.setPaintEraser)
@@ -81,7 +81,7 @@ export function MaterialPaintPanel({ onCreateMaterialRequest }: MaterialPaintPan
         },
       },
     })
-    setActivePaintMaterial({ materialPreset: toSceneMaterialRef(id), sourceTarget: activePaintTarget })
+    armMaterialPaint({ materialPreset: toSceneMaterialRef(id), sourceTarget: activePaintTarget })
     setAutoEditMaterialId(id)
   }
 
@@ -118,7 +118,7 @@ export function MaterialPaintPanel({ onCreateMaterialRequest }: MaterialPaintPan
         <MaterialPicker
           onCreateMaterialRequest={onCreateMaterialRequest}
           onSelectMaterialPreset={(materialPreset) => {
-            setActivePaintMaterial({ materialPreset, sourceTarget: activePaintTarget })
+            armMaterialPaint({ materialPreset, sourceTarget: activePaintTarget })
           }}
           selectedMaterialPreset={activePaintMaterial?.materialPreset}
         />

--- a/packages/editor/src/components/ui/controls/scene-material-list.tsx
+++ b/packages/editor/src/components/ui/controls/scene-material-list.tsx
@@ -33,7 +33,7 @@ export function SceneMaterialList({ autoEditId }: { autoEditId?: SceneMaterialId
   const removeSceneMaterial = useScene((state) => state.removeSceneMaterial)
   const activePaintTarget = useEditor((state) => state.activePaintTarget)
   const activePaintRef = useEditor((state) => state.activePaintMaterial?.materialPreset)
-  const setActivePaintMaterial = useEditor((state) => state.setActivePaintMaterial)
+  const armMaterialPaint = useEditor((state) => state.armMaterialPaint)
 
   const materialEntries = useMemo(
     () => Object.entries(materials) as [SceneMaterialId, SceneMaterial][],
@@ -76,7 +76,7 @@ export function SceneMaterialList({ autoEditId }: { autoEditId?: SceneMaterialId
           key={id}
           removeSceneMaterial={removeSceneMaterial}
           sceneMaterial={sceneMaterial}
-          setActivePaintMaterial={setActivePaintMaterial}
+          armMaterialPaint={armMaterialPaint}
           updateSceneMaterial={updateSceneMaterial}
           usageCount={usageCounts.get(id) ?? 0}
         />
@@ -95,7 +95,7 @@ function SceneMaterialRow({
   addSceneMaterial,
   updateSceneMaterial,
   removeSceneMaterial,
-  setActivePaintMaterial,
+  armMaterialPaint,
 }: {
   id: SceneMaterialId
   sceneMaterial: SceneMaterial
@@ -106,7 +106,7 @@ function SceneMaterialRow({
   addSceneMaterial: ReturnType<typeof useScene.getState>['addSceneMaterial']
   updateSceneMaterial: ReturnType<typeof useScene.getState>['updateSceneMaterial']
   removeSceneMaterial: ReturnType<typeof useScene.getState>['removeSceneMaterial']
-  setActivePaintMaterial: ReturnType<typeof useEditor.getState>['setActivePaintMaterial']
+  armMaterialPaint: ReturnType<typeof useEditor.getState>['armMaterialPaint']
 }) {
   // A freshly-created material (via "+ Custom") mounts with its editor open.
   const [isEditingMaterial, setIsEditingMaterial] = useState(autoEdit)
@@ -175,7 +175,7 @@ function SceneMaterialRow({
               <Button
                 aria-label="Paint with"
                 onClick={() =>
-                  setActivePaintMaterial({
+                  armMaterialPaint({
                     materialPreset: toSceneMaterialRef(id),
                     sourceTarget: activePaintTarget,
                   })

--- a/packages/editor/src/hooks/use-keyboard.test.ts
+++ b/packages/editor/src/hooks/use-keyboard.test.ts
@@ -45,19 +45,19 @@ beforeEach(() => {
 
 afterEach(() => {
   useInteractionScope.getState().end()
-  useEditor.setState({ mode: 'select', tool: null })
+  useEditor.getState().armToolMode({ mode: 'select' })
   clearSceneHistory()
 })
 
 describe('rotation shortcut ownership', () => {
   test('leaves R and T to the active item placement tool', () => {
-    useEditor.setState({ mode: 'build', tool: 'item' })
+    useEditor.getState().armToolMode({ mode: 'build', tool: 'item' })
 
     expect(isToolOwnedRotation()).toBe(true)
   })
 
   test('leaves R and T to the active lean-to placement tool', () => {
-    useEditor.setState({ mode: 'build', tool: 'lean-to-extension' })
+    useEditor.getState().armToolMode({ mode: 'build', tool: 'lean-to-extension' })
 
     expect(isToolOwnedRotation()).toBe(true)
   })
@@ -76,10 +76,10 @@ describe('rotation shortcut ownership', () => {
   })
 
   test('leaves F to the active lean-to placement tool', () => {
-    useEditor.setState({ mode: 'build', tool: 'lean-to-extension' })
+    useEditor.getState().armToolMode({ mode: 'build', tool: 'lean-to-extension' })
 
     expect(isToolOwnedCanopyForm()).toBe(true)
-    useEditor.setState({ tool: 'wall' })
+    useEditor.getState().armToolMode({ mode: 'build', tool: 'wall' })
     expect(isToolOwnedCanopyForm()).toBe(false)
   })
 })

--- a/packages/editor/src/hooks/use-keyboard.ts
+++ b/packages/editor/src/hooks/use-keyboard.ts
@@ -117,10 +117,10 @@ const exitToSelectAfterUnconsumedCancel = () => {
   // From zone mode, return to structure select
   if (currentPhase === 'structure' && currentStructureLayer === 'zones') {
     useEditor.getState().setStructureLayer('elements')
-    useEditor.getState().setMode('select')
+    useEditor.getState().armToolMode({ mode: 'select' })
   } else {
     // Return to the default select tool while keeping the active building/level context.
-    useEditor.getState().setMode('select')
+    useEditor.getState().armToolMode({ mode: 'select' })
   }
 
   useEditor.getState().setFloorplanSelectionTool('click')
@@ -367,33 +367,28 @@ export const useKeyboard = ({
       } else if (e.key === '1' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
         useEditor.getState().setPhase('site')
-        useEditor.getState().setMode('select')
+        useEditor.getState().armToolMode({ mode: 'select' })
       } else if (e.key === '2' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
         useEditor.getState().setPhase('structure')
-        useEditor.getState().setMode('select')
+        useEditor.getState().armToolMode({ mode: 'select' })
       } else if (e.key === '3' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
         useEditor.getState().setPhase('furnish')
-        useEditor.getState().setMode('select')
+        useEditor.getState().armToolMode({ mode: 'select' })
       } else if (e.key === 'f' && !e.metaKey && !e.ctrlKey) {
         if (isVersionPreviewMode) return
         if (isToolOwnedCanopyForm()) return
         e.preventDefault()
         useEditor.getState().setPhase('furnish')
-        useEditor.getState().setMode('build')
-        // Set the item tool explicitly so the active tool never inherits a
-        // stale tool from a prior build session.
-        useEditor.getState().setTool('item')
+        useEditor.getState().armToolMode({ mode: 'build', tool: 'item' })
         useEditor.getState().setActiveSidebarPanel('items')
       } else if (e.key === 'z' && !e.metaKey && !e.ctrlKey) {
         if (isVersionPreviewMode) return
         e.preventDefault()
         useEditor.getState().setPhase('structure')
         useEditor.getState().setStructureLayer('zones')
-        useEditor.getState().setMode('build')
-        // Set the zone tool explicitly so it never inherits a stale tool.
-        useEditor.getState().setTool('zone')
+        useEditor.getState().armToolMode({ mode: 'build', tool: 'zone' })
       } else if (e.key === 'm' && !e.metaKey && !e.ctrlKey) {
         if (isVersionPreviewMode) return
         e.preventDefault()
@@ -401,39 +396,33 @@ export const useKeyboard = ({
         editor.setPhase('structure')
         editor.setStructureLayer('elements')
         editor.setToolDefaults('measurement', { kind: editor.lastMeasurementKind })
-        editor.setMode('build')
-        editor.setTool('measurement')
+        editor.armToolMode({ mode: 'build', tool: 'measurement' })
       }
       if (e.key === 'v' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
-        useEditor.getState().setMode('select')
+        useEditor.getState().armToolMode({ mode: 'select' })
         useEditor.getState().setFloorplanSelectionTool('click')
       } else if (e.key === 'b' && !e.metaKey && !e.ctrlKey) {
         if (isVersionPreviewMode) return
         e.preventDefault()
         useEditor.getState().setPhase('structure')
         useEditor.getState().setStructureLayer('elements')
-        useEditor.getState().setMode('build')
-        // Set the wall tool explicitly so B never inherits a stale tool
-        // (e.g. fence) left over from a prior build session.
-        useEditor.getState().setTool('wall')
+        useEditor.getState().armToolMode({ mode: 'build', tool: 'wall' })
       } else if (e.key === 'x' && !e.metaKey && !e.ctrlKey) {
         if (isVersionPreviewMode) return
         e.preventDefault()
-        useEditor.getState().setMode('delete')
+        useEditor.getState().armToolMode({ mode: 'delete' })
       } else if (e.key === 'p' && !e.metaKey && !e.ctrlKey) {
         if (isVersionPreviewMode) return
         e.preventDefault()
-        useEditor.getState().primeMaterialPaintFromSelection()
         useEditor.getState().setPhase('structure')
         useEditor.getState().setStructureLayer('elements')
-        useEditor.getState().setMode('material-paint')
+        useEditor.getState().armMaterialPaint()
       } else if (e.key === 'g' && !e.metaKey && !e.ctrlKey) {
         if (isVersionPreviewMode) return
         e.preventDefault()
-        // G for ground. No `setPhase` — `setMode` moves to the site phase itself,
-        // and doing it here would set the phase twice with a mode reset between.
-        useEditor.getState().setMode('terrain-sculpt')
+        // G for ground. The ToolMode transition moves to the site phase itself.
+        useEditor.getState().armToolMode({ mode: 'terrain-sculpt' })
       } else if (e.key === 'c' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
         if (isVersionPreviewMode) return
         e.preventDefault()

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -462,6 +462,7 @@ export {
   scopeNodeId,
 } from './lib/interaction/scope'
 export {
+  type ActivePaintMaterial,
   buildResetSurfaceMaterialUpdates,
   buildRoofSurfaceMaterialPatch,
   buildSingleSurfaceMaterialPatch,
@@ -598,15 +599,20 @@ export {
 export type {
   CaptureMode,
   FloorplanSelectionTool,
+  Mode,
   SnapshotCropMode,
   SnapshotStandardAspect,
   SplitOrientation,
+  StructureTool,
   Tool,
   ToolDefaults,
+  ToolMode,
   ViewMode,
   WorkspaceMode,
 } from './store/use-editor'
 export {
+  armMaterialPaint,
+  armToolMode,
   default as useEditor,
   getActiveContinuationContext,
   getActiveSnapContext,

--- a/packages/editor/src/lib/scene.ts
+++ b/packages/editor/src/lib/scene.ts
@@ -155,11 +155,18 @@ function getEditorUiStateForRestoredSelection(
   fallbackUiState: PersistedEditorUiState,
 ): PersistedEditorUiState {
   if (!selection.levelId) {
+    const mode = fallbackUiState.phase === 'site' ? fallbackUiState.mode : 'select'
     return {
       ...fallbackUiState,
       phase: 'site',
-      mode: fallbackUiState.phase === 'site' ? fallbackUiState.mode : 'select',
-      tool: null,
+      toolMode:
+        mode === 'build'
+          ? { mode, tool: 'property-line' }
+          : mode === 'terrain-sculpt'
+            ? { mode }
+            : { mode: 'select' },
+      mode,
+      tool: mode === 'build' ? 'property-line' : null,
       structureLayer: 'elements',
       catalogCategory: null,
     }
@@ -169,6 +176,7 @@ function getEditorUiStateForRestoredSelection(
     return {
       ...fallbackUiState,
       phase: 'structure',
+      toolMode: { mode: 'select' },
       mode: 'select',
       tool: null,
       structureLayer: 'zones',
@@ -192,6 +200,7 @@ function getEditorUiStateForRestoredSelection(
   return {
     ...fallbackUiState,
     phase: shouldRestoreFurnishPhase ? 'furnish' : 'structure',
+    toolMode: { mode: 'select' },
     mode: 'select',
     tool: null,
     structureLayer: 'elements',
@@ -304,14 +313,14 @@ export function syncEditorSelectionFromCurrentScene() {
         // SelectionPath expects branded ids. The runtime values match the
         // brand; the cast bridges the static gap.
         useViewer.getState().setSelection(restoredSelection as never)
-        useEditor.setState(
+        restoreEditorUiState(
           restoredEditorUiState.phase === 'site'
             ? (selectionDrivenEditorUiState ?? restoredEditorUiState)
             : restoredEditorUiState,
         )
       } else if (restoredEditorUiState.phase === 'site') {
         useViewer.getState().resetSelection()
-        useEditor.setState(restoredEditorUiState)
+        restoreEditorUiState(restoredEditorUiState)
       } else {
         useViewer.getState().setSelection({
           buildingId: firstBuilding.id,
@@ -319,7 +328,7 @@ export function syncEditorSelectionFromCurrentScene() {
           selectedIds: [],
           zoneId: null,
         })
-        useEditor.setState(restoredEditorUiState)
+        restoreEditorUiState(restoredEditorUiState)
       }
       return
     }
@@ -327,7 +336,7 @@ export function syncEditorSelectionFromCurrentScene() {
     if (restoredSelection) {
       useViewer.getState().setSelection(restoredSelection as never)
       if (selectionDrivenEditorUiState) {
-        useEditor.setState(selectionDrivenEditorUiState)
+        restoreEditorUiState(selectionDrivenEditorUiState)
       }
       return
     }
@@ -351,6 +360,12 @@ export function syncEditorSelectionFromCurrentScene() {
   }
 }
 
+function restoreEditorUiState(state: PersistedEditorUiState) {
+  const { toolMode, mode: _mode, tool: _tool, ...rest } = state
+  useEditor.setState(rest)
+  useEditor.getState().armToolMode(toolMode)
+}
+
 function resetEditorInteractionState() {
   useViewer.getState().setHoveredId(null)
   useViewer.getState().resetSelection()
@@ -362,8 +377,6 @@ function resetEditorInteractionState() {
   sceneRegistry.clear()
   useEditor.setState({
     phase: 'site',
-    mode: 'select',
-    tool: null,
     structureLayer: 'elements',
     catalogCategory: null,
     selectedItem: null,
@@ -372,6 +385,7 @@ function resetEditorInteractionState() {
     hoveredHole: null,
     isPreviewMode: false,
   })
+  useEditor.getState().armToolMode({ mode: 'select' })
 }
 
 function hasUsableSceneGraph(sceneGraph?: SceneGraph | null): sceneGraph is SceneGraph {

--- a/packages/editor/src/lib/selection-routing.test.ts
+++ b/packages/editor/src/lib/selection-routing.test.ts
@@ -83,7 +83,7 @@ describe('emitCanvasNodeSelection', () => {
 
   test('deletes an accepted floorplan node when Delete mode is active', () => {
     const node = BlockNode.parse({ id: 'block_floorplan-delete-target' })
-    const previousMode = useEditor.getState().mode
+    const previousToolMode = useEditor.getState().toolMode
     const previousScene = useScene.getState()
     const previousSelection = useViewer.getState().selection
     const received: AnyNode[] = []
@@ -92,7 +92,7 @@ describe('emitCanvasNodeSelection', () => {
     emitter.on('selection:canvas-node-click', listener)
 
     try {
-      useEditor.setState({ mode: 'delete' })
+      useEditor.getState().armToolMode({ mode: 'delete' })
       useScene.setState({
         nodes: { [node.id]: node },
         rootNodeIds: [node.id],
@@ -107,7 +107,7 @@ describe('emitCanvasNodeSelection', () => {
       expect(received).toEqual([])
     } finally {
       emitter.off('selection:canvas-node-click', listener)
-      useEditor.setState({ mode: previousMode })
+      useEditor.getState().armToolMode(previousToolMode)
       useScene.setState(previousScene)
       useViewer.setState({ selection: previousSelection })
     }
@@ -115,12 +115,12 @@ describe('emitCanvasNodeSelection', () => {
 
   test('preserves a floorplan node and its selection when the scene is read-only', () => {
     const node = BlockNode.parse({ id: 'block_floorplan-read-only-target' })
-    const previousMode = useEditor.getState().mode
+    const previousToolMode = useEditor.getState().toolMode
     const previousScene = useScene.getState()
     const previousSelection = useViewer.getState().selection
 
     try {
-      useEditor.setState({ mode: 'delete' })
+      useEditor.getState().armToolMode({ mode: 'delete' })
       useScene.setState({
         nodes: { [node.id]: node },
         rootNodeIds: [node.id],
@@ -133,7 +133,7 @@ describe('emitCanvasNodeSelection', () => {
       expect(useScene.getState().nodes[node.id]).toEqual(node)
       expect(useViewer.getState().selection.selectedIds).toEqual([node.id])
     } finally {
-      useEditor.setState({ mode: previousMode })
+      useEditor.getState().armToolMode(previousToolMode)
       useScene.setState(previousScene)
       useViewer.setState({ selection: previousSelection })
     }

--- a/packages/editor/src/store/terrain-sculpt-mode.test.ts
+++ b/packages/editor/src/store/terrain-sculpt-mode.test.ts
@@ -52,8 +52,7 @@ describe('terrain-sculpt mode lifecycle', () => {
 
   test('a phase switch out of site drops the scope', () => {
     useEditor.getState().setMode('terrain-sculpt')
-    // This path rewrites `mode` without going through `setMode`, which is
-    // exactly why the scope sync is its own function.
+    // The phase setter delegates its mode rewrite to the ToolMode transition.
     useEditor.getState().setPhase('structure')
     expect(useInteractionScope.getState().scope.kind).toBe('idle')
   })
@@ -153,10 +152,8 @@ describe('the brush and the 3D canvas travel together', () => {
 
 describe('the modes that hide the editing canvas release the brush', () => {
   // Preview / walkthrough / studio all unmount `ToolManager` (via `noEditing`),
-  // so the sculpt tool that would release the scope on unmount is gone. Each one
-  // resets `mode` with a raw `set` rather than `setMode`, which is exactly the
-  // bug class `setPhase` had: a `sculpting` scope leaked here disables selection
-  // across the whole editor with nothing left mounted to clear it.
+  // so the sculpt tool that would release the scope on unmount is gone. Their
+  // ToolMode transitions must release the scope before the canvas disappears.
   test('entering preview releases it', () => {
     useEditor.getState().setMode('terrain-sculpt')
     useEditor.getState().setPreviewMode(true)

--- a/packages/editor/src/store/tool-mode.test.ts
+++ b/packages/editor/src/store/tool-mode.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import useEditor, { normalizePersistedEditorUiState } from './use-editor'
+
+function resetToolMode() {
+  useEditor.getState().setPhase('structure')
+  useEditor.getState().setStructureLayer('elements')
+  useEditor.getState().armToolMode({ mode: 'select' })
+  useEditor.getState().setActivePaintMaterial(null)
+}
+
+afterEach(resetToolMode)
+
+describe('ToolMode transition', () => {
+  test('choosing a paint swatch while selected arms material paint', () => {
+    useEditor.getState().armToolMode({ mode: 'select' })
+    useEditor.getState().armMaterialPaint({
+      materialPreset: 'library:test-paint',
+      sourceTarget: 'wall',
+    })
+
+    expect(useEditor.getState().toolMode).toEqual({ mode: 'material-paint' })
+    expect(useEditor.getState().mode).toBe('material-paint')
+    expect(useEditor.getState().tool).toBeNull()
+    expect(useEditor.getState().activePaintMaterial?.materialPreset).toBe('library:test-paint')
+  })
+
+  test('leaving build clears the materialized tool', () => {
+    useEditor.getState().armToolMode({ mode: 'build', tool: 'wall' })
+    useEditor.getState().armToolMode({ mode: 'select' })
+
+    expect(useEditor.getState().toolMode).toEqual({ mode: 'select' })
+    expect(useEditor.getState().mode).toBe('select')
+    expect(useEditor.getState().tool).toBeNull()
+  })
+
+  test('the setMode compatibility wrapper elects a default build tool', () => {
+    useEditor.getState().setMode('build')
+
+    expect(useEditor.getState().toolMode).toEqual({ mode: 'build', tool: 'wall' })
+    expect(useEditor.getState().mode).toBe('build')
+    expect(useEditor.getState().tool).toBe('wall')
+  })
+
+  test('setTool enters build and null exits it', () => {
+    useEditor.getState().armToolMode({ mode: 'select' })
+    useEditor.getState().setTool('slab')
+
+    expect(useEditor.getState().toolMode).toEqual({ mode: 'build', tool: 'slab' })
+    expect(useEditor.getState().mode).toBe('build')
+    expect(useEditor.getState().tool).toBe('slab')
+
+    useEditor.getState().setTool(null)
+    expect(useEditor.getState().toolMode).toEqual({ mode: 'select' })
+    expect(useEditor.getState().tool).toBeNull()
+  })
+})
+
+describe('persisted ToolMode normalization', () => {
+  test('elects a default for build with a null tool', () => {
+    const state = normalizePersistedEditorUiState({
+      phase: 'structure',
+      toolMode: { mode: 'build', tool: null as never },
+      mode: 'select',
+      tool: 'slab',
+      structureLayer: 'elements',
+    })
+
+    expect(state.toolMode).toEqual({ mode: 'build', tool: 'wall' })
+    expect(state.mode).toBe('build')
+    expect(state.tool).toBe('wall')
+  })
+
+  test('clears a persisted tool from a non-build mode', () => {
+    const state = normalizePersistedEditorUiState({
+      phase: 'structure',
+      toolMode: { mode: 'select' },
+      mode: 'build',
+      tool: 'wall',
+      structureLayer: 'elements',
+    })
+
+    expect(state.toolMode).toEqual({ mode: 'select' })
+    expect(state.mode).toBe('select')
+    expect(state.tool).toBeNull()
+  })
+})

--- a/packages/editor/src/store/use-editor.tsx
+++ b/packages/editor/src/store/use-editor.tsx
@@ -212,6 +212,14 @@ export type NavigationSyncPoseInput = Omit<NavigationSyncPose, 'revision'>
 export type KnownTool = SiteTool | StructureTool | FurnishTool
 export type Tool = KnownTool | (string & {})
 
+export type ToolMode =
+  | { mode: 'select' }
+  | { mode: 'edit' }
+  | { mode: 'delete' }
+  | { mode: 'build'; tool: StructureTool }
+  | { mode: 'material-paint' }
+  | { mode: 'terrain-sculpt' }
+
 /**
  * Starting parameters seeded into a draw tool before it mints a node.
  * A loose param bag — the tool's create path validates it through the
@@ -250,6 +258,9 @@ export type GuideUiState = {
 type EditorState = {
   phase: Phase
   setPhase: (phase: Phase) => void
+  toolMode: ToolMode
+  armToolMode: (next: ToolMode) => void
+  armMaterialPaint: (material?: ActivePaintMaterial) => void
   mode: Mode
   setMode: (mode: Mode) => void
   tool: Tool | null
@@ -492,7 +503,14 @@ type EditorState = {
 
 export type PersistedEditorUiState = Pick<
   EditorState,
-  'phase' | 'mode' | 'tool' | 'structureLayer' | 'catalogCategory' | 'isFloorplanOpen' | 'viewMode'
+  | 'phase'
+  | 'toolMode'
+  | 'mode'
+  | 'tool'
+  | 'structureLayer'
+  | 'catalogCategory'
+  | 'isFloorplanOpen'
+  | 'viewMode'
 >
 
 type PersistedEditorLayoutState = Pick<
@@ -514,6 +532,7 @@ type PersistedEditorState = PersistedEditorUiState & PersistedEditorLayoutState
 
 export const DEFAULT_PERSISTED_EDITOR_UI_STATE: PersistedEditorUiState = {
   phase: 'site',
+  toolMode: { mode: 'select' },
   mode: 'select',
   tool: null,
   structureLayer: 'elements',
@@ -553,13 +572,67 @@ type SelectDefaultBuildingAndLevelOptions = {
   forceGroundLevel?: boolean
 }
 
+function defaultBuildTool(phase: Phase, structureLayer: StructureLayer): StructureTool {
+  if (phase === 'site') return 'property-line'
+  if (phase === 'furnish') return 'item'
+  return structureLayer === 'zones' ? 'zone' : 'wall'
+}
+
+function materializeToolMode(
+  mode: Mode,
+  tool: unknown,
+  phase: Phase,
+  structureLayer: StructureLayer,
+): ToolMode {
+  if (mode === 'build') {
+    return {
+      mode,
+      tool:
+        typeof tool === 'string' && tool.length > 0
+          ? (tool as StructureTool)
+          : defaultBuildTool(phase, structureLayer),
+    }
+  }
+
+  return { mode } as ToolMode
+}
+
+function readPersistedToolMode(state: Partial<PersistedEditorUiState> | null | undefined): {
+  mode: Mode | undefined
+  tool: unknown
+} {
+  const candidate = state?.toolMode as Partial<ToolMode> | undefined
+  if (
+    candidate?.mode === 'select' ||
+    candidate?.mode === 'edit' ||
+    candidate?.mode === 'delete' ||
+    candidate?.mode === 'build' ||
+    candidate?.mode === 'material-paint' ||
+    candidate?.mode === 'terrain-sculpt'
+  ) {
+    return {
+      mode: candidate.mode,
+      tool: candidate.mode === 'build' ? (candidate as { tool?: unknown }).tool : null,
+    }
+  }
+
+  return { mode: state?.mode, tool: state?.tool }
+}
+
+function withMaterializedToolMode(
+  state: Omit<PersistedEditorUiState, 'toolMode'>,
+): PersistedEditorUiState {
+  return {
+    ...state,
+    toolMode: materializeToolMode(state.mode, state.tool, state.phase, state.structureLayer),
+  }
+}
+
 function normalizeModeForPhase(phase: Phase, mode: Mode | undefined): Mode {
-  // The site phase used to hard-return `select`, which made a site-phase brush
-  // mode unrepresentable. It is an allowlist now rather than a free-for-all:
-  // `delete` and `material-paint` still have nothing to act on at site scope, so
-  // letting them survive here would restore a mode with no targets.
+  // Site has its own property-line build tool and terrain brush. The remaining
+  // modes have nothing to act on at site scope, so they restore as select.
   if (phase === 'site') {
-    return mode === 'terrain-sculpt' ? mode : 'select'
+    return mode === 'build' || mode === 'terrain-sculpt' ? mode : 'select'
   }
 
   return mode === 'build' || mode === 'delete' || mode === 'material-paint' ? mode : 'select'
@@ -577,7 +650,8 @@ export function normalizePersistedEditorUiState(
   state: Partial<PersistedEditorUiState> | null | undefined,
 ): PersistedEditorUiState {
   const phase = state?.phase === 'structure' || state?.phase === 'furnish' ? state.phase : 'site'
-  let mode = normalizeModeForPhase(phase, state?.mode)
+  const persistedToolMode = readPersistedToolMode(state)
+  let mode = normalizeModeForPhase(phase, persistedToolMode.mode)
 
   // Migrate old isFloorplanOpen to viewMode
   let viewMode: ViewMode = '3d'
@@ -596,17 +670,19 @@ export function normalizePersistedEditorUiState(
   if (mode === 'terrain-sculpt' && viewMode === '2d') mode = 'select'
 
   if (phase === 'site') {
-    return {
-      ...DEFAULT_PERSISTED_EDITOR_UI_STATE,
+    return withMaterializedToolMode({
       phase,
       mode,
+      tool: mode === 'build' ? 'property-line' : null,
+      structureLayer: 'elements',
+      catalogCategory: null,
       viewMode,
       isFloorplanOpen,
-    }
+    })
   }
 
   if (phase === 'furnish') {
-    return {
+    return withMaterializedToolMode({
       phase,
       mode,
       tool: mode === 'build' ? 'item' : null,
@@ -614,13 +690,13 @@ export function normalizePersistedEditorUiState(
       catalogCategory: mode === 'build' ? (state?.catalogCategory ?? 'furniture') : null,
       viewMode,
       isFloorplanOpen,
-    }
+    })
   }
 
   const structureLayer = state?.structureLayer === 'zones' ? 'zones' : 'elements'
 
   if (mode !== 'build') {
-    return {
+    return withMaterializedToolMode({
       phase,
       mode,
       tool: null,
@@ -628,11 +704,11 @@ export function normalizePersistedEditorUiState(
       catalogCategory: null,
       viewMode,
       isFloorplanOpen,
-    }
+    })
   }
 
   if (structureLayer === 'zones') {
-    return {
+    return withMaterializedToolMode({
       phase,
       mode,
       tool: 'zone',
@@ -640,19 +716,25 @@ export function normalizePersistedEditorUiState(
       catalogCategory: null,
       viewMode,
       isFloorplanOpen,
-    }
+    })
   }
 
-  return {
+  const tool =
+    persistedToolMode.tool &&
+    persistedToolMode.tool !== 'property-line' &&
+    persistedToolMode.tool !== 'zone'
+      ? (persistedToolMode.tool as Tool)
+      : 'wall'
+
+  return withMaterializedToolMode({
     phase,
     mode,
-    tool:
-      state?.tool && state.tool !== 'property-line' && state.tool !== 'zone' ? state.tool : 'wall',
+    tool,
     structureLayer,
-    catalogCategory: state?.tool === 'item' ? (state.catalogCategory ?? null) : null,
+    catalogCategory: tool === 'item' ? (state?.catalogCategory ?? null) : null,
     viewMode,
     isFloorplanOpen,
-  }
+  })
 }
 
 // Validate a persisted per-context mode against that context's allowed set
@@ -853,21 +935,16 @@ let viewModeBeforeCapture: ViewMode | null = null
  *
  * Paint and sculpt are the two modes whose scope lifetime is the *mode*, not a
  * pointer gesture. Both must be released whenever the mode changes for any
- * reason — including the phase switch that resets the mode without going through
- * `setMode`. A stuck `sculpting` scope would leave selection disabled across the
- * whole editor, so this is one function called from every mode transition rather
- * than a rule each transition remembers.
+ * reason. A stuck `sculpting` scope would leave selection disabled across the
+ * whole editor, so the ToolMode transition owns this side effect.
  *
  * The eyedropper arm rides along for the same reason: it is one-shot state whose
  * UI is unmounted the moment sculpt mode ends, so it has to be cleared on every
  * exit path and not just the one through `setMode`.
  *
- * Every `set({ mode: ... })` in this store must be followed by a call to this —
- * see the callers in `setPhase`, `setStructureLayer`, `setPreviewMode`,
- * `setFirstPersonMode` and `setWorkspaceMode`. The four view-swapping ones are
- * the dangerous class: they unmount `ToolManager` (via `noEditing`), so the
- * sculpt tool that would otherwise release the scope on unmount is gone, and a
- * scope leaked there is unrecoverable without a reload.
+ * View-swapping actions are the dangerous class: they unmount `ToolManager`
+ * (via `noEditing`), so the sculpt tool that would otherwise release the scope
+ * on unmount is gone, and a leaked scope is unrecoverable without a reload.
  */
 function syncBrushModeScope(mode: Mode): void {
   const scope = useInteractionScope.getState()
@@ -903,31 +980,18 @@ const useEditor = create<EditorState>()(
       setPhase: (phase) => {
         const currentPhase = get().phase
         if (currentPhase === phase) return
-
-        set({ phase })
-
-        const { mode, structureLayer } = get()
-
-        if (mode === 'build') {
-          // Stay in build mode, select the first tool for the new phase
-          if (phase === 'site') {
-            set({ tool: 'property-line', catalogCategory: null })
-          } else if (phase === 'structure' && structureLayer === 'zones') {
-            set({ tool: 'zone', catalogCategory: null })
-          } else if (phase === 'structure') {
-            set({ tool: 'wall', catalogCategory: null })
-          } else if (phase === 'furnish') {
-            set({ tool: 'item', catalogCategory: 'furniture' })
-          }
-        } else {
-          // Reset to select mode and clear tool/catalog when switching phases
-          set({ mode: 'select', tool: null, catalogCategory: null })
-        }
-
-        // Leaving the site phase must drop a held sculpt scope: this branch
-        // rewrites `mode` without going through `setMode`, so without this a
-        // stuck `sculpting` scope would disable selection in structure phase.
-        syncBrushModeScope(get().mode)
+        const wasBuilding = get().toolMode.mode === 'build'
+        const structureLayer = phase === 'furnish' ? 'elements' : get().structureLayer
+        set({
+          phase,
+          structureLayer,
+          catalogCategory: wasBuilding && phase === 'furnish' ? 'furniture' : null,
+        })
+        get().armToolMode(
+          wasBuilding
+            ? { mode: 'build', tool: defaultBuildTool(phase, structureLayer) }
+            : { mode: 'select' },
+        )
 
         switch (phase) {
           case 'site':
@@ -940,64 +1004,99 @@ const useEditor = create<EditorState>()(
 
           case 'furnish':
             selectDefaultBuildingAndLevel()
-            // Furnish mode only supports elements layer, not zones
-            set({ structureLayer: 'elements' })
             break
         }
       },
-      mode: DEFAULT_PERSISTED_EDITOR_UI_STATE.mode,
-      setMode: (mode) => {
-        // Sculpting is a site-phase mode. Arming it from structure/furnish moves
-        // the phase rather than failing silently: the user asked for the ground,
-        // and `normalizeModeForPhase` would otherwise reject the mode on the next
-        // rehydrate, leaving the UI showing a mode the store does not hold.
-        if (mode === 'terrain-sculpt' && get().phase !== 'site') {
-          get().setPhase('site')
-        }
+      toolMode: DEFAULT_PERSISTED_EDITOR_UI_STATE.toolMode,
+      armToolMode: (requested) => {
+        const current = get()
+        let phase = current.phase
+        let structureLayer = current.structureLayer
+        let viewMode = current.viewMode
+        let isFloorplanOpen = current.isFloorplanOpen
+        const next = materializeToolMode(
+          requested.mode,
+          requested.mode === 'build' ? requested.tool : null,
+          phase,
+          structureLayer,
+        )
 
-        // Same promotion, one axis over. The brush needs the 3D canvas: in `2d`
-        // the pane is only `display: none`, so the mode would arm, hold its
-        // scope and show its HUD while no pointer event could ever reach it.
-        // `split` is the smallest move that satisfies it — a plain `3d` would
-        // throw away a floorplan the user deliberately opened.
-        if (mode === 'terrain-sculpt' && get().viewMode === '2d') {
-          set({ viewMode: 'split', isFloorplanOpen: true })
-        }
-
-        set({ mode })
-
-        const { phase, structureLayer, tool } = get()
-
-        if (mode === 'build') {
-          // Ensure a tool is selected in build mode
-          if (!tool) {
-            if (phase === 'structure' && structureLayer === 'zones') {
-              set({ tool: 'zone' })
-            } else if (phase === 'structure' && structureLayer === 'elements') {
-              set({ tool: 'wall' })
-            } else if (phase === 'furnish') {
-              set({ tool: 'item', catalogCategory: 'furniture' })
-            }
+        if (next.mode === 'terrain-sculpt') {
+          phase = 'site'
+          structureLayer = 'elements'
+          if (viewMode === '2d') {
+            viewMode = 'split'
+            isFloorplanOpen = true
           }
-        } else if (mode === 'material-paint') {
-          get().primeMaterialPaintFromSelection()
-        }
-        // When leaving build mode, clear tool
-        else if (tool) {
-          set({ tool: null })
+        } else if (next.mode === 'build' && next.tool === 'property-line') {
+          phase = 'site'
+          structureLayer = 'elements'
+        } else if (next.mode === 'build' && next.tool === 'zone') {
+          phase = 'structure'
+          structureLayer = 'zones'
+        } else if (next.mode === 'build' && phase === 'site') {
+          phase = 'structure'
+          structureLayer = 'elements'
+        } else if (next.mode === 'material-paint' && phase === 'site') {
+          phase = 'structure'
+          structureLayer = 'elements'
+        } else if (phase !== 'structure') {
+          structureLayer = 'elements'
         }
 
-        if (mode === 'terrain-sculpt') {
-          // Sculpting acts on the ground, never on a node. Clearing the
-          // selection on entry is what stops the selected wall's gizmo from
-          // sitting under the brush, competing for the same clicks.
+        const phaseChanged = phase !== current.phase
+        set({
+          toolMode: next,
+          mode: next.mode,
+          tool: next.mode === 'build' ? next.tool : null,
+          ...(phaseChanged ? { phase } : {}),
+          ...(structureLayer !== current.structureLayer ? { structureLayer } : {}),
+          ...(viewMode !== current.viewMode ? { viewMode } : {}),
+          ...(isFloorplanOpen !== current.isFloorplanOpen ? { isFloorplanOpen } : {}),
+          ...(next.mode === 'build' && phase === 'furnish' && !current.catalogCategory
+            ? { catalogCategory: 'furniture' }
+            : {}),
+        })
+
+        if (phaseChanged) {
+          if (phase === 'site') selectSiteFloorplanContext()
+          else selectDefaultBuildingAndLevel()
+        }
+        if (next.mode === 'material-paint') get().primeMaterialPaintFromSelection()
+        if (next.mode === 'terrain-sculpt') {
           useViewer.getState().setSelection({ selectedIds: [], zoneId: null })
         }
-
-        syncBrushModeScope(mode)
+        syncBrushModeScope(next.mode)
+      },
+      armMaterialPaint: (material) => {
+        get().armToolMode({ mode: 'material-paint' })
+        if (material) get().setActivePaintMaterial(material)
+      },
+      mode: DEFAULT_PERSISTED_EDITOR_UI_STATE.mode,
+      setMode: (mode) => {
+        if (mode === 'build') {
+          const { phase, structureLayer, toolMode } = get()
+          get().armToolMode({
+            mode,
+            tool:
+              toolMode.mode === 'build' ? toolMode.tool : defaultBuildTool(phase, structureLayer),
+          })
+          return
+        }
+        get().armToolMode({ mode } as ToolMode)
       },
       tool: DEFAULT_PERSISTED_EDITOR_UI_STATE.tool,
-      setTool: (tool) => set({ tool }),
+      setTool: (tool) => {
+        if (tool) {
+          get().armToolMode({ mode: 'build', tool })
+          return
+        }
+        if (get().toolMode.mode === 'build' || get().mode === 'build') {
+          get().armToolMode({ mode: 'select' })
+          return
+        }
+        get().armToolMode(materializeToolMode(get().mode, null, get().phase, get().structureLayer))
+      },
       toolDefaults: {},
       setToolDefaults: (tool, defaults) =>
         set((state) => {
@@ -1013,15 +1112,13 @@ const useEditor = create<EditorState>()(
       setLastMeasurementKind: (kind) => set({ lastMeasurementKind: kind }),
       structureLayer: DEFAULT_PERSISTED_EDITOR_UI_STATE.structureLayer,
       setStructureLayer: (layer) => {
-        const { mode } = get()
-
-        if (mode === 'build') {
-          const tool = layer === 'zones' ? 'zone' : 'wall'
-          set({ structureLayer: layer, tool })
-        } else {
-          set({ structureLayer: layer, mode: 'select', tool: null })
-          syncBrushModeScope('select')
-        }
+        const wasBuilding = get().toolMode.mode === 'build'
+        set({ structureLayer: layer })
+        get().armToolMode(
+          wasBuilding
+            ? { mode: 'build', tool: layer === 'zones' ? 'zone' : 'wall' }
+            : { mode: 'select' },
+        )
 
         const viewer = useViewer.getState()
         viewer.setSelection({
@@ -1205,8 +1302,8 @@ const useEditor = create<EditorState>()(
       isPreviewMode: false,
       setPreviewMode: (preview) => {
         if (preview) {
-          set({ isPreviewMode: true, mode: 'select', tool: null, catalogCategory: null })
-          syncBrushModeScope('select')
+          set({ isPreviewMode: true, catalogCategory: null })
+          get().armToolMode({ mode: 'select' })
           // Clear zone/item selection for clean viewer drill-down hierarchy
           useViewer.getState().setSelection({ selectedIds: [], zoneId: null })
         } else {
@@ -1356,11 +1453,9 @@ const useEditor = create<EditorState>()(
             _viewModeBeforeFirstPerson: currentViewMode,
             viewMode: '3d',
             isFloorplanOpen: false,
-            mode: 'select',
-            tool: null,
             catalogCategory: null,
           })
-          syncBrushModeScope('select')
+          get().armToolMode({ mode: 'select' })
         } else {
           const prevMode = get()._viewModeBeforeFirstPerson
           set({
@@ -1396,11 +1491,9 @@ const useEditor = create<EditorState>()(
             _viewModeBeforeStudio: currentViewMode,
             viewMode: '3d',
             isFloorplanOpen: false,
-            mode: 'select',
-            tool: null,
             catalogCategory: null,
           })
-          syncBrushModeScope('select')
+          get().armToolMode({ mode: 'select' })
           // Clear selection so no edit affordances bleed into the clean canvas.
           useViewer.getState().setSelection({ selectedIds: [], zoneId: null })
         } else {
@@ -1446,7 +1539,7 @@ const useEditor = create<EditorState>()(
             : {}),
         }
       },
-      // `mode` is persisted, but the interaction scope a brush mode holds is not
+      // `toolMode` is persisted, but the interaction scope a brush mode holds is not
       // — it lives in a separate, non-persisted store. Rehydrating into
       // `terrain-sculpt` (or paint) without re-claiming the scope would restore
       // the brush with selection still enabled, so every dab could grab a wall.
@@ -1455,6 +1548,7 @@ const useEditor = create<EditorState>()(
       },
       partialize: (state) => ({
         phase: state.phase,
+        toolMode: state.toolMode,
         mode: state.mode,
         tool: state.tool,
         structureLayer: state.structureLayer,
@@ -1478,6 +1572,14 @@ const useEditor = create<EditorState>()(
     },
   ),
 )
+
+export function armToolMode(next: ToolMode): void {
+  useEditor.getState().armToolMode(next)
+}
+
+export function armMaterialPaint(material?: ActivePaintMaterial): void {
+  useEditor.getState().armMaterialPaint(material)
+}
 
 /**
  * Effective magnetic-snap state: the legacy `magneticSnap` flag AND the active


### PR DESCRIPTION
## What does this PR do?

`mode` and `tool` were two independently-writable, independently-persisted fields with six ad-hoc writers (`setMode`, raw `setTool`, `setPhase`'s rewrite, `setStructureLayer`'s rewrite, keyboard, panels), so impossible states — build with no tool, a lit tool tile in select mode, a paint-swatch click that never re-armed paint mode — were representable and survived reload. This is the un-migrated remainder of the interaction-scope overhaul.

The store now holds a `ToolMode` discriminated union as the source of truth (`build` carries its tool by construction) with `armToolMode` as the sole transition — it owns phase/viewMode promotions, default-tool election, paint priming and `syncBrushModeScope`, and materializes `mode`/`tool` mirrors so the ~150 existing readers are untouched. `armMaterialPaint` arms paint and sets the brush in one step; the material picker routes through it, so picking a swatch always returns to paint mode. `setMode`/`setTool` stay as thin wrappers; rehydration normalizes persisted `toolMode` against legacy pairs. Unit tests cover the transitions and the rehydration normalization.

## How to test

1. `bun dev`, open the paint panel, click the select ("V") control, then click any swatch → you're back in paint mode (previously stuck in select with a highlighted swatch).
2. Arm the wall tool, switch to select via the toolbar → no build tile stays lit anywhere; `useEditor.getState().tool` is null exactly when mode isn't build.
3. B/Z/G shortcuts, command palette entries, mobile layout panel switches — all land in coherent (mode, tool) pairs.
4. Reload mid-build: the persisted state rehydrates with a tool elected for the mode.
5. `bun test` — tool-mode transition + keyboard + selection-routing suites.

## Screenshots / screen recording

N/A — state-machine refactor; observable behavior is the two impossible-state fixes in step 1–2.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor interaction state, persistence/rehydration, and every mode-switch path; regressions could show up as wrong tools, stuck brush scopes, or bad state after reload.
> 
> **Overview**
> Replaces ad-hoc **`setMode` / `setTool` / raw `setState`** writes with a persisted **`ToolMode`** discriminated union and **`armToolMode`** as the sole transition. Build mode always carries an explicit tool; **`mode`** and **`tool`** stay as mirrored fields for existing readers.
> 
> **`armToolMode`** centralizes phase/view promotions (e.g. terrain sculpt → site, property-line → site), default build-tool election, material-paint priming, and **`syncBrushModeScope`** so brush scopes cannot leak when preview/walkthrough/studio unmount the canvas. **`armMaterialPaint`** arms paint and optional swatch in one step; pickers and shortcuts route through it instead of **`primeMaterialPaintFromSelection` + `setMode`**.
> 
> **`setMode` / `setTool`** remain compatibility wrappers. Rehydration normalizes legacy **`mode`/`tool`** pairs via **`toolMode`**; scene restore uses **`restoreEditorUiState`**. Site phase normalization now allows **build** (property-line). UI call sites (keyboard, command palette, control modes, mobile layout, floorplan site boundary) are migrated; new **`tool-mode.test.ts`** covers transitions and persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a98023c94ebca95ab860b5e8c1195712311335e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->