### PR TITLE
editor: a failed scene load shows an error with retry, never an empty scene

### DIFF
--- a/packages/editor/src/components/editor/index.tsx
+++ b/packages/editor/src/components/editor/index.tsx
@@ -64,7 +64,7 @@ import { PanelManager } from '../ui/panels/panel-manager'
 import { ErrorBoundary } from '../ui/primitives/error-boundary'
 import { useSidebarStore } from '../ui/primitives/sidebar'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/primitives/tooltip'
-import { SceneLoader } from '../ui/scene-loader'
+import { SceneLoader, SceneLoadFailed } from '../ui/scene-loader'
 import { AppSidebar } from '../ui/sidebar/app-sidebar'
 import type { ExtraPanel } from '../ui/sidebar/icon-rail'
 import { SettingsPanel, type SettingsPanelProps } from '../ui/sidebar/panels/settings-panel'
@@ -1255,6 +1255,11 @@ function EditorContent({
 
   const [isSceneLoading, setIsSceneLoading] = useState(false)
   const [hasLoadedInitialScene, setHasLoadedInitialScene] = useState(false)
+  // A failed `onLoad` is shown as an error with a retry, never as an empty
+  // scene: an editor that renders the default scaffold after a failed load
+  // autosaves that scaffold over the real project.
+  const [sceneLoadError, setSceneLoadError] = useState<unknown>(null)
+  const [sceneLoadAttempt, setSceneLoadAttempt] = useState(0)
   const [sceneReadyKey, setSceneReadyKey] = useState(0)
   const [isViewerSceneReady, setIsViewerSceneReady] = useState(false)
   const [previewStageMode, setPreviewStageMode] = useState<ViewerStageMode>('3d')
@@ -1296,6 +1301,7 @@ function EditorContent({
 
     async function load() {
       isLoadingSceneRef.current = true
+      setSceneLoadError(null)
       setHasLoadedInitialScene(false)
       setIsViewerSceneReady(false)
       setIsSceneLoading(true)
@@ -1304,6 +1310,7 @@ function EditorContent({
       // Session groups are not scene-graph state — clear on every load/switch.
       useSessionGroups.getState().clearGroups()
 
+      let failed = false
       try {
         const sceneGraph = onLoad ? await onLoad() : loadSceneFromLocalStorage()
         if (!cancelled) {
@@ -1311,19 +1318,23 @@ function EditorContent({
           setIsViewerSceneReady(false)
           setSceneReadyKey((key) => key + 1)
         }
-      } catch {
+      } catch (error) {
+        // Leave the store unloaded and the autosave loop in its loading
+        // state: nothing may be written until a load actually succeeds.
+        failed = true
         if (!cancelled) {
-          applySceneGraphToEditor(null)
-          setIsViewerSceneReady(false)
-          setSceneReadyKey((key) => key + 1)
+          console.error('[editor] scene load failed', error)
+          setSceneLoadError(error ?? new Error('Scene load failed'))
         }
       } finally {
         if (!cancelled) {
           setIsSceneLoading(false)
-          setHasLoadedInitialScene(true)
-          requestAnimationFrame(() => {
-            isLoadingSceneRef.current = false
-          })
+          if (!failed) {
+            setHasLoadedInitialScene(true)
+            requestAnimationFrame(() => {
+              isLoadingSceneRef.current = false
+            })
+          }
         }
       }
     }
@@ -1333,7 +1344,11 @@ function EditorContent({
     return () => {
       cancelled = true
     }
-  }, [onLoad, isLoadingSceneRef])
+  }, [onLoad, isLoadingSceneRef, sceneLoadAttempt])
+
+  const retrySceneLoad = useCallback(() => {
+    setSceneLoadAttempt((attempt) => attempt + 1)
+  }, [])
 
   // Apply preview scene when version preview mode changes
   useEffect(() => {
@@ -1522,7 +1537,11 @@ function EditorContent({
         <FloorplanModeCoordinator />
         {visibleLoader && (
           <div className="fixed inset-0 z-60">
-            <SceneLoader className="bg-background" />
+            {sceneLoadError ? (
+              <SceneLoadFailed className="bg-background" onRetry={retrySceneLoad} />
+            ) : (
+              <SceneLoader className="bg-background" />
+            )}
           </div>
         )}
 
@@ -1598,7 +1617,11 @@ function EditorContent({
       <FloorplanModeCoordinator />
       {visibleLoader && (
         <div className="fixed inset-0 z-60">
-          <SceneLoader className="bg-background" />
+          {sceneLoadError ? (
+            <SceneLoadFailed className="bg-background" onRetry={retrySceneLoad} />
+          ) : (
+            <SceneLoader className="bg-background" />
+          )}
         </div>
       )}
 

--- a/packages/editor/src/components/ui/scene-loader.tsx
+++ b/packages/editor/src/components/ui/scene-loader.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { cn } from '../../lib/utils'
+import { Button } from './primitives/button'
 
 const LOADERS = [
   'pascal-loader-1',
@@ -33,6 +34,40 @@ export function SceneLoader({ className, fullScreen = false }: SceneLoaderProps)
       )}
     >
       <div className={cn(loaderClass, 'text-foreground opacity-80')} />
+    </div>
+  )
+}
+
+interface SceneLoadFailedProps {
+  className?: string
+  onRetry: () => void
+}
+
+/**
+ * Replaces the loader when the host could not deliver the scene. Rendered
+ * INSTEAD of falling back to an empty default scene: a session that shows
+ * scaffold nodes after a failed load autosaves that scaffold over the real
+ * project (prod scene-wipe class, 2026-09-02).
+ */
+export function SceneLoadFailed({ className, onRetry }: SceneLoadFailedProps) {
+  return (
+    <div
+      className={cn(
+        'z-100 flex flex-col items-center justify-center gap-4 bg-background/90 px-6 text-center backdrop-blur-md',
+        'absolute inset-0',
+        className,
+      )}
+      role="alert"
+    >
+      <div className="flex flex-col gap-1">
+        <p className="font-medium text-foreground text-sm">This project couldn't be loaded</p>
+        <p className="text-muted-foreground text-sm">
+          Nothing was changed. Check your connection and try again.
+        </p>
+      </div>
+      <Button className="rounded-full" onClick={onRetry} size="sm" type="button">
+        Try again
+      </Button>
     </div>
   )
 }


### PR DESCRIPTION
## What does this PR do?

A host `onLoad` that rejects (failed fetch, timeout) used to fall through to `applySceneGraphToEditor(null)`, i.e. the default site/building/level scaffold. The autosave loop re-baselined its wipe guard on that cleared store, the next store touch (host-panel `installedPlugins` sync, a plugin tick) armed a save, and the scaffold was written over the real project.

Prod audit on the hosted editor, 2026-09-02: 10–100 such wipes per day; 11–13 % of forks and template starts opened over two weeks lost their copied scene on the first save (scene fetch p95 is ~20 s against a 3 × 8 s host timeout).

Now a failed load keeps the store unloaded and the autosave loop in its loading state, so nothing can be written, and renders a new `SceneLoadFailed` overlay whose "Try again" re-runs the load effect. A load that resolves `null` (a genuinely empty project) is unchanged.

Companion host-side PR in `private-editor` adds a server-side wipe guard and makes the host `onLoad` throw on a failed fetch.

## How to test

1. In a host (or the standalone app), make `onLoad` reject or hang past its timeout — e.g. stall the scene fetch in devtools.
2. Expected: the loader is replaced by "This project couldn't be loaded" with a "Try again" button; no autosave fires (check the network tab / `[autosave]` console lines); the persisted scene is untouched.
3. Restore the network and click "Try again": the scene loads normally.
4. `bun test packages/editor/src/hooks/use-auto-save.test.ts` still passes; `bun x tsgo --noEmit -p packages/editor/tsconfig.json` is clean (needs a fresh core/viewer dist).

Verified end to end with a headless Playwright probe against the hosted editor on a local stack: stalled fetch → overlay, 0 autosave writes, DB row untouched → retry loads the scene.

## Screenshots / screen recording

Overlay: centred "This project couldn't be loaded — Nothing was changed. Check your connection and try again." with a rounded "Try again" button over the editor shell. (Probe screenshot available on request; the dev build's component-outline overlay makes it noisy.)

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLB54VYmGTzvyHNFb3wWxE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches initial scene load and autosave gating—core persistence path where the prior behavior caused production scene wipes; the change reduces that risk but must behave correctly on every failure mode.
> 
> **Overview**
> **Failed host `onLoad` no longer falls back to the default scaffold**, which could be autosaved over the real project. On rejection, the scene store stays unloaded, **`isLoadingSceneRef` stays true** so autosave does not run, and **`hasLoadedInitialScene` is not set** until a load succeeds.
> 
> The full-screen loader is replaced by a new **`SceneLoadFailed`** overlay (“This project couldn't be loaded” + **Try again**). Retry bumps **`sceneLoadAttempt`** to re-run the load effect. A resolved **`null`** (intentionally empty project) is unchanged.
> 
> Both v1 and v2 layouts use the same error-vs-loader branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be598973c06381ed7c0d8ad0b047a04968338629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->