### PR TITLE
CSG union tests: give the rounded-opening unions a 30 s budget

### DIFF
--- a/packages/viewer/src/systems/wall/wall-csg-union.test.ts
+++ b/packages/viewer/src/systems/wall/wall-csg-union.test.ts
@@ -503,7 +503,7 @@ describe('wall cutter union', () => {
       } finally {
         cleanup()
       }
-    })
+    }, 30_000)
   }
 
   test('unions overlapping support and door cuts alongside an item proxy', () => {
@@ -543,7 +543,7 @@ describe('wall cutter union', () => {
       proxy.geometry.dispose()
       cleanup()
     }
-  })
+  }, 30_000)
 
   test('bakes transforms and normalizes mixed indexed and non-indexed attributes', () => {
     const a = new Brush(new THREE.BoxGeometry(1, 1, 1))


### PR DESCRIPTION
On the private monorepo's CI (22 turbo test tasks on one runner) the rounded-opening union test from #762 took 6.0 s against bun's 5 s default timeout; it takes 0.6 s on this repo's CI. The three union tests that do real boolean work get an explicit 30 s budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout adjustments with no production code or assertion changes.
> 
> **Overview**
> Raises Bun’s per-test timeout from the default **5 s** to **30 s** for the heaviest wall CSG union cases so they don’t flake on slower CI (e.g. crowded monorepo runners).
> 
> The **arch/rounded overlapping openings** parameterized test and **`unions overlapping support and door cuts alongside an item proxy`** now pass an explicit `30_000` ms budget; behavior under test is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a36f26b45790864812bb5901e5ca4014b44d96b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->