### PR TITLE
editor: add presentation.findInCatalog opt-out for the action menu

### DIFF
--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -1458,6 +1458,9 @@ export type Presentation = {
   /** Set false when selection is edited directly through in-scene affordances
    * and the generic floating action menu would duplicate or conflict with them. */
   actionMenu?: boolean
+  /** Set false to drop the "Find in catalog" action for this kind — for nodes
+   * that are placed through a plugin panel rather than a browsable catalog. */
+  findInCatalog?: boolean
 }
 
 export type IconRef =

--- a/packages/editor/src/components/editor/floating-action-menu.tsx
+++ b/packages/editor/src/components/editor/floating-action-menu.tsx
@@ -786,7 +786,13 @@ export function FloatingActionMenu() {
           >
             {menuVisibility.actions ? (
               <NodeActionMenu
-                onFind={node && canFindNode ? handleFind : undefined}
+                onFind={
+                  node &&
+                  canFindNode &&
+                  nodeRegistry.get(node.type)?.presentation?.findInCatalog !== false
+                    ? handleFind
+                    : undefined
+                }
                 onAddHole={node && HOLE_TYPES.includes(node.type) ? handleAddHole : undefined}
                 onCurve={
                   (node?.type === 'fence' && !isSplineFence(node) && !isCurvedWall(node)) ||


### PR DESCRIPTION
## What does this PR do?

Adds an optional `presentation.findInCatalog?: boolean` to `NodeDefinition` and gates the floating action menu's "Find in catalog" button on it (default unchanged). Panel-placed plugin kinds — like the Bloblins pets plugin, whose creatures are hatched from its own panel and have no catalog entry — can set `findInCatalog: false` to drop the Search action while keeping move/duplicate/delete.

## How to test

1. `bun dev`, open a project, select a built-in node (wall, item) — the action menu still shows the Find in catalog button as before.
2. Load a plugin whose definition sets `presentation: { findInCatalog: false, ... }` (e.g. `@wass08/plugin-bloblins`) and select one of its nodes — the Search button is absent; Move/Duplicate/Delete remain.
3. `cd packages/core && bun run check-types` — the new field is additive and optional.

## Screenshots / screen recording

N/A — removes one conditional button for opted-out kinds; no visual change for built-ins.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive registry flag and a single UI gate; default behavior is unchanged when the field is omitted.
> 
> **Overview**
> Adds optional **`presentation.findInCatalog`** on node definitions so kinds can hide the floating action menu’s **Find in catalog** action without affecting other buttons.
> 
> The menu still passes **`onFind`** only when **`canFindNode`** is true and the selected kind’s registry entry does **not** set **`findInCatalog: false`**. Omitted or **`true`** keeps today’s behavior for built-ins; plugin kinds placed only from a panel (e.g. Bloblins pets) can opt out while move, duplicate, and delete stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 468002d4c70ecb5a179debf982797c5a7a8a90db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->