### PR TITLE
Wall batch test: drive the frame function directly

### DIFF
--- a/packages/nodes/src/wall/wall-batch-system.test.ts
+++ b/packages/nodes/src/wall/wall-batch-system.test.ts
@@ -1,9 +1,6 @@
-import { afterAll, afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { afterAll, afterEach, describe, expect, spyOn, test } from 'bun:test'
 import { sceneRegistry, useScene } from '@pascal-app/core'
 import { SCENE_LAYER, useViewer } from '@pascal-app/viewer'
-import type { useFrame } from '@react-three/fiber'
-import { createElement } from 'react'
-import { renderToString } from 'react-dom/server'
 import {
   BufferGeometry,
   Float32BufferAttribute,
@@ -18,22 +15,12 @@ import {
   collectWallBatchCandidates,
   holdBatchedWallsAfterCapture,
   revealBatchedWallsForCapture,
-  WallBatchSystem,
+  runBatchFrame,
 } from './wall-batch-system'
 
-type FrameCallback = Parameters<typeof useFrame>[0]
-let frameCallback: FrameCallback | null = null
 let nowMs = 0
-const fiber = await import('@react-three/fiber')
-
-mock.module('@react-three/fiber', () => ({
-  ...fiber,
-  useFrame: (callback: FrameCallback) => {
-    frameCallback = callback
-  },
-  useThree: (selector: (state: { invalidate: () => void }) => unknown) =>
-    selector({ invalidate: () => undefined }),
-}))
+const wakeRef: { current: ReturnType<typeof setTimeout> | null } = { current: null }
+const runFrame = (_state?: unknown, _delta?: number) => runBatchFrame(() => undefined, wakeRef)
 
 const performanceNow = spyOn(performance, 'now').mockImplementation(() => nowMs)
 
@@ -41,7 +28,7 @@ const registeredIds: string[] = []
 
 afterEach(() => {
   useViewer.setState({ wallMode: 'down' } as never)
-  frameCallback?.({} as never, 0)
+  runFrame()
   for (const id of registeredIds.splice(0)) {
     const object = sceneRegistry.nodes.get(id)
     if (!(object instanceof Mesh)) continue
@@ -52,7 +39,6 @@ afterEach(() => {
   sceneRegistry.clear()
   useScene.setState({ nodes: {}, rootNodeIds: [] } as never)
   useViewer.setState({ hoverHighlightMode: 'default', hoveredId: null, wallMode: 'up' } as never)
-  frameCallback = null
 })
 
 afterAll(() => {
@@ -67,12 +53,6 @@ function registerWall(id: string, material: Material = new MeshBasicMaterial()) 
   sceneRegistry.byType.wall.add(id)
   registeredIds.push(id)
   return mesh
-}
-
-function takeFrameCallback(): FrameCallback {
-  const callback = frameCallback
-  if (!callback) throw new Error('frame callback expected')
-  return callback
 }
 
 function setupBatchedLevel(count = 8) {
@@ -103,9 +83,6 @@ function setupBatchedLevel(count = 8) {
     hoveredId: null,
   } as never)
 
-  frameCallback = null
-  renderToString(createElement(WallBatchSystem))
-  const runFrame = takeFrameCallback()
   nowMs = 0
   runFrame({} as never, 0)
   nowMs = 181

--- a/packages/nodes/src/wall/wall-batch-system.tsx
+++ b/packages/nodes/src/wall/wall-batch-system.tsx
@@ -414,7 +414,7 @@ export const WallBatchSystem = () => {
  * "did this wall move" on its own, and the per-frame cost is the size of the
  * dirty set rather than the size of the floor.
  */
-function runBatchFrame(
+export function runBatchFrame(
   invalidate: () => void,
   wakeRef: { current: ReturnType<typeof setTimeout> | null },
 ) {


### PR DESCRIPTION
The wall batch test harness (added in #761) rendered `WallBatchSystem` through `react-dom/server` to capture the `useFrame` callback. `react-dom` is not resolvable from `packages/nodes` in the private monorepo's install, so its CI could not load the file (`Cannot find module 'react-dom/server'`). The frame function is now exported and the test calls it directly; the fiber mock goes away with the render.

`bun test packages/nodes`: 1 909 pass. Repo-wide biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor plus exporting an existing internal frame helper; production behavior is unchanged aside from the public export.
> 
> **Overview**
> Fixes **CI failures** in `packages/nodes` where wall batch tests could not load because they depended on `react-dom/server`, which is not resolvable from that package’s install.
> 
> **`runBatchFrame`** is now **exported** from `wall-batch-system.tsx` (the same function `WallBatchSystem` already invokes from `useFrame`). The test harness calls it through a small `runFrame` wrapper with a noop `invalidate` and a `wakeRef`, instead of rendering the React component via SSR to capture the fiber `useFrame` callback.
> 
> The **`@react-three/fiber` mock**, **`react-dom/server`**, and related setup/teardown around `frameCallback` are removed; batch setup still advances simulated time and runs two frames to create the merged `wall-batch` mesh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e8fb6f4e2726b7e21cd844614ea3f091c358670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->