### PR TITLE
Wall batching stays live in cutaway

### DIFF
--- a/packages/nodes/src/wall/wall-batch-suspension.test.ts
+++ b/packages/nodes/src/wall/wall-batch-suspension.test.ts
@@ -4,16 +4,16 @@ import { canBatchWalls } from './wall-batch-system'
 
 /**
  * The merged mesh captures one material set when it is sewn and never re-reads
- * it, so it may only exist while every batched wall's materials hold still.
- * These are the states in which that is true.
+ * it, so it may only exist while every batched wall's materials are safe to
+ * represent in the merged copy. These are the states in which that is true.
  */
 describe('canBatchWalls', () => {
-  test('merges in the one mode that leaves wall materials alone', () => {
+  test('merges in up mode', () => {
     expect(canBatchWalls('up', false)).toBe(true)
   })
 
-  test('stands down in cutaway — the facing test re-assigns materials as the camera turns', () => {
-    expect(canBatchWalls('cutaway', false)).toBe(false)
+  test('stays live in cutaway while hidden walls are released individually', () => {
+    expect(canBatchWalls('cutaway', false)).toBe(true)
   })
 
   test('stands down in the modes that make walls see-through', () => {

--- a/packages/nodes/src/wall/wall-batch-system.test.ts
+++ b/packages/nodes/src/wall/wall-batch-system.test.ts
@@ -222,4 +222,24 @@ describe('WallBatchSystem cutaway releases', () => {
     expect(root.children.find((child) => child.name === 'wall-batch')).not.toBe(batch)
     expect(walls.every((wall) => !wall.layers.isEnabled(SCENE_LAYER))).toBe(true)
   })
+
+  test('re-sews a settled level once its hidden walls become visible again', () => {
+    const { root, runFrame, walls } = setupBatchedLevel()
+    for (const wall of walls) wall.userData.wallHidden = true
+
+    nowMs = 200
+    runFrame({} as never, 0)
+    nowMs = 381
+    runFrame({} as never, 0)
+    expect(walls.every((wall) => wall.layers.isEnabled(SCENE_LAYER))).toBe(true)
+
+    for (const wall of walls) wall.userData.wallHidden = false
+    nowMs = 400
+    runFrame({} as never, 0)
+    nowMs = 581
+    runFrame({} as never, 0)
+
+    expect(root.children.some((child) => child.name === 'wall-batch')).toBe(true)
+    expect(walls.every((wall) => !wall.layers.isEnabled(SCENE_LAYER))).toBe(true)
+  })
 })

--- a/packages/nodes/src/wall/wall-batch-system.test.ts
+++ b/packages/nodes/src/wall/wall-batch-system.test.ts
@@ -72,10 +72,10 @@ function takeFrameCallback(): FrameCallback {
   return callback
 }
 
-function setupBatchedLevel() {
+function setupBatchedLevel(count = 8) {
   const root = new Object3D()
   const material = new MeshBasicMaterial()
-  const wallIds = Array.from({ length: 8 }, (_, index) => `wall_${index}`)
+  const wallIds = Array.from({ length: count }, (_, index) => `wall_${index}`)
   const walls = wallIds.map((id) => registerWall(id, material))
   for (const wall of walls) root.add(wall)
   sceneRegistry.nodes.set('level', root)
@@ -241,5 +241,25 @@ describe('WallBatchSystem cutaway releases', () => {
 
     expect(root.children.some((child) => child.name === 'wall-batch')).toBe(true)
     expect(walls.every((wall) => !wall.layers.isEnabled(SCENE_LAYER))).toBe(true)
+  })
+
+  test('a hovered wall does not hold the settle window open', () => {
+    const { root, runFrame, walls } = setupBatchedLevel(9)
+    for (const wall of walls) wall.userData.wallHidden = true
+    nowMs = 200
+    runFrame({} as never, 0)
+    for (const wall of walls) wall.userData.wallHidden = false
+    useViewer.setState({ hoveredId: 'wall_0' } as never)
+
+    nowMs = 400
+    runFrame({} as never, 0)
+    nowMs = 581
+    runFrame({} as never, 0)
+    nowMs = 762
+    runFrame({} as never, 0)
+
+    expect(root.children.some((child) => child.name === 'wall-batch')).toBe(true)
+    expect(walls.slice(1).every((wall) => !wall.layers.isEnabled(SCENE_LAYER))).toBe(true)
+    expect(walls[0]!.layers.isEnabled(SCENE_LAYER)).toBe(true)
   })
 })

--- a/packages/nodes/src/wall/wall-batch-system.test.ts
+++ b/packages/nodes/src/wall/wall-batch-system.test.ts
@@ -1,29 +1,116 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterAll, afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import { sceneRegistry, useScene } from '@pascal-app/core'
-import { useViewer } from '@pascal-app/viewer'
-import { BufferGeometry, Float32BufferAttribute, Mesh, MeshBasicMaterial } from 'three'
-import { collectTintedWalls, collectWallBatchCandidates } from './wall-batch-system'
+import { SCENE_LAYER, useViewer } from '@pascal-app/viewer'
+import type { useFrame } from '@react-three/fiber'
+import { createElement } from 'react'
+import { renderToString } from 'react-dom/server'
+import {
+  BufferGeometry,
+  Float32BufferAttribute,
+  type Material,
+  Mesh,
+  MeshBasicMaterial,
+  Object3D,
+} from 'three'
+import {
+  collectTintedWalls,
+  collectWallBatchCandidates,
+  WallBatchSystem,
+} from './wall-batch-system'
+
+type FrameCallback = Parameters<typeof useFrame>[0]
+let frameCallback: FrameCallback | null = null
+let nowMs = 0
+const fiber = await import('@react-three/fiber')
+
+mock.module('@react-three/fiber', () => ({
+  ...fiber,
+  useFrame: (callback: FrameCallback) => {
+    frameCallback = callback
+  },
+  useThree: (selector: (state: { invalidate: () => void }) => unknown) =>
+    selector({ invalidate: () => undefined }),
+}))
+
+const performanceNow = spyOn(performance, 'now').mockImplementation(() => nowMs)
 
 const registeredIds: string[] = []
 
 afterEach(() => {
+  useViewer.setState({ wallMode: 'down' } as never)
+  frameCallback?.({} as never, 0)
   for (const id of registeredIds.splice(0)) {
-    const mesh = sceneRegistry.nodes.get(id) as Mesh | undefined
-    mesh?.geometry.dispose()
-    const materials = Array.isArray(mesh?.material) ? mesh.material : [mesh?.material]
+    const object = sceneRegistry.nodes.get(id)
+    if (!(object instanceof Mesh)) continue
+    object.geometry.dispose()
+    const materials = Array.isArray(object.material) ? object.material : [object.material]
     for (const material of materials) material?.dispose()
-    sceneRegistry.nodes.delete(id)
   }
+  sceneRegistry.clear()
   useScene.setState({ nodes: {}, rootNodeIds: [] } as never)
-  useViewer.setState({ hoverHighlightMode: 'default', hoveredId: null } as never)
+  useViewer.setState({ hoverHighlightMode: 'default', hoveredId: null, wallMode: 'up' } as never)
+  frameCallback = null
 })
 
-function registerWall(id: string) {
+afterAll(() => {
+  performanceNow.mockRestore()
+})
+
+function registerWall(id: string, material: Material = new MeshBasicMaterial()) {
   const geometry = new BufferGeometry()
   geometry.setAttribute('position', new Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3))
-  const mesh = new Mesh(geometry, [new MeshBasicMaterial()])
+  const mesh = new Mesh(geometry, [material])
   sceneRegistry.nodes.set(id, mesh)
+  sceneRegistry.byType.wall.add(id)
   registeredIds.push(id)
+  return mesh
+}
+
+function takeFrameCallback(): FrameCallback {
+  const callback = frameCallback
+  if (!callback) throw new Error('frame callback expected')
+  return callback
+}
+
+function setupBatchedLevel() {
+  const root = new Object3D()
+  const material = new MeshBasicMaterial()
+  const wallIds = Array.from({ length: 8 }, (_, index) => `wall_${index}`)
+  const walls = wallIds.map((id) => registerWall(id, material))
+  for (const wall of walls) root.add(wall)
+  sceneRegistry.nodes.set('level', root)
+  sceneRegistry.byType.level.add('level')
+  registeredIds.push('level')
+
+  useScene.setState({
+    nodes: {
+      level: { id: 'level', type: 'level', children: wallIds },
+      ...Object.fromEntries(
+        wallIds.map((id) => [id, { id, type: 'wall', parentId: 'level', visible: true }]),
+      ),
+    },
+    rootNodeIds: ['level'],
+    dirtyNodes: new Set(),
+  } as never)
+  const selection = useViewer.getState().selection
+  useViewer.setState({
+    wallMode: 'cutaway',
+    selection: { ...selection, selectedIds: new Set() },
+    previewSelectedIds: new Set(),
+    hoveredId: null,
+  } as never)
+
+  frameCallback = null
+  renderToString(createElement(WallBatchSystem))
+  const runFrame = takeFrameCallback()
+  nowMs = 0
+  runFrame({} as never, 0)
+  nowMs = 181
+  runFrame({} as never, 0)
+
+  const batch = root.children.find((child) => child.name === 'wall-batch') as Mesh | undefined
+  if (!batch) throw new Error('wall batch expected')
+  return { batch, root, runFrame, walls }
 }
 
 describe('collectWallBatchCandidates', () => {
@@ -45,6 +132,27 @@ describe('collectWallBatchCandidates', () => {
     const candidates = [...collectWallBatchCandidates('level', tinted).values()].flat()
 
     expect(candidates.map((candidate) => candidate.nodeId)).toEqual(wallIds.slice(8))
+  })
+
+  test('keeps walls stamped hidden out of a batch', () => {
+    registerWall('wall_hidden')
+    const mesh = sceneRegistry.nodes.get('wall_hidden') as Mesh
+    mesh.userData.wallHidden = true
+
+    useScene.setState({
+      nodes: {
+        level: { id: 'level', type: 'level', children: ['wall_hidden'] },
+        wall_hidden: {
+          id: 'wall_hidden',
+          type: 'wall',
+          parentId: 'level',
+          visible: true,
+        },
+      },
+      rootNodeIds: ['level'],
+    } as never)
+
+    expect(collectWallBatchCandidates('level').size).toBe(0)
   })
 })
 
@@ -70,5 +178,48 @@ describe('collectTintedWalls', () => {
     useViewer.setState({ hoverHighlightMode: 'default', hoveredId: 'slab_a' } as never)
 
     expect([...collectTintedWalls(wallIds)]).toEqual([])
+  })
+})
+
+describe('WallBatchSystem cutaway releases', () => {
+  test('releases a batched wall on the frame its wallHidden stamp appears', () => {
+    const { batch, runFrame, walls } = setupBatchedLevel()
+    const wall = walls[0]!
+    wall.userData.wallHidden = true
+
+    nowMs = 200
+    runFrame({} as never, 0)
+
+    expect(wall.layers.isEnabled(SCENE_LAYER)).toBe(true)
+    expect(batch.geometry.groups[0]?.count).toBe(21)
+  })
+
+  test('does not count hidden walls toward the settled re-merge threshold', () => {
+    const { batch, root, runFrame, walls } = setupBatchedLevel()
+    for (const wall of walls) wall.userData.wallHidden = true
+
+    nowMs = 200
+    runFrame({} as never, 0)
+    nowMs = 381
+    runFrame({} as never, 0)
+
+    expect(root.children.find((child) => child.name === 'wall-batch')).toBe(batch)
+    expect(walls.every((wall) => wall.layers.isEnabled(SCENE_LAYER))).toBe(true)
+  })
+
+  test('re-sews released walls that become visible before settlement', () => {
+    const { batch, root, runFrame, walls } = setupBatchedLevel()
+    for (const wall of walls) wall.userData.wallHidden = true
+
+    nowMs = 200
+    runFrame({} as never, 0)
+    for (const wall of walls) wall.userData.wallHidden = false
+    nowMs = 201
+    runFrame({} as never, 0)
+    nowMs = 381
+    runFrame({} as never, 0)
+
+    expect(root.children.find((child) => child.name === 'wall-batch')).not.toBe(batch)
+    expect(walls.every((wall) => !wall.layers.isEnabled(SCENE_LAYER))).toBe(true)
   })
 })

--- a/packages/nodes/src/wall/wall-batch-system.tsx
+++ b/packages/nodes/src/wall/wall-batch-system.tsx
@@ -455,7 +455,7 @@ function runBatchFrame(
     changed = true
   }
   lastCutawayHiddenWalls = cutawayHiddenWalls
-  const excludedNodeIds = cutawayHiddenWalls
+  const excludedNodeIds = new Set(cutawayHiddenWalls)
   for (const nodeId of tintedWalls) excludedNodeIds.add(nodeId)
 
   // A theme, texture or material-library switch re-makes every wall's

--- a/packages/nodes/src/wall/wall-batch-system.tsx
+++ b/packages/nodes/src/wall/wall-batch-system.tsx
@@ -152,6 +152,7 @@ function toCandidate(
 
   const mesh = sceneRegistry.nodes.get(nodeId) as Mesh | undefined
   if (!mesh?.visible) return null
+  if (mesh.userData.wallHidden === true) return null
   // Solo's shadow-caster-only pass and the viewer's isolation filter both
   // hide a wall by taking it off the scene layer. Sewing it in would put it
   // back on screen through the merged mesh, which neither asked for.
@@ -170,15 +171,14 @@ function toCandidate(
  *
  * The merged mesh captures one material set when it is sewn and nothing
  * re-reads it, so batching is only sound while every batched wall's materials
- * hold still. That is true in one wall mode. `cutaway` re-assigns materials
- * from the camera's facing test as the view turns, `down` makes every wall
- * see-through and `translucent` does the same by definition — in all three the
- * merged copy would keep drawing walls the cutaway pass has since turned to
- * glass. Isolation is the other stand-down: it hides the level root the merged
- * mesh hangs off, which would leave a focused batched wall drawn by nobody.
+ * hold still. That is true in `up`; in `cutaway`, walls stamped `wallHidden`
+ * are released per wall in the same frame because WallCutout runs at priority
+ * 0 and this system at 5. `down` and `translucent` make every wall see-through.
+ * Isolation is the other stand-down: it hides the level root the merged mesh
+ * hangs off, which would leave a focused batched wall drawn by nobody.
  */
 export function canBatchWalls(wallMode: WallMode, isolationActive: boolean): boolean {
-  return !isolationActive && wallMode === 'up'
+  return !isolationActive && (wallMode === 'up' || wallMode === 'cutaway')
 }
 
 /**
@@ -399,6 +399,25 @@ function runBatchFrame(
     changed = true
   }
 
+  // Only cutaway hides walls one by one; `up` hides none and the other modes
+  // stand the batch down, so the stamp scan is worth a frame only there.
+  const cutawayHiddenWalls = new Set<string>()
+  if (useViewer.getState().wallMode === 'cutaway') {
+    for (const nodeId of wallIds) {
+      const mesh = sceneRegistry.nodes.get(nodeId)
+      if (mesh?.userData.wallHidden === true) cutawayHiddenWalls.add(nodeId)
+    }
+  }
+  for (const nodeId of cutawayHiddenWalls) {
+    const record = batchByNode.get(nodeId)
+    if (!record) continue
+    releaseWall(nodeId)
+    staleLevels.add(record.levelId)
+    changed = true
+  }
+  const excludedNodeIds = cutawayHiddenWalls
+  for (const nodeId of tintedWalls) excludedNodeIds.add(nodeId)
+
   // A theme, texture or material-library switch re-makes every wall's
   // materials without marking a single node, so the merged copies have to be
   // sewn again from the new ones. See `appearanceChanged`.
@@ -421,13 +440,11 @@ function runBatchFrame(
     }
   }
 
-  // Two things make merging unsound, and both are handled the same way: the
-  // batch stands down for as long as they hold, and sews the floors back
-  // together once they lift. Isolation hides everything outside the focused
-  // subtree, and a level's merged mesh hangs off the level root — so it goes
-  // dark with everything else, leaving a focused batched wall drawn by nobody.
-  // Every wall mode but `up` re-assigns wall materials the merged mesh does not
-  // follow. See `canBatchWalls`.
+  // Isolation, `down` and `translucent` make batching unsound, so the batch
+  // stands down while they hold and sews the floors back together once they
+  // lift. `cutaway` stays live because WallCutout stamps hidden walls at
+  // priority 0 and this system releases them per wall at priority 5 in the
+  // same frame. See `canBatchWalls`.
   const suspended = !canBatchWalls(useViewer.getState().wallMode, isIsolationActive())
   if (suspended !== batchingSuspended) {
     batchingSuspended = suspended
@@ -466,8 +483,8 @@ function runBatchFrame(
   }
 
   for (const levelId of staleLevels) {
-    if (unbatchedWallCount(levelId, tintedWalls) >= MIN_BATCH_WALLS) {
-      mergeLevel(levelId, tintedWalls)
+    if (unbatchedWallCount(levelId, excludedNodeIds) >= MIN_BATCH_WALLS) {
+      mergeLevel(levelId, excludedNodeIds)
     }
   }
   staleLevels.clear()

--- a/packages/nodes/src/wall/wall-batch-system.tsx
+++ b/packages/nodes/src/wall/wall-batch-system.tsx
@@ -328,6 +328,34 @@ export const WallBatchSystem = () => {
 
   useFrame(() => runBatchFrame(invalidate, wakeRef), 5)
 
+  // Scripted-probe hook, ?perf sessions only (mirrors __itemBatch): the
+  // panel has no row for the merged wall batch, so probes read it here.
+  useEffect(() => {
+    if (!new URLSearchParams(window.location.search).has('perf')) return
+    const probe = {
+      stats: () => {
+        let batches = 0
+        for (const records of batchesByLevel.values()) batches += records.length
+        let hidden = 0
+        for (const nodeId of sceneRegistry.byType.wall ?? EMPTY_IDS) {
+          if (sceneRegistry.nodes.get(nodeId)?.userData.wallHidden === true) hidden++
+        }
+        return {
+          walls: batchByNode.size,
+          batches,
+          levels: batchesByLevel.size,
+          hidden,
+          suspended: batchingSuspended,
+          wallMode: useViewer.getState().wallMode,
+        }
+      },
+    }
+    ;(window as unknown as { __wallBatch?: unknown }).__wallBatch = probe
+    return () => {
+      delete (window as unknown as { __wallBatch?: unknown }).__wallBatch
+    }
+  }, [])
+
   useEffect(
     () => () => {
       if (wakeRef.current) clearTimeout(wakeRef.current)

--- a/packages/nodes/src/wall/wall-batch-system.tsx
+++ b/packages/nodes/src/wall/wall-batch-system.tsx
@@ -90,6 +90,7 @@ const batchByNode = new Map<string, BatchRecord>()
 const staleLevels = new Set<string>()
 const changedWalls = new Set<string>()
 const EMPTY_IDS: ReadonlySet<string> = new Set()
+let lastCutawayHiddenWalls: ReadonlySet<string> = EMPTY_IDS
 let knownWallCount = -1
 let lastWallChangeAtMs = 0
 let batchingSuspended = false
@@ -362,6 +363,7 @@ export const WallBatchSystem = () => {
       for (const levelId of [...batchesByLevel.keys()]) disposeLevelBatches(levelId)
       changedWalls.clear()
       staleLevels.clear()
+      lastCutawayHiddenWalls = EMPTY_IDS
       knownWallCount = -1
       batchingSuspended = false
       lastAppearance.shading = undefined
@@ -443,6 +445,16 @@ function runBatchFrame(
     staleLevels.add(record.levelId)
     changed = true
   }
+  // A stamp that lifts hands the wall back to its own draw call, and nothing
+  // else marks the level — so the flip itself has to, or the wall would stay
+  // out of the merged mesh until an unrelated edit re-sews the floor.
+  for (const nodeId of lastCutawayHiddenWalls) {
+    if (cutawayHiddenWalls.has(nodeId)) continue
+    const node = nodes[nodeId as AnyNodeId]
+    if (node?.type === 'wall' && node.parentId) staleLevels.add(node.parentId)
+    changed = true
+  }
+  lastCutawayHiddenWalls = cutawayHiddenWalls
   const excludedNodeIds = cutawayHiddenWalls
   for (const nodeId of tintedWalls) excludedNodeIds.add(nodeId)
 


### PR DESCRIPTION
## Metric

Charter backlog 3c: idle frame cpu in **cutaway** should match the full-height number on the rich fixtures (the mode users edit in loads walls unbatched today).

## What changes

Cutaway never changes wall geometry: `WallCutout` (viewer, `useFrame` priority 0) swaps each wall's material array by camera facing and stamps `userData.wallHidden`. The merged wall batch already released tinted walls every frame, so hidden walls take the same path — released the frame the stamp appears (this system runs at priority 5, same frame), excluded from candidates and from the re-merge drift count, re-sewn at settle when they come back. Mode flips between up and cutaway no longer dispose every level. `down`, `translucent` and isolation still stand the batch down.

`window.__wallBatch.stats()` is exposed under `?perf` so scripted runs can read wall batch membership (the panel's batch row only covers node batching).

## Before / after (private `scripts/perf/run-scaling-matrix.ts`, same machine, load avg 5–6)

| fixture | mode at load | idle frame cpu | post-hover idle |
| --- | --- | ---: | ---: |
| rich 4× (356 walls, 540 items) | cutaway | 16.9 → 14.0 ms (−17%) | 18.9 → 15.9 ms |
| rich 2× | cutaway | 8.4 → 8.4 ms | 8.6 → 8.4 ms |
| tower 2×18 | full height | 11.1 → 9.5 ms | 11.6 → 10.2 ms |
| Maxi 8× | full height | 15.2 → 18.0 ms (noise; identical code path) | 19.0 → 22.2 ms |

Wall mode is persisted per project, so only the rich fixtures load in cutaway. In-page probe on the PR build: cutaway batches 164 of the rich-4× walls (172 hidden), 82 on rich-2×, 160 on Maxi-4×; cutaway vs full-height frame cost within 5 % on all three; draws −350…−580 at the load pose.

## Gates

- `bun test packages/nodes`: 1888 pass. New unit coverage: hidden walls are not candidates, a batched wall is released the frame its stamp appears, hidden walls do not count toward the re-merge threshold, released walls re-sew once visible and settled.
- E2e against the PR build: perf-regression pack 5/5, click-batched-wall, click-hidden-wall, opening-placement-preview green; `placement-preview-follows-cursor` fails identically on base (pre-existing).
- Visual parity (canvas screenshots, cutaway load pose / after orbit / full height / cutaway again): ≤ 0.28 % differing pixels on rich 2×/4×; Maxi 4× post-orbit poses differ by an orbit end-pose shift only.
- Bake parity: Maxi 1× and rich 2× bakes identical in triangles, meshes, primitives, nodes and materials.

## Follow-ups (not here)

Camera flips still cost a re-sew at each orbit stop in cutaway; keeping hidden walls resident (or moving walls onto `NodeBatchStore`) removes that. The rich-4× < 12 ms target needs ceilings + slabs coverage on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rendering batching and cutaway interaction timing; mistakes could cause wrong walls drawn, missing picks, or hover glitches, though coverage is strong.
> 
> **Overview**
> **Wall merging now stays enabled in cutaway** instead of tearing down every level batch on mode entry. `canBatchWalls` treats `cutaway` like `up`; `down`, `translucent`, and isolation still suspend batching.
> 
> Cutaway-hidden walls are handled like hover/selection releases: meshes stamped `userData.wallHidden` are skipped as batch candidates, released from the merged mesh the same frame the stamp appears (after WallCutout at priority 0), and excluded from the settle re-merge count so the batch can stay stable while most walls remain merged. When a stamp clears, the level is marked stale so visible walls re-sew after the usual settle window.
> 
> Re-merge and candidate collection use a combined `excludedNodeIds` set (cutaway-hidden plus tinted walls). **`?perf` sessions** get `window.__wallBatch.stats()` for scripted batch metrics. Tests cover suspension rules, hidden candidates, per-frame release, settle behavior, visibility flip re-sew, and hover not blocking settle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f6706470557ee1ffaa07c2b95773c6dd85f5e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->