### PR TITLE
perf(viewer): cache wall cutout facing instead of re-evaluating every wall per camera move

### DIFF
--- a/packages/viewer/src/lib/materials.ts
+++ b/packages/viewer/src/lib/materials.ts
@@ -111,6 +111,12 @@ const surfaceRoleMaterialCache = new Map<string, THREE.Material>()
 const textureCache = new Map<string, THREE.Texture>()
 const textureLoadPromises = new Map<string, Promise<THREE.Texture | null>>()
 const textureLoader = new THREE.TextureLoader()
+let materialTextureVersion = 0
+
+// Highlight clones can observe late assignments without polling every material.
+export function getMaterialTextureVersion(): number {
+  return materialTextureVersion
+}
 
 // `.ktx2` finish maps transcode through the shared KTX2 loader (support is
 // detected once at viewer init); everything else loads as a normal image.
@@ -385,6 +391,7 @@ function queueTextureAssignment(
       // and crash in TextureNode.update ("null (reading 'matrix')").
       textureMaterial[slot] = null
       material.needsUpdate = true
+      materialTextureVersion++
     }
     return
   }
@@ -401,6 +408,7 @@ function queueTextureAssignment(
   if (cached) {
     textureMaterial[slot] = createAssignedTexture(cached, props, slot)
     material.needsUpdate = true
+    materialTextureVersion++
     return
   }
 
@@ -411,12 +419,14 @@ function queueTextureAssignment(
   if (textureMaterial[slot] != null) {
     textureMaterial[slot] = null
     material.needsUpdate = true
+    materialTextureVersion++
   }
 
   loadPresetTexture(path, props, slot).then((texture) => {
     if (!texture) return
     textureMaterial[slot] = createAssignedTexture(texture, props, slot)
     material.needsUpdate = true
+    materialTextureVersion++
   })
 }
 

--- a/packages/viewer/src/systems/wall/wall-cutout-cache.test.ts
+++ b/packages/viewer/src/systems/wall/wall-cutout-cache.test.ts
@@ -1,16 +1,33 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 import {
+  BuildingNode,
+  LevelNode,
   MaterialPresetPayloadSchema,
   registerLibraryMaterials,
   SceneMaterial,
+  SiteNode,
   sceneRegistry,
   unregisterLibraryMaterials,
+  useLiveTransforms,
   useScene,
   WallNode,
 } from '@pascal-app/core'
-import { BoxGeometry, Group, type Material, Mesh, PerspectiveCamera, Texture, Vector3 } from 'three'
+import { act, createRoot, useFrame } from '@react-three/fiber'
+import { createElement } from 'react'
+import {
+  BoxGeometry,
+  Group,
+  type Material,
+  Mesh,
+  MeshBasicMaterial,
+  PerspectiveCamera,
+  Texture,
+  TextureLoader,
+  Vector3,
+} from 'three'
+import { applyMaterialPresetToMaterials } from '../../lib/materials'
 import useViewer from '../../store/use-viewer'
-import { getWallHideState } from './wall-cutout'
+import { getWallHideState, WallCutout } from './wall-cutout'
 import {
   sameMaterialArray,
   WALL_FACING_HYSTERESIS,
@@ -29,6 +46,7 @@ const viewerBefore = useViewer.getState()
 let cache: WallCutoutCache
 let camera: PerspectiveCamera
 let unsubscribe: () => void
+let unsubscribeTransforms: () => void
 
 function addWall(frontSide = 'exterior', backSide = 'interior') {
   const node = WallNode.parse({ start: [0, 0], end: [4, 0], frontSide, backSide })
@@ -75,13 +93,17 @@ beforeEach(() => {
     hoveredId: null,
     hoverHighlightMode: 'default',
   })
+  useLiveTransforms.getState().clearAll()
   cache = new WallCutoutCache()
+  unsubscribeTransforms = cache.subscribeLiveTransforms()
   camera = new PerspectiveCamera()
   unsubscribe = subscribeWallRebuilds((id) => cache.rebuilt.add(id))
 })
 
 afterEach(() => {
   unsubscribe()
+  unsubscribeTransforms()
+  useLiveTransforms.getState().clearAll()
   drainRebuiltWalls(new Set())
   sceneRegistry.clear()
   useScene.setState(sceneBefore)
@@ -186,10 +208,19 @@ describe('WallCutoutCache', () => {
   test('scene transform and side changes refresh facing with a stationary camera', () => {
     const { node, mesh } = addWall()
     const parent = new Group()
+    const ancestor = BuildingNode.parse({})
+    useScene.setState({
+      nodes: { [ancestor.id]: ancestor, [node.id]: { ...node, parentId: ancestor.id } },
+    })
     parent.add(mesh)
     cache.update(camera, 1)
     parent.rotation.y = Math.PI
-    useScene.setState({ nodes: { ...useScene.getState().nodes } })
+    useScene.setState({
+      nodes: {
+        ...useScene.getState().nodes,
+        [ancestor.id]: { ...ancestor, rotation: [0, Math.PI, 0] },
+      },
+    })
     cache.update(camera, 1.01)
     expect(mesh.userData.wallHidden).toBe(false)
     useScene.setState({
@@ -197,6 +228,238 @@ describe('WallCutoutCache', () => {
     })
     cache.update(camera, 1.02)
     expect(mesh.userData.wallHidden).toBe(true)
+  })
+
+  for (const schema of [SiteNode, BuildingNode, LevelNode]) {
+    test(`live ${schema.parse({}).type} rotation, commit and cancel refresh descendant normals`, () => {
+      const parentNode = schema.parse({})
+      const parent = new Group()
+      const { node, mesh } = addWall()
+      parent.add(mesh)
+      useScene.setState({
+        nodes: {
+          ...useScene.getState().nodes,
+          [parentNode.id]: parentNode,
+          [node.id]: { ...node, parentId: parentNode.id },
+        },
+      })
+      const nodes = useScene.getState().nodes
+      cache.update(camera, 1)
+      const publish = (rotation: number) => {
+        parent.rotation.y = rotation
+        useLiveTransforms.getState().set(parentNode.id, { position: [0, 0, 0], rotation })
+        cache.update(camera, 1.01)
+        expect(mesh.userData.wallHidden).toBe(
+          getWallHideState(node, mesh, 'cutaway', new Vector3(0, 0, -1)),
+        )
+      }
+      publish(Math.PI)
+      expect(mesh.userData.wallHidden).toBe(false)
+      publish(0)
+      publish(Math.PI)
+      expect(useScene.getState().nodes).toBe(nodes)
+      useLiveTransforms.getState().clear(parentNode.id)
+      cache.update(camera, 1.02)
+      expect(mesh.userData.wallHidden).toBe(false)
+      publish(0)
+      parent.rotation.y = Math.PI
+      useLiveTransforms.getState().clearAll()
+      cache.update(camera, 1.03)
+      expect(mesh.userData.wallHidden).toBe(false)
+    })
+  }
+
+  test('same-facing scans repair restored materials and corrupted stamps', () => {
+    const { mesh } = addWall()
+    cache.update(camera, 1)
+    const expected = mesh.material
+    mesh.material = [new MeshBasicMaterial()]
+    mesh.userData.wallHidden = false
+    camera.position.x++
+    cache.update(camera, 2)
+    expect(mesh.material).toBe(expected)
+    expect(mesh.userData.wallHidden).toBe(true)
+  })
+
+  test('paint hover preserves preview through cache updates and restores current appearance on leave', () => {
+    useViewer.setState({ wallMode: 'up' })
+    const { node, mesh } = addWall()
+    cache.update(camera, 1)
+    const original = mesh.material
+    const preview = [new MeshBasicMaterial()]
+    useViewer.setState({ hoveredId: node.id })
+    useViewer.setState({ hoverHighlightMode: 'paint-ready' })
+    mesh.material = preview
+    const normal = spyOn(mesh, 'updateWorldMatrix')
+    cache.update(camera, 1.01)
+    expect(mesh.material).toBe(preview)
+    expect(normal).not.toHaveBeenCalled()
+    useViewer.setState({ wallMode: 'cutaway' })
+    cache.update(camera, 1.02)
+    camera.position.x++
+    cache.update(camera, 2)
+    expect(mesh.material).toBe(preview)
+    mesh.material = original
+    useViewer.setState({ hoveredId: null, hoverHighlightMode: 'default' })
+    cache.update(camera, 2.01)
+    expect(mesh.material).toBe(cache.walls.get(node.id)!.hiddenVariant.materials)
+    normal.mockRestore()
+  })
+
+  test('appearance changes during preview are applied when temporary ownership ends', () => {
+    useViewer.setState({ wallMode: 'up' })
+    const { node, mesh } = addWall()
+    cache.update(camera, 1)
+    const original = mesh.material
+    const preview = [new MeshBasicMaterial()]
+    useViewer.setState({ hoveredId: node.id, hoverHighlightMode: 'paint-ready' })
+    mesh.material = preview
+    useViewer.setState({ colorPreset: 'white' })
+    cache.update(camera, 1.01)
+    expect(mesh.material).toBe(preview)
+    mesh.material = original
+    useViewer.setState({ hoveredId: null, hoverHighlightMode: 'default' })
+    cache.update(camera, 1.02)
+    expect(mesh.material).toBe(cache.walls.get(node.id)!.visibleVariant.materials)
+    expect(mesh.material).not.toBe(original)
+  })
+
+  test('a live ancestor above the level updates every descendant once', () => {
+    const building = BuildingNode.parse({})
+    const level = LevelNode.parse({ parentId: building.id })
+    const outer = new Group()
+    const inner = new Group()
+    outer.add(inner)
+    const walls = [addWall(), addWall()]
+    for (const { node, mesh } of walls) {
+      inner.add(mesh)
+      useScene.setState({
+        nodes: {
+          ...useScene.getState().nodes,
+          [building.id]: building,
+          [level.id]: level,
+          [node.id]: { ...node, parentId: level.id },
+        },
+      })
+    }
+    cache.update(camera, 1)
+    const outerUpdate = spyOn(outer, 'updateWorldMatrix')
+    const innerUpdate = spyOn(inner, 'updateWorldMatrix')
+    outer.rotation.y = Math.PI
+    useLiveTransforms.getState().set(building.id, { position: [0, 0, 0], rotation: Math.PI })
+    cache.update(camera, 1.01)
+    expect(outerUpdate).toHaveBeenCalledTimes(1)
+    expect(innerUpdate).toHaveBeenCalledTimes(1)
+    for (const { mesh } of walls) expect(mesh.userData.wallHidden).toBe(false)
+    outerUpdate.mockRestore()
+    innerUpdate.mockRestore()
+  })
+
+  test('scopes node edits to their wall paths and updates shared ancestors once', () => {
+    const parents = Array.from({ length: 4 }, () => ({
+      node: BuildingNode.parse({}),
+      mesh: new Group(),
+    }))
+    const walls = Array.from({ length: 100 }, (_, i) => {
+      const wall = addWall()
+      const parent = parents[i % 4]!
+      parent.mesh.add(wall.mesh)
+      useScene.setState({
+        nodes: {
+          ...useScene.getState().nodes,
+          [parent.node.id]: parent.node,
+          [wall.node.id]: { ...wall.node, parentId: parent.node.id },
+        },
+      })
+      return wall
+    })
+    cache.update(camera, 1)
+    const parentUpdates = parents.map(({ mesh }) => spyOn(mesh, 'updateWorldMatrix'))
+    const wallUpdates = walls.map(({ mesh }) => spyOn(mesh, 'updateWorldMatrix'))
+    const variants = walls.map(({ node }) => cache.walls.get(node.id)!.visibleVariant)
+    const unrelated = BuildingNode.parse({})
+    useScene.setState({ nodes: { ...useScene.getState().nodes, [unrelated.id]: unrelated } })
+    cache.update(camera, 1.01)
+    for (const spy of [...parentUpdates, ...wallUpdates]) expect(spy).not.toHaveBeenCalled()
+    walls.forEach(({ node }, i) => {
+      expect(cache.walls.get(node.id)!.visibleVariant).toBe(variants[i])
+    })
+    const changed = parents[0]!
+    changed.mesh.rotation.y = Math.PI
+    useScene.setState({
+      nodes: {
+        ...useScene.getState().nodes,
+        [changed.node.id]: { ...changed.node, rotation: [0, Math.PI, 0] },
+      },
+    })
+    cache.update(camera, 1.02)
+    parentUpdates.forEach((spy, i) => {
+      expect(spy).toHaveBeenCalledTimes(i === 0 ? 1 : 0)
+    })
+    wallUpdates.forEach((spy, i) => {
+      expect(spy).toHaveBeenCalledTimes(i % 4 === 0 ? 1 : 0)
+    })
+    walls.forEach(({ node, mesh }, i) => {
+      expect(mesh.userData.wallHidden).toBe(i % 4 !== 0)
+      if (i % 4 !== 0) expect(cache.walls.get(node.id)!.visibleVariant).toBe(variants[i])
+    })
+    for (const spy of [...parentUpdates, ...wallUpdates]) spy.mockRestore()
+  })
+
+  test('appearance changes do not revisit transforms', () => {
+    const { mesh } = addWall()
+    cache.update(camera, 1)
+    const matrix = spyOn(mesh, 'updateWorldMatrix')
+    useViewer.setState({ colorPreset: 'white' })
+    cache.update(camera, 1.01)
+    expect(matrix).not.toHaveBeenCalled()
+    matrix.mockRestore()
+  })
+
+  test('actual R3F advance renders camera stamps before rebuilds and passes them to the batch', async () => {
+    const { node, mesh } = addWall()
+    const canvas = { width: 1, height: 1, style: {} } as HTMLCanvasElement
+    const root = createRoot(canvas)
+    const rendered: boolean[] = []
+    const batched: boolean[] = []
+    let rebuild = false
+    function FrameConsumers() {
+      useFrame(() => rendered.push(mesh.userData.wallHidden), 1)
+      useFrame(() => {
+        if (!rebuild) return
+        mesh.rotation.y = Math.PI
+        notifyWallRebuilt(node.id)
+        rebuild = false
+      }, 4)
+      useFrame(() => batched.push(mesh.userData.wallHidden), 5)
+      return createElement(WallCutout)
+    }
+    await root.configure({
+      camera,
+      frameloop: 'never',
+      size: { width: 1, height: 1, top: 0, left: 0 },
+      gl: { render() {}, setSize() {}, setPixelRatio() {} } as never,
+    })
+    let store: ReturnType<typeof root.render>
+    await act(async () => {
+      store = root.render(createElement(FrameConsumers))
+    })
+    try {
+      const advance = (time: number) => store!.getState().advance(time)
+      advance(1)
+      camera.rotation.y = Math.PI
+      advance(2)
+      expect(rendered).toEqual([true, false])
+      expect(batched).toEqual(rendered)
+      rebuild = true
+      advance(3)
+      expect(rendered[2]).toBe(false)
+      advance(3.01)
+      expect(rendered[3]).toBe(true)
+      expect(batched).toEqual(rendered)
+    } finally {
+      await act(async () => root.unmount())
+    }
   })
 
   test('mode round trips immediately lift stamps and preserve low/translucent semantics', () => {
@@ -317,7 +580,7 @@ describe('WallCutoutCache', () => {
     }
   })
 
-  test('selected wall clones pick up a late texture with a stationary full-height camera', () => {
+  test('selected wall clones pick up a late texture with a stationary full-height camera', async () => {
     const { node, mesh } = addWall()
     useViewer.setState({
       wallMode: 'up',
@@ -334,13 +597,35 @@ describe('WallCutoutCache', () => {
     ).visible[1]! as Material & { map: Texture | null }
     const originalMap = source.map
     const texture = new Texture()
+    const loader = spyOn(TextureLoader.prototype, 'loadAsync').mockResolvedValue(texture)
     try {
-      source.map = texture
+      applyMaterialPresetToMaterials(
+        source,
+        MaterialPresetPayloadSchema.parse({
+          maps: { albedoMap: '/row14-late-texture.png' },
+          mapProperties: {},
+        }),
+      )
+      await new Promise((resolve) => setTimeout(resolve, 0))
       cache.update(camera, 1.01)
       expect(
-        ((mesh.material as Material[])[1] as Material & { map: Texture }).map === texture,
+        ((mesh.material as Material[])[1] as Material & { map: Texture }).map === source.map,
       ).toBe(true)
+      expect(source.map).not.toBeNull()
+      const loadedMap = source.map
+      let reads = 0
+      Object.defineProperty(source, 'map', {
+        configurable: true,
+        get: () => {
+          reads++
+          return loadedMap
+        },
+      })
+      for (let i = 0; i < 100; i++) cache.update(camera, 2 + i)
+      expect(reads).toBe(0)
+      Object.defineProperty(source, 'map', { configurable: true, writable: true, value: loadedMap })
     } finally {
+      loader.mockRestore()
       source.map = originalMap
       texture.dispose()
     }
@@ -393,4 +678,17 @@ test('hysteresis holds both sides near zero and switches beyond the band', () =>
   }
   expect(wallFacingNegative(-2 * e, false)).toBe(true)
   expect(wallFacingNegative(2 * e, true)).toBe(false)
+})
+
+test('legacy wall extensions preserve the viewer-to-nodes dependency boundary', async () => {
+  const root = new URL('../../', import.meta.url).pathname
+  for (const file of new Bun.Glob('**/*.{ts,tsx}').scanSync(root)) {
+    const source = await Bun.file(`${root}${file}`).text()
+    expect(source).not.toMatch(/(?:from|import\s*\()\s*['"]@pascal-app\/nodes/)
+  }
+  for (const file of ['wall-cutout-cache.ts', 'wall-rebuild-notifications.ts']) {
+    const source = await Bun.file(new URL(file, import.meta.url)).text()
+    expect(source.split('\n')[0]).toContain('New kind-specific modules belong in nodes')
+    expect(source.split('\n')[1]).toContain('viewer-owned')
+  }
 })

--- a/packages/viewer/src/systems/wall/wall-cutout-cache.test.ts
+++ b/packages/viewer/src/systems/wall/wall-cutout-cache.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
 import {
   BuildingNode,
   LevelNode,
@@ -25,13 +26,14 @@ import {
   TextureLoader,
   Vector3,
 } from 'three'
+import { createStore, type StoreApi } from 'zustand/vanilla'
 import { applyMaterialPresetToMaterials } from '../../lib/materials'
-import useViewer from '../../store/use-viewer'
 import { getWallHideState, WallCutout } from './wall-cutout'
 import {
   sameMaterialArray,
   WALL_FACING_HYSTERESIS,
   WallCutoutCache,
+  type WallCutoutViewerState,
   wallFacingNegative,
 } from './wall-cutout-cache'
 import { getMaterialsForWall } from './wall-materials'
@@ -42,7 +44,7 @@ import {
 } from './wall-rebuild-notifications'
 
 const sceneBefore = useScene.getState()
-const viewerBefore = useViewer.getState()
+let viewerStore: StoreApi<WallCutoutViewerState>
 let cache: WallCutoutCache
 let camera: PerspectiveCamera
 let unsubscribe: () => void
@@ -83,18 +85,19 @@ function trackWrites(mesh: Mesh) {
 beforeEach(() => {
   sceneRegistry.clear()
   useScene.setState({ nodes: {}, materials: {} })
-  useViewer.setState({
+  viewerStore = createStore<WallCutoutViewerState>(() => ({
     wallMode: 'cutaway',
     shading: 'solid',
     textures: false,
     colorPreset: 'clay',
-    selection: { ...viewerBefore.selection, selectedIds: [] },
+    sceneTheme: 'studio',
+    selection: { buildingId: null, levelId: null, zoneId: null, selectedIds: [] },
     previewSelectedIds: [],
     hoveredId: null,
     hoverHighlightMode: 'default',
-  })
+  }))
   useLiveTransforms.getState().clearAll()
-  cache = new WallCutoutCache()
+  cache = new WallCutoutCache(viewerStore)
   unsubscribeTransforms = cache.subscribeLiveTransforms()
   camera = new PerspectiveCamera()
   unsubscribe = subscribeWallRebuilds((id) => cache.rebuilt.add(id))
@@ -107,12 +110,11 @@ afterEach(() => {
   drainRebuiltWalls(new Set())
   sceneRegistry.clear()
   useScene.setState(sceneBefore)
-  useViewer.setState(viewerBefore)
 })
 
 describe('WallCutoutCache', () => {
   test('camera orbit in full height never iterates cached walls or reads camera direction', () => {
-    useViewer.setState({ wallMode: 'up' })
+    viewerStore.setState({ wallMode: 'up' })
     const { mesh } = addWall()
     const writes = trackWrites(mesh)
     cache.update(camera, 1)
@@ -282,43 +284,43 @@ describe('WallCutoutCache', () => {
   })
 
   test('paint hover preserves preview through cache updates and restores current appearance on leave', () => {
-    useViewer.setState({ wallMode: 'up' })
+    viewerStore.setState({ wallMode: 'up' })
     const { node, mesh } = addWall()
     cache.update(camera, 1)
     const original = mesh.material
     const preview = [new MeshBasicMaterial()]
-    useViewer.setState({ hoveredId: node.id })
-    useViewer.setState({ hoverHighlightMode: 'paint-ready' })
+    viewerStore.setState({ hoveredId: node.id })
+    viewerStore.setState({ hoverHighlightMode: 'paint-ready' })
     mesh.material = preview
     const normal = spyOn(mesh, 'updateWorldMatrix')
     cache.update(camera, 1.01)
     expect(mesh.material).toBe(preview)
     expect(normal).not.toHaveBeenCalled()
-    useViewer.setState({ wallMode: 'cutaway' })
+    viewerStore.setState({ wallMode: 'cutaway' })
     cache.update(camera, 1.02)
     camera.position.x++
     cache.update(camera, 2)
     expect(mesh.material).toBe(preview)
     mesh.material = original
-    useViewer.setState({ hoveredId: null, hoverHighlightMode: 'default' })
+    viewerStore.setState({ hoveredId: null, hoverHighlightMode: 'default' })
     cache.update(camera, 2.01)
     expect(mesh.material).toBe(cache.walls.get(node.id)!.hiddenVariant.materials)
     normal.mockRestore()
   })
 
   test('appearance changes during preview are applied when temporary ownership ends', () => {
-    useViewer.setState({ wallMode: 'up' })
+    viewerStore.setState({ wallMode: 'up' })
     const { node, mesh } = addWall()
     cache.update(camera, 1)
     const original = mesh.material
     const preview = [new MeshBasicMaterial()]
-    useViewer.setState({ hoveredId: node.id, hoverHighlightMode: 'paint-ready' })
+    viewerStore.setState({ hoveredId: node.id, hoverHighlightMode: 'paint-ready' })
     mesh.material = preview
-    useViewer.setState({ colorPreset: 'white' })
+    viewerStore.setState({ colorPreset: 'white' })
     cache.update(camera, 1.01)
     expect(mesh.material).toBe(preview)
     mesh.material = original
-    useViewer.setState({ hoveredId: null, hoverHighlightMode: 'default' })
+    viewerStore.setState({ hoveredId: null, hoverHighlightMode: 'default' })
     cache.update(camera, 1.02)
     expect(mesh.material).toBe(cache.walls.get(node.id)!.visibleVariant.materials)
     expect(mesh.material).not.toBe(original)
@@ -410,13 +412,29 @@ describe('WallCutoutCache', () => {
     const { mesh } = addWall()
     cache.update(camera, 1)
     const matrix = spyOn(mesh, 'updateWorldMatrix')
-    useViewer.setState({ colorPreset: 'white' })
+    viewerStore.setState({ colorPreset: 'white' })
     cache.update(camera, 1.01)
     expect(matrix).not.toHaveBeenCalled()
     matrix.mockRestore()
   })
 
   test('actual R3F advance renders camera stamps before rebuilds and passes them to the batch', async () => {
+    // The level tests also leak a useFrame mock; real frame ordering needs a fresh runtime.
+    if (process.env.PASCAL_WALL_CUTOUT_FRAME_TEST !== '1') {
+      const result = spawnSync(
+        process.execPath,
+        ['test', import.meta.filename, '--test-name-pattern', 'actual R3F advance'],
+        {
+          env: { ...process.env, PASCAL_WALL_CUTOUT_FRAME_TEST: '1' },
+          encoding: 'utf8',
+          timeout: 4000,
+        },
+      )
+      const output = result.stdout + result.stderr
+      expect(result.status, output).toBe(0)
+      expect(output).toContain('1 pass')
+      return
+    }
     const { node, mesh } = addWall()
     const canvas = { width: 1, height: 1, style: {} } as HTMLCanvasElement
     const root = createRoot(canvas)
@@ -432,7 +450,7 @@ describe('WallCutoutCache', () => {
         rebuild = false
       }, 4)
       useFrame(() => batched.push(mesh.userData.wallHidden), 5)
-      return createElement(WallCutout)
+      return createElement(WallCutout, { viewerStore })
     }
     await root.configure({
       camera,
@@ -471,7 +489,7 @@ describe('WallCutoutCache', () => {
       ['translucent', false],
       ['cutaway', true],
     ] as const) {
-      useViewer.setState({ wallMode: mode })
+      viewerStore.setState({ wallMode: mode })
       cache.update(camera, 1.01)
       expect(mesh.userData.wallHidden).toBe(hidden)
       expect(cache.walls.values().next().value!.variantKey).toBe(
@@ -482,20 +500,22 @@ describe('WallCutoutCache', () => {
 
   test('appearance and highlight refreshes do not reassign an already-current material array', () => {
     const { node, mesh } = addWall()
-    useViewer.setState({ wallMode: 'up' })
+    viewerStore.setState({ wallMode: 'up' })
     const writes = trackWrites(mesh)
     cache.update(camera, 1)
-    useViewer.setState({ hoveredId: node.id })
+    viewerStore.setState({ hoveredId: node.id })
     cache.update(camera, 1.01)
     expect(writes.material).toBe(1)
-    useViewer.setState({ selection: { ...viewerBefore.selection, selectedIds: [node.id] } })
+    viewerStore.setState({
+      selection: { ...viewerStore.getState().selection, selectedIds: [node.id] },
+    })
     cache.update(camera, 1.02)
     expect(writes.material).toBe(2)
-    useViewer.setState({ previewSelectedIds: [node.id] })
+    viewerStore.setState({ previewSelectedIds: [node.id] })
     cache.update(camera, 1.03)
     expect(writes.material).toBe(2)
     expect(writes.stamp).toBe(1)
-    useViewer.setState({ hoverHighlightMode: 'delete' })
+    viewerStore.setState({ hoverHighlightMode: 'delete' })
     cache.update(camera, 1.04)
     expect(cache.walls.get(node.id)?.variantKey).toBe('delete-visible')
     expect(writes.material).toBe(3)
@@ -503,7 +523,7 @@ describe('WallCutoutCache', () => {
 
   test('all appearance inputs refresh in full height without camera movement', () => {
     const { node, mesh } = addWall()
-    useViewer.setState({ wallMode: 'up' })
+    viewerStore.setState({ wallMode: 'up' })
     cache.update(camera, 1)
     const patches = [
       { shading: 'rendered' as const },
@@ -512,9 +532,9 @@ describe('WallCutoutCache', () => {
       { textures: true },
     ]
     for (const patch of patches) {
-      useViewer.setState(patch)
+      viewerStore.setState(patch)
       cache.update(camera, 1.01)
-      const v = useViewer.getState()
+      const v = viewerStore.getState()
       expect(
         sameMaterialArray(
           mesh.material,
@@ -547,7 +567,7 @@ describe('WallCutoutCache', () => {
       slots: { interior: `scene:${material.id}`, exterior: 'library:mtl_row14_test' },
     })
     useScene.setState({ nodes: { [node.id]: painted }, materials: { [material.id]: material } })
-    useViewer.setState({ wallMode: 'up', textures: true })
+    viewerStore.setState({ wallMode: 'up', textures: true })
     cache.update(camera, 1)
     const red = (mesh.material as Material[])[1]
     useScene.setState({
@@ -582,12 +602,12 @@ describe('WallCutoutCache', () => {
 
   test('selected wall clones pick up a late texture with a stationary full-height camera', async () => {
     const { node, mesh } = addWall()
-    useViewer.setState({
+    viewerStore.setState({
       wallMode: 'up',
-      selection: { ...viewerBefore.selection, selectedIds: [node.id] },
+      selection: { ...viewerStore.getState().selection, selectedIds: [node.id] },
     })
     cache.update(camera, 1)
-    const viewer = useViewer.getState()
+    const viewer = viewerStore.getState()
     const source = getMaterialsForWall(
       node,
       viewer.shading,
@@ -633,9 +653,9 @@ describe('WallCutoutCache', () => {
 
   test('face-band changes remove whole-wall selection highlighting immediately', () => {
     const { node } = addWall()
-    useViewer.setState({
+    viewerStore.setState({
       wallMode: 'up',
-      selection: { ...viewerBefore.selection, selectedIds: [node.id] },
+      selection: { ...viewerStore.getState().selection, selectedIds: [node.id] },
     })
     cache.update(camera, 1)
     expect(cache.walls.get(node.id)?.variantKey).toBe('selection-visible')
@@ -651,7 +671,7 @@ describe('WallCutoutCache', () => {
       for (const back of ['interior', 'exterior']) {
         const { node, mesh } = addWall(front, back)
         for (const mode of ['up', 'cutaway', 'down', 'translucent'] as const) {
-          useViewer.setState({ wallMode: mode })
+          viewerStore.setState({ wallMode: mode })
           for (const angle of [0, Math.PI]) {
             camera.rotation.y = angle
             cache.update(camera, 2 + angle)

--- a/packages/viewer/src/systems/wall/wall-cutout-cache.test.ts
+++ b/packages/viewer/src/systems/wall/wall-cutout-cache.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
-import { spawnSync } from 'node:child_process'
 import {
   BuildingNode,
   LevelNode,
@@ -13,8 +12,6 @@ import {
   useScene,
   WallNode,
 } from '@pascal-app/core'
-import { act, createRoot, useFrame } from '@react-three/fiber'
-import { createElement } from 'react'
 import {
   BoxGeometry,
   Group,
@@ -28,7 +25,7 @@ import {
 } from 'three'
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { applyMaterialPresetToMaterials } from '../../lib/materials'
-import { getWallHideState, WallCutout } from './wall-cutout'
+import { getWallHideState, runWallCutoutFrame, WALL_CUTOUT_FRAME_PRIORITY } from './wall-cutout'
 import {
   sameMaterialArray,
   WALL_FACING_HYSTERESIS,
@@ -418,66 +415,49 @@ describe('WallCutoutCache', () => {
     matrix.mockRestore()
   })
 
-  test('actual R3F advance renders camera stamps before rebuilds and passes them to the batch', async () => {
-    // The level tests also leak a useFrame mock; real frame ordering needs a fresh runtime.
-    if (process.env.PASCAL_WALL_CUTOUT_FRAME_TEST !== '1') {
-      const result = spawnSync(
-        process.execPath,
-        ['test', import.meta.filename, '--test-name-pattern', 'actual R3F advance'],
-        {
-          env: { ...process.env, PASCAL_WALL_CUTOUT_FRAME_TEST: '1' },
-          encoding: 'utf8',
-          timeout: 4000,
-        },
-      )
-      const output = result.stdout + result.stderr
-      expect(result.status, output).toBe(0)
-      expect(output).toContain('1 pass')
-      return
-    }
+  test('frame priority order renders camera stamps before rebuilds and passes them to the batch', () => {
     const { node, mesh } = addWall()
-    const canvas = { width: 1, height: 1, style: {} } as HTMLCanvasElement
-    const root = createRoot(canvas)
+    const state = { camera, clock: { elapsedTime: 0 } }
+    const callbacks: { callback: () => void; priority: number }[] = []
+    const registerFrame = (callback: () => void, priority: number) => {
+      callbacks.push({ callback, priority })
+    }
+    const advance = (time: number) => {
+      state.clock.elapsedTime = time
+      for (const { callback } of callbacks.toSorted((a, b) => a.priority - b.priority)) callback()
+    }
     const rendered: boolean[] = []
     const batched: boolean[] = []
+    const batchChanges = new Set<string>()
     let rebuild = false
-    function FrameConsumers() {
-      useFrame(() => rendered.push(mesh.userData.wallHidden), 1)
-      useFrame(() => {
-        if (!rebuild) return
-        mesh.rotation.y = Math.PI
-        notifyWallRebuilt(node.id)
-        rebuild = false
-      }, 4)
-      useFrame(() => batched.push(mesh.userData.wallHidden), 5)
-      return createElement(WallCutout, { viewerStore })
-    }
-    await root.configure({
-      camera,
-      frameloop: 'never',
-      size: { width: 1, height: 1, top: 0, left: 0 },
-      gl: { render() {}, setSize() {}, setPixelRatio() {} } as never,
-    })
-    let store: ReturnType<typeof root.render>
-    await act(async () => {
-      store = root.render(createElement(FrameConsumers))
-    })
-    try {
-      const advance = (time: number) => store!.getState().advance(time)
-      advance(1)
-      camera.rotation.y = Math.PI
-      advance(2)
-      expect(rendered).toEqual([true, false])
-      expect(batched).toEqual(rendered)
-      rebuild = true
-      advance(3)
-      expect(rendered[2]).toBe(false)
-      advance(3.01)
-      expect(rendered[3]).toBe(true)
-      expect(batched).toEqual(rendered)
-    } finally {
-      await act(async () => root.unmount())
-    }
+    registerFrame(() => rendered.push(mesh.userData.wallHidden), 1)
+    registerFrame(() => {
+      if (!rebuild) return
+      mesh.rotation.y = Math.PI
+      notifyWallRebuilt(node.id)
+      rebuild = false
+    }, 4)
+    registerFrame(() => {
+      drainRebuiltWalls(batchChanges)
+      batched.push(mesh.userData.wallHidden)
+    }, 5)
+    registerFrame(() => runWallCutoutFrame(cache, state), WALL_CUTOUT_FRAME_PRIORITY)
+
+    advance(1)
+    camera.rotation.y = Math.PI
+    advance(2)
+    expect(rendered).toEqual([true, false])
+    expect(batched).toEqual(rendered)
+    rebuild = true
+    advance(3)
+    expect(rendered[2]).toBe(false)
+    expect(batched[2]).toBe(false)
+    expect(batchChanges.has(node.id)).toBe(true)
+    expect(cache.rebuilt.has(node.id)).toBe(true)
+    advance(3.01)
+    expect(rendered).toEqual([true, false, false, true])
+    expect(batched).toEqual(rendered)
+    expect(cache.rebuilt.size).toBe(0)
   })
 
   test('mode round trips immediately lift stamps and preserve low/translucent semantics', () => {

--- a/packages/viewer/src/systems/wall/wall-cutout-cache.test.ts
+++ b/packages/viewer/src/systems/wall/wall-cutout-cache.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import {
+  MaterialPresetPayloadSchema,
+  registerLibraryMaterials,
+  SceneMaterial,
+  sceneRegistry,
+  unregisterLibraryMaterials,
+  useScene,
+  WallNode,
+} from '@pascal-app/core'
+import { BoxGeometry, Group, type Material, Mesh, PerspectiveCamera, Texture, Vector3 } from 'three'
+import useViewer from '../../store/use-viewer'
+import { getWallHideState } from './wall-cutout'
+import {
+  sameMaterialArray,
+  WALL_FACING_HYSTERESIS,
+  WallCutoutCache,
+  wallFacingNegative,
+} from './wall-cutout-cache'
+import { getMaterialsForWall } from './wall-materials'
+import {
+  drainRebuiltWalls,
+  notifyWallRebuilt,
+  subscribeWallRebuilds,
+} from './wall-rebuild-notifications'
+
+const sceneBefore = useScene.getState()
+const viewerBefore = useViewer.getState()
+let cache: WallCutoutCache
+let camera: PerspectiveCamera
+let unsubscribe: () => void
+
+function addWall(frontSide = 'exterior', backSide = 'interior') {
+  const node = WallNode.parse({ start: [0, 0], end: [4, 0], frontSide, backSide })
+  const mesh = new Mesh()
+  sceneRegistry.nodes.set(node.id, mesh)
+  sceneRegistry.byType.wall!.add(node.id)
+  useScene.setState({ nodes: { ...useScene.getState().nodes, [node.id]: node } })
+  return { node, mesh }
+}
+
+function trackWrites(mesh: Mesh) {
+  let material = mesh.material
+  let hidden = mesh.userData.wallHidden
+  const writes = { material: 0, stamp: 0 }
+  Object.defineProperty(mesh, 'material', {
+    configurable: true,
+    get: () => material,
+    set: (value: Material | Material[]) => {
+      material = value
+      writes.material++
+    },
+  })
+  Object.defineProperty(mesh.userData, 'wallHidden', {
+    configurable: true,
+    get: () => hidden,
+    set: (value: boolean) => {
+      hidden = value
+      writes.stamp++
+    },
+  })
+  return writes
+}
+
+beforeEach(() => {
+  sceneRegistry.clear()
+  useScene.setState({ nodes: {}, materials: {} })
+  useViewer.setState({
+    wallMode: 'cutaway',
+    shading: 'solid',
+    textures: false,
+    colorPreset: 'clay',
+    selection: { ...viewerBefore.selection, selectedIds: [] },
+    previewSelectedIds: [],
+    hoveredId: null,
+    hoverHighlightMode: 'default',
+  })
+  cache = new WallCutoutCache()
+  camera = new PerspectiveCamera()
+  unsubscribe = subscribeWallRebuilds((id) => cache.rebuilt.add(id))
+})
+
+afterEach(() => {
+  unsubscribe()
+  drainRebuiltWalls(new Set())
+  sceneRegistry.clear()
+  useScene.setState(sceneBefore)
+  useViewer.setState(viewerBefore)
+})
+
+describe('WallCutoutCache', () => {
+  test('camera orbit in full height never iterates cached walls or reads camera direction', () => {
+    useViewer.setState({ wallMode: 'up' })
+    const { mesh } = addWall()
+    const writes = trackWrites(mesh)
+    cache.update(camera, 1)
+    const direction = spyOn(camera, 'getWorldDirection')
+    const registry = spyOn(sceneRegistry.nodes, 'get')
+    const wallIteration = spyOn(cache.walls, Symbol.iterator)
+    for (let i = 0; i < 100; i++) {
+      camera.position.x += 1
+      camera.rotation.y += 0.1
+      cache.update(camera, 2 + i)
+    }
+    expect(direction).not.toHaveBeenCalled()
+    expect(registry).not.toHaveBeenCalled()
+    expect(wallIteration).not.toHaveBeenCalled()
+    expect(writes).toEqual({ material: 1, stamp: 1 })
+    direction.mockRestore()
+    registry.mockRestore()
+    wallIteration.mockRestore()
+  })
+
+  test('only facing flips write materials and stamps; unchanged normals are never refreshed', () => {
+    const { mesh } = addWall()
+    const writes = trackWrites(mesh)
+    cache.update(camera, 1)
+    expect(mesh.userData.wallHidden).toBe(true)
+    const matrices = spyOn(mesh, 'updateWorldMatrix')
+    for (let i = 0; i < 10; i++) {
+      camera.position.x++
+      cache.update(camera, 2 + i)
+    }
+    expect(writes).toEqual({ material: 1, stamp: 1 })
+    expect(matrices).not.toHaveBeenCalled()
+    camera.rotation.y = Math.PI
+    cache.update(camera, 20)
+    expect(mesh.userData.wallHidden).toBe(false)
+    expect(writes).toEqual({ material: 2, stamp: 2 })
+    matrices.mockRestore()
+  })
+
+  test('coalesces small movement and preserves the existing time gate', () => {
+    const { mesh } = addWall()
+    cache.update(camera, 1)
+    const dot = spyOn(cache.walls.values().next().value!.normal, 'dot')
+    camera.position.x = 0.1
+    cache.update(camera, 2)
+    expect(dot).not.toHaveBeenCalled()
+    camera.rotation.y = Math.PI
+    cache.update(camera, 1.05)
+    expect(mesh.userData.wallHidden).toBe(true)
+    cache.update(camera, 2)
+    expect(mesh.userData.wallHidden).toBe(false)
+    expect(dot).toHaveBeenCalledTimes(1)
+    dot.mockRestore()
+  })
+
+  test('adds, removes and replaces meshes even when the wall count is unchanged', () => {
+    const first = addWall()
+    cache.update(camera, 1)
+    sceneRegistry.nodes.delete(first.node.id)
+    sceneRegistry.byType.wall!.delete(first.node.id)
+    const second = addWall()
+    cache.update(camera, 1.01)
+    expect(cache.walls.has(first.node.id)).toBe(false)
+    expect(cache.walls.get(second.node.id)?.mesh).toBe(second.mesh)
+    expect(second.mesh.userData.wallHidden).toBe(true)
+    const replacement = new Mesh()
+    replacement.rotation.y = Math.PI
+    sceneRegistry.nodes.set(second.node.id, replacement)
+    cache.update(camera, 1.02)
+    expect(cache.walls.get(second.node.id)?.mesh).toBe(replacement)
+    expect(replacement.userData.wallHidden).toBe(false)
+  })
+
+  test('rebuild completion updates only the moved wall before the batch drains the same notice', () => {
+    const moved = addWall()
+    const other = addWall()
+    cache.update(camera, 1)
+    const otherMatrix = spyOn(other.mesh, 'updateWorldMatrix')
+    moved.mesh.rotation.y = Math.PI
+    moved.mesh.geometry = new BoxGeometry()
+    notifyWallRebuilt(moved.node.id)
+    cache.update(camera, 1.01)
+    expect(moved.mesh.userData.wallHidden).toBe(false)
+    expect(cache.walls.get(moved.node.id)?.normal.z).toBeCloseTo(-1)
+    expect(otherMatrix).not.toHaveBeenCalled()
+    const batchChanges = new Set<string>()
+    drainRebuiltWalls(batchChanges)
+    expect(batchChanges.has(moved.node.id)).toBe(true)
+    expect(cache.rebuilt.size).toBe(0)
+    otherMatrix.mockRestore()
+  })
+
+  test('scene transform and side changes refresh facing with a stationary camera', () => {
+    const { node, mesh } = addWall()
+    const parent = new Group()
+    parent.add(mesh)
+    cache.update(camera, 1)
+    parent.rotation.y = Math.PI
+    useScene.setState({ nodes: { ...useScene.getState().nodes } })
+    cache.update(camera, 1.01)
+    expect(mesh.userData.wallHidden).toBe(false)
+    useScene.setState({
+      nodes: { [node.id]: { ...node, frontSide: 'interior', backSide: 'interior' } },
+    })
+    cache.update(camera, 1.02)
+    expect(mesh.userData.wallHidden).toBe(true)
+  })
+
+  test('mode round trips immediately lift stamps and preserve low/translucent semantics', () => {
+    const { mesh } = addWall()
+    cache.update(camera, 1)
+    for (const [mode, hidden] of [
+      ['up', false],
+      ['down', true],
+      ['translucent', false],
+      ['cutaway', true],
+    ] as const) {
+      useViewer.setState({ wallMode: mode })
+      cache.update(camera, 1.01)
+      expect(mesh.userData.wallHidden).toBe(hidden)
+      expect(cache.walls.values().next().value!.variantKey).toBe(
+        mode === 'translucent' ? 'translucent' : hidden ? 'invisible' : 'visible',
+      )
+    }
+  })
+
+  test('appearance and highlight refreshes do not reassign an already-current material array', () => {
+    const { node, mesh } = addWall()
+    useViewer.setState({ wallMode: 'up' })
+    const writes = trackWrites(mesh)
+    cache.update(camera, 1)
+    useViewer.setState({ hoveredId: node.id })
+    cache.update(camera, 1.01)
+    expect(writes.material).toBe(1)
+    useViewer.setState({ selection: { ...viewerBefore.selection, selectedIds: [node.id] } })
+    cache.update(camera, 1.02)
+    expect(writes.material).toBe(2)
+    useViewer.setState({ previewSelectedIds: [node.id] })
+    cache.update(camera, 1.03)
+    expect(writes.material).toBe(2)
+    expect(writes.stamp).toBe(1)
+    useViewer.setState({ hoverHighlightMode: 'delete' })
+    cache.update(camera, 1.04)
+    expect(cache.walls.get(node.id)?.variantKey).toBe('delete-visible')
+    expect(writes.material).toBe(3)
+  })
+
+  test('all appearance inputs refresh in full height without camera movement', () => {
+    const { node, mesh } = addWall()
+    useViewer.setState({ wallMode: 'up' })
+    cache.update(camera, 1)
+    const patches = [
+      { shading: 'rendered' as const },
+      { colorPreset: 'white' as const },
+      { sceneTheme: 'dark' },
+      { textures: true },
+    ]
+    for (const patch of patches) {
+      useViewer.setState(patch)
+      cache.update(camera, 1.01)
+      const v = useViewer.getState()
+      expect(
+        sameMaterialArray(
+          mesh.material,
+          getMaterialsForWall(
+            node,
+            v.shading,
+            v.textures,
+            v.colorPreset,
+            v.sceneTheme,
+            useScene.getState().materials,
+          ).visible,
+        ),
+      ).toBe(true)
+    }
+    const painted = WallNode.parse({ ...node, material: { properties: { color: '#ff0000' } } })
+    useScene.setState({ nodes: { [node.id]: painted } })
+    cache.update(camera, 1.02)
+    expect(cache.walls.get(node.id)?.node).toBe(painted)
+  })
+
+  test('scene palette edits and late library registration replace cached materials immediately', () => {
+    const { node, mesh } = addWall()
+    const material = SceneMaterial.parse({
+      id: 'mat_row14_test',
+      name: 'red',
+      material: { properties: { color: '#ff0000' } },
+    })
+    const painted = WallNode.parse({
+      ...node,
+      slots: { interior: `scene:${material.id}`, exterior: 'library:mtl_row14_test' },
+    })
+    useScene.setState({ nodes: { [node.id]: painted }, materials: { [material.id]: material } })
+    useViewer.setState({ wallMode: 'up', textures: true })
+    cache.update(camera, 1)
+    const red = (mesh.material as Material[])[1]
+    useScene.setState({
+      materials: {
+        [material.id]: SceneMaterial.parse({
+          ...material,
+          material: { properties: { color: '#0000ff' } },
+        }),
+      },
+    })
+    cache.update(camera, 1.01)
+    expect((mesh.material as Material[])[1] === red).toBe(false)
+    const unresolved = (mesh.material as Material[])[2]
+    try {
+      registerLibraryMaterials([
+        {
+          id: 'mtl_row14_test',
+          label: 'test',
+          category: 'colors',
+          preset: MaterialPresetPayloadSchema.parse({
+            maps: {},
+            mapProperties: { color: '#00ff00' },
+          }),
+        },
+      ])
+      cache.update(camera, 1.02)
+      expect((mesh.material as Material[])[2] === unresolved).toBe(false)
+    } finally {
+      unregisterLibraryMaterials(['mtl_row14_test'])
+    }
+  })
+
+  test('selected wall clones pick up a late texture with a stationary full-height camera', () => {
+    const { node, mesh } = addWall()
+    useViewer.setState({
+      wallMode: 'up',
+      selection: { ...viewerBefore.selection, selectedIds: [node.id] },
+    })
+    cache.update(camera, 1)
+    const viewer = useViewer.getState()
+    const source = getMaterialsForWall(
+      node,
+      viewer.shading,
+      viewer.textures,
+      viewer.colorPreset,
+      viewer.sceneTheme,
+    ).visible[1]! as Material & { map: Texture | null }
+    const originalMap = source.map
+    const texture = new Texture()
+    try {
+      source.map = texture
+      cache.update(camera, 1.01)
+      expect(
+        ((mesh.material as Material[])[1] as Material & { map: Texture }).map === texture,
+      ).toBe(true)
+    } finally {
+      source.map = originalMap
+      texture.dispose()
+    }
+  })
+
+  test('face-band changes remove whole-wall selection highlighting immediately', () => {
+    const { node } = addWall()
+    useViewer.setState({
+      wallMode: 'up',
+      selection: { ...viewerBefore.selection, selectedIds: [node.id] },
+    })
+    cache.update(camera, 1)
+    expect(cache.walls.get(node.id)?.variantKey).toBe('selection-visible')
+    useScene.setState({
+      nodes: { [node.id]: WallNode.parse({ ...node, faceBands: { enabled: true, count: 3 } }) },
+    })
+    cache.update(camera, 1.01)
+    expect(cache.walls.get(node.id)?.variantKey).toBe('visible')
+  })
+
+  test('cached semantics match the public facing helper away from the hysteresis band', () => {
+    for (const front of ['interior', 'exterior'])
+      for (const back of ['interior', 'exterior']) {
+        const { node, mesh } = addWall(front, back)
+        for (const mode of ['up', 'cutaway', 'down', 'translucent'] as const) {
+          useViewer.setState({ wallMode: mode })
+          for (const angle of [0, Math.PI]) {
+            camera.rotation.y = angle
+            cache.update(camera, 2 + angle)
+            const expected = getWallHideState(
+              node,
+              mesh,
+              mode,
+              camera.getWorldDirection(new Vector3()),
+            )
+            expect(mesh.userData.wallHidden).toBe(mode !== 'translucent' && expected)
+          }
+        }
+      }
+  })
+})
+
+test('hysteresis holds both sides near zero and switches beyond the band', () => {
+  const e = WALL_FACING_HYSTERESIS
+  expect(wallFacingNegative(-e / 2, undefined)).toBe(true)
+  expect(wallFacingNegative(0, undefined)).toBe(false)
+  for (const dot of [-e / 2, 0, e / 2]) {
+    expect(wallFacingNegative(dot, false)).toBe(false)
+    expect(wallFacingNegative(dot, true)).toBe(true)
+  }
+  expect(wallFacingNegative(-2 * e, false)).toBe(true)
+  expect(wallFacingNegative(2 * e, true)).toBe(false)
+})

--- a/packages/viewer/src/systems/wall/wall-cutout-cache.ts
+++ b/packages/viewer/src/systems/wall/wall-cutout-cache.ts
@@ -95,10 +95,25 @@ export function wallFacingNegative(dot: number, previous: boolean | undefined): 
   return previous ? dot < WALL_FACING_HYSTERESIS : dot < -WALL_FACING_HYSTERESIS
 }
 
+export type WallCutoutViewerState = Pick<
+  ReturnType<typeof useViewer.getState>,
+  | 'wallMode'
+  | 'shading'
+  | 'textures'
+  | 'colorPreset'
+  | 'sceneTheme'
+  | 'selection'
+  | 'previewSelectedIds'
+  | 'hoveredId'
+  | 'hoverHighlightMode'
+>
+
+export type WallCutoutViewerStore = { getState: () => WallCutoutViewerState }
+
 export class WallCutoutCache {
   readonly walls = new Map<string, CachedWall>()
   readonly rebuilt = new Set<string>()
-  private viewer: ReturnType<typeof useViewer.getState> | undefined
+  private viewer: WallCutoutViewerState | undefined
   private nodes: ReturnType<typeof useScene.getState>['nodes'] | undefined
   private materials: ReturnType<typeof useScene.getState>['materials'] | undefined
   private registryRevision = -1
@@ -114,6 +129,8 @@ export class WallCutoutCache {
   private highlightKey = ''
   private transformed = new Set<string>()
 
+  constructor(private readonly viewerStore: WallCutoutViewerStore = useViewer) {}
+
   subscribeLiveTransforms(): () => void {
     return useLiveTransforms.subscribe((state, previous) => {
       for (const [id, transform] of state.transforms) {
@@ -126,7 +143,7 @@ export class WallCutoutCache {
   }
 
   update(camera: Camera, time: number): void {
-    const viewer = useViewer.getState()
+    const viewer = this.viewerStore.getState()
     const scene = useScene.getState()
     const wallIds = sceneRegistry.byType.wall!
     const libraryVersion = getLibraryMaterialsVersion()

--- a/packages/viewer/src/systems/wall/wall-cutout-cache.ts
+++ b/packages/viewer/src/systems/wall/wall-cutout-cache.ts
@@ -1,0 +1,298 @@
+import {
+  type AnyNodeId,
+  getLibraryMaterialsVersion,
+  getWallFaceBandConfig,
+  getWallPlaneTop,
+  resolveLevelId,
+  resolveWallEffectiveHeight,
+  sceneRegistry,
+  spatialGridManager,
+  useScene,
+  type WallNode,
+} from '@pascal-app/core'
+import { type Camera, type Material, Matrix4, type Mesh, Vector3 } from 'three'
+import useViewer, { type WallMode } from '../../store/use-viewer'
+import { resolveWallMaterialVariant, type WallMaterialVariant } from './wall-material-variant'
+import {
+  getHoverHighlightMaterials,
+  getMaterialsForWall,
+  getSelectionHighlightMaterials,
+  type WallMaterials,
+} from './wall-materials'
+
+export function sameMaterialArray(a: Material | Material[], b: Material[]): boolean {
+  return Array.isArray(a) && a.length === b.length && a.every((material, i) => material === b[i])
+}
+
+/** Materialize a resolved variant from the wall's cached material set. */
+function materialsForVariant(variant: WallMaterialVariant, materials: WallMaterials) {
+  switch (variant) {
+    case 'visible':
+      return materials.visible
+    case 'invisible':
+      return materials.invisible
+    case 'translucent':
+      return materials.translucent
+    case 'delete-visible':
+      return materials.deleteVisible
+    case 'delete-invisible':
+      return materials.deleteInvisible
+    case 'delete-translucent':
+      return materials.deleteTranslucent
+    case 'selection-visible':
+      return getSelectionHighlightMaterials(materials.visible)
+    case 'selection-invisible':
+      return getSelectionHighlightMaterials(materials.invisible)
+    case 'selection-translucent':
+      return getSelectionHighlightMaterials(materials.translucent)
+    case 'hover-invisible':
+      return getHoverHighlightMaterials(materials.invisible)
+    default: {
+      const exhaustive: never = variant
+      return exhaustive
+    }
+  }
+}
+
+type Variant = { key: WallMaterialVariant; materials: Material[] }
+type CachedWall = {
+  mesh: Mesh
+  node: WallNode
+  normal: Vector3
+  matrix: Matrix4
+  geometry: Mesh['geometry']
+  negativeFacing: boolean | undefined
+  hidden: boolean | undefined
+  variantKey: WallMaterialVariant | undefined
+  visibleVariant: Variant
+  hiddenVariant: Variant
+}
+
+// About 0.06 degrees: retain the previous side at edge-on poses without
+// introducing a perceptible delay when an orbit crosses a wall's plane.
+export const WALL_FACING_HYSTERESIS = 0.001
+
+export function wallHiddenFromFacing(
+  node: Pick<WallNode, 'frontSide' | 'backSide'>,
+  mode: WallMode,
+  negativeFacing: boolean,
+): boolean {
+  if (mode === 'up') return false
+  if (mode === 'down') return true
+  if (node.frontSide === 'interior' && node.backSide === 'interior') return true
+  return negativeFacing
+    ? node.frontSide === 'exterior' && node.backSide !== 'exterior'
+    : node.backSide === 'exterior' && node.frontSide !== 'exterior'
+}
+
+export function wallFacingNegative(dot: number, previous: boolean | undefined): boolean {
+  if (previous === undefined) return dot < 0
+  return previous ? dot < WALL_FACING_HYSTERESIS : dot < -WALL_FACING_HYSTERESIS
+}
+
+export class WallCutoutCache {
+  readonly walls = new Map<string, CachedWall>()
+  readonly rebuilt = new Set<string>()
+  private viewer: ReturnType<typeof useViewer.getState> | undefined
+  private nodes: ReturnType<typeof useScene.getState>['nodes'] | undefined
+  private materials: ReturnType<typeof useScene.getState>['materials'] | undefined
+  private registryRevision = -1
+  private wallCount = -1
+  private libraryVersion = -1
+  private lastCameraPosition = new Vector3()
+  private lastCameraTarget = new Vector3()
+  private cameraDirection = new Vector3()
+  private cameraTarget = new Vector3()
+  private lastUpdateTime = 0
+  private highlightMaps: Array<{ material: Material & { map?: unknown }; map: unknown }> = []
+
+  update(camera: Camera, time: number): void {
+    const viewer = useViewer.getState()
+    const scene = useScene.getState()
+    const wallIds = sceneRegistry.byType.wall!
+    const libraryVersion = getLibraryMaterialsVersion()
+    const previous = this.viewer
+    const nodesChanged = this.nodes !== scene.nodes
+    const registryChanged =
+      this.registryRevision !== sceneRegistry.revision || this.wallCount !== wallIds.size
+    const refresh =
+      !previous ||
+      nodesChanged ||
+      registryChanged ||
+      this.materials !== scene.materials ||
+      this.libraryVersion !== libraryVersion ||
+      this.highlightMaps.some(({ material, map }) => material.map !== map) ||
+      previous.wallMode !== viewer.wallMode ||
+      previous.shading !== viewer.shading ||
+      previous.textures !== viewer.textures ||
+      previous.colorPreset !== viewer.colorPreset ||
+      previous.sceneTheme !== viewer.sceneTheme ||
+      previous.selection.selectedIds !== viewer.selection.selectedIds ||
+      previous.previewSelectedIds !== viewer.previewSelectedIds ||
+      previous.hoveredId !== viewer.hoveredId ||
+      previous.hoverHighlightMode !== viewer.hoverHighlightMode
+
+    // Only cutaway's output depends on facing. Low always hides, translucent
+    // always draws the translucent variant and keeps pointer events enabled.
+    if (!refresh && this.rebuilt.size === 0 && viewer.wallMode !== 'cutaway') return
+
+    camera.getWorldDirection(this.cameraDirection)
+    this.cameraTarget.copy(this.cameraDirection).add(camera.position)
+    const cameraChanged =
+      viewer.wallMode === 'cutaway' &&
+      time - this.lastUpdateTime > 0.1 &&
+      (camera.position.distanceTo(this.lastCameraPosition) > 0.5 ||
+        this.cameraTarget.distanceTo(this.lastCameraTarget) > 0.3)
+    if (!refresh && this.rebuilt.size === 0 && !cameraChanged) return
+
+    if (registryChanged || nodesChanged) {
+      for (const [id, wall] of this.walls) {
+        if (
+          !wallIds.has(id) ||
+          sceneRegistry.nodes.get(id) !== wall.mesh ||
+          scene.nodes[id as AnyNodeId]?.type !== 'wall'
+        ) {
+          this.walls.delete(id)
+        }
+      }
+    }
+
+    if (refresh) {
+      this.highlightMaps = []
+      const selected = new Set([...viewer.selection.selectedIds, ...viewer.previewSelectedIds])
+      for (const id of wallIds) {
+        const mesh = sceneRegistry.nodes.get(id) as Mesh | undefined
+        const node = scene.nodes[id as AnyNodeId]
+        if (!mesh || node?.type !== 'wall') continue
+        let wall = this.walls.get(id)
+        if (!wall) {
+          wall = {
+            mesh,
+            node,
+            normal: new Vector3(),
+            matrix: new Matrix4().makeScale(0, 0, 0),
+            geometry: mesh.geometry,
+            negativeFacing: undefined,
+            hidden: undefined,
+            variantKey: undefined,
+            visibleVariant: { key: 'visible', materials: [] },
+            hiddenVariant: { key: 'invisible', materials: [] },
+          }
+          this.walls.set(id, wall)
+          this.refreshNormal(wall)
+        } else if (nodesChanged || this.rebuilt.has(id)) {
+          this.refreshNormal(wall)
+        }
+        wall.node = node
+        const deleted = viewer.hoverHighlightMode === 'delete' && viewer.hoveredId === id
+        let selectionHighlighted = !deleted && selected.has(id)
+        if (selectionHighlighted) {
+          const levelId = resolveLevelId(node, scene.nodes)
+          const support = spatialGridManager.getSlabSupportForWall(
+            levelId,
+            node.start,
+            node.end,
+            node.curveOffset ?? 0,
+            node.thickness,
+            node.supportSlabId,
+          )
+          const height = resolveWallEffectiveHeight(
+            node,
+            getWallPlaneTop(node, levelId, scene.nodes),
+            support.elevation,
+          )
+          selectionHighlighted = !getWallFaceBandConfig(node, height).enabled
+        }
+        const materials = getMaterialsForWall(
+          node,
+          viewer.shading,
+          viewer.textures,
+          viewer.colorPreset,
+          viewer.sceneTheme,
+          scene.materials,
+        )
+        // Selection clones need to pick up textures that arrive after mount.
+        // Check only these few source materials, never every wall's material set.
+        if (selectionHighlighted) {
+          for (const material of materials.visible) {
+            this.highlightMaps.push({
+              material,
+              map: (material as Material & { map?: unknown }).map,
+            })
+          }
+        }
+        const variant = (hidden: boolean): Variant => {
+          const key = resolveWallMaterialVariant({
+            translucentMode: viewer.wallMode === 'translucent',
+            hidden,
+            deleteHighlighted: deleted,
+            selectionHighlighted,
+            hoverHighlighted: viewer.hoverHighlightMode === 'default' && viewer.hoveredId === id,
+          })
+          return { key, materials: materialsForVariant(key, materials) }
+        }
+        wall.visibleVariant = variant(false)
+        wall.hiddenVariant = variant(true)
+        this.apply(wall, viewer.wallMode, true)
+      }
+    } else {
+      for (const id of this.rebuilt) {
+        const wall = this.walls.get(id)
+        if (!wall) continue
+        this.refreshNormal(wall)
+        this.apply(wall, viewer.wallMode, true)
+      }
+      if (cameraChanged) {
+        for (const [id, wall] of this.walls) {
+          if (!this.rebuilt.has(id)) this.apply(wall, viewer.wallMode, false)
+        }
+      }
+    }
+    this.rebuilt.clear()
+    this.viewer = viewer
+    this.nodes = scene.nodes
+    this.materials = scene.materials
+    this.registryRevision = sceneRegistry.revision
+    this.wallCount = wallIds.size
+    this.libraryVersion = libraryVersion
+    if (refresh || cameraChanged) {
+      this.lastCameraPosition.copy(camera.position)
+      this.lastCameraTarget.copy(this.cameraTarget)
+      this.lastUpdateTime = time
+    }
+  }
+
+  private refreshNormal(wall: CachedWall): void {
+    wall.mesh.updateWorldMatrix(true, false)
+    if (wall.matrix.equals(wall.mesh.matrixWorld) && wall.geometry === wall.mesh.geometry) return
+    wall.matrix.copy(wall.mesh.matrixWorld)
+    wall.geometry = wall.mesh.geometry
+    wall.normal.setFromMatrixColumn(wall.matrix, 2).normalize()
+  }
+
+  private apply(wall: CachedWall, mode: WallMode, refresh: boolean): void {
+    if (mode === 'cutaway') {
+      wall.negativeFacing = wallFacingNegative(
+        wall.normal.dot(this.cameraDirection),
+        wall.negativeFacing,
+      )
+    }
+    const hidden = wallHiddenFromFacing(wall.node, mode, wall.negativeFacing ?? false)
+    if (!refresh && hidden === wall.hidden) return
+    wall.hidden = hidden
+    // The wall batch and pointer handlers consume this boolean, including
+    // false on stamp lift; translucent walls must continue receiving events.
+    const stamp = mode !== 'translucent' && hidden
+    if (wall.mesh.userData.wallHidden !== stamp) wall.mesh.userData.wallHidden = stamp
+    const variant = hidden ? wall.hiddenVariant : wall.visibleVariant
+    if (wall.variantKey !== variant.key || refresh) {
+      if (
+        wall.mesh.material !== variant.materials &&
+        !sameMaterialArray(wall.mesh.material, variant.materials)
+      ) {
+        wall.mesh.material = variant.materials
+      }
+      wall.variantKey = variant.key
+    }
+  }
+}

--- a/packages/viewer/src/systems/wall/wall-cutout-cache.ts
+++ b/packages/viewer/src/systems/wall/wall-cutout-cache.ts
@@ -1,3 +1,5 @@
+// New kind-specific modules belong in nodes; viewer must not depend on nodes.
+// This extends the existing viewer-owned wall cutout and material implementation.
 import {
   type AnyNodeId,
   getLibraryMaterialsVersion,
@@ -7,10 +9,12 @@ import {
   resolveWallEffectiveHeight,
   sceneRegistry,
   spatialGridManager,
+  useLiveTransforms,
   useScene,
   type WallNode,
 } from '@pascal-app/core'
-import { type Camera, type Material, Matrix4, type Mesh, Vector3 } from 'three'
+import { type Camera, type Material, Matrix4, type Mesh, type Object3D, Vector3 } from 'three'
+import { getMaterialTextureVersion } from '../../lib/materials'
 import useViewer, { type WallMode } from '../../store/use-viewer'
 import { resolveWallMaterialVariant, type WallMaterialVariant } from './wall-material-variant'
 import {
@@ -64,6 +68,7 @@ type CachedWall = {
   negativeFacing: boolean | undefined
   hidden: boolean | undefined
   variantKey: WallMaterialVariant | undefined
+  assignedMaterials: Material | Material[] | undefined
   visibleVariant: Variant
   hiddenVariant: Variant
 }
@@ -104,37 +109,78 @@ export class WallCutoutCache {
   private cameraDirection = new Vector3()
   private cameraTarget = new Vector3()
   private lastUpdateTime = 0
-  private highlightMaps: Array<{ material: Material & { map?: unknown }; map: unknown }> = []
+  private textureVersion = -1
+  private selected = new Set<string>()
+  private highlightKey = ''
+  private transformed = new Set<string>()
+
+  subscribeLiveTransforms(): () => void {
+    return useLiveTransforms.subscribe((state, previous) => {
+      for (const [id, transform] of state.transforms) {
+        if (transform !== previous.transforms.get(id)) this.transformed.add(id)
+      }
+      for (const id of previous.transforms.keys()) {
+        if (!state.transforms.has(id)) this.transformed.add(id)
+      }
+    })
+  }
 
   update(camera: Camera, time: number): void {
     const viewer = useViewer.getState()
     const scene = useScene.getState()
     const wallIds = sceneRegistry.byType.wall!
     const libraryVersion = getLibraryMaterialsVersion()
+    const textureVersion = getMaterialTextureVersion()
     const previous = this.viewer
     const nodesChanged = this.nodes !== scene.nodes
     const registryChanged =
       this.registryRevision !== sceneRegistry.revision || this.wallCount !== wallIds.size
-    const refresh =
+    let highlightChanged = false
+    if (
       !previous ||
       nodesChanged ||
-      registryChanged ||
-      this.materials !== scene.materials ||
-      this.libraryVersion !== libraryVersion ||
-      this.highlightMaps.some(({ material, map }) => material.map !== map) ||
-      previous.wallMode !== viewer.wallMode ||
-      previous.shading !== viewer.shading ||
-      previous.textures !== viewer.textures ||
-      previous.colorPreset !== viewer.colorPreset ||
-      previous.sceneTheme !== viewer.sceneTheme ||
       previous.selection.selectedIds !== viewer.selection.selectedIds ||
       previous.previewSelectedIds !== viewer.previewSelectedIds ||
       previous.hoveredId !== viewer.hoveredId ||
       previous.hoverHighlightMode !== viewer.hoverHighlightMode
+    ) {
+      this.selected = new Set(
+        [...viewer.selection.selectedIds, ...viewer.previewSelectedIds].filter(
+          (id) => scene.nodes[id as AnyNodeId]?.type === 'wall',
+        ),
+      )
+      const hovered =
+        scene.nodes[viewer.hoveredId as AnyNodeId]?.type === 'wall' ? viewer.hoveredId : null
+      const key = `${Array.from(this.selected).sort().join('|')}::${viewer.hoverHighlightMode === 'delete' ? (hovered ?? '') : ''}::${viewer.hoverHighlightMode === 'default' ? (hovered ?? '') : ''}`
+      highlightChanged = key !== this.highlightKey
+      this.highlightKey = key
+    }
+    const appearanceChanged =
+      !previous ||
+      highlightChanged ||
+      this.materials !== scene.materials ||
+      this.libraryVersion !== libraryVersion ||
+      (this.textureVersion !== textureVersion && this.selected.size > 0) ||
+      previous.wallMode !== viewer.wallMode ||
+      previous.shading !== viewer.shading ||
+      previous.textures !== viewer.textures ||
+      previous.colorPreset !== viewer.colorPreset ||
+      previous.sceneTheme !== viewer.sceneTheme
+    const previewId = (state: typeof viewer | undefined) =>
+      state && state.hoverHighlightMode !== 'default' && state.hoverHighlightMode !== 'delete'
+        ? state.hoveredId
+        : null
+    const releasedPreview = previewId(previous) !== previewId(viewer) ? previewId(previous) : null
+    this.viewer = viewer
+    const invalidated =
+      appearanceChanged ||
+      nodesChanged ||
+      registryChanged ||
+      this.rebuilt.size > 0 ||
+      this.transformed.size > 0 ||
+      releasedPreview !== null
 
-    // Only cutaway's output depends on facing. Low always hides, translucent
-    // always draws the translucent variant and keeps pointer events enabled.
-    if (!refresh && this.rebuilt.size === 0 && viewer.wallMode !== 'cutaway') return
+    if (!invalidated && viewer.wallMode !== 'cutaway') return
 
     camera.getWorldDirection(this.cameraDirection)
     this.cameraTarget.copy(this.cameraDirection).add(camera.position)
@@ -143,7 +189,7 @@ export class WallCutoutCache {
       time - this.lastUpdateTime > 0.1 &&
       (camera.position.distanceTo(this.lastCameraPosition) > 0.5 ||
         this.cameraTarget.distanceTo(this.lastCameraTarget) > 0.3)
-    if (!refresh && this.rebuilt.size === 0 && !cameraChanged) return
+    if (!invalidated && !cameraChanged) return
 
     if (registryChanged || nodesChanged) {
       for (const [id, wall] of this.walls) {
@@ -151,21 +197,33 @@ export class WallCutoutCache {
           !wallIds.has(id) ||
           sceneRegistry.nodes.get(id) !== wall.mesh ||
           scene.nodes[id as AnyNodeId]?.type !== 'wall'
-        ) {
+        )
           this.walls.delete(id)
-        }
       }
     }
 
-    if (refresh) {
-      this.highlightMaps = []
-      const selected = new Set([...viewer.selection.selectedIds, ...viewer.previewSelectedIds])
-      for (const id of wallIds) {
-        const mesh = sceneRegistry.nodes.get(id) as Mesh | undefined
+    if (invalidated) {
+      const changedPaths = new Map<string, boolean>()
+      const pathChanged = (id: string): boolean => {
+        const cached = changedPaths.get(id)
+        if (cached !== undefined) return cached
         const node = scene.nodes[id as AnyNodeId]
-        if (!mesh || node?.type !== 'wall') continue
+        const changed =
+          this.transformed.has(id) ||
+          (nodesChanged && this.nodes?.[id as AnyNodeId] !== node) ||
+          !!(node?.parentId && pathChanged(node.parentId))
+        changedPaths.set(id, changed)
+        return changed
+      }
+      const visited = new Set<Object3D>()
+      for (const id of wallIds) {
+        const node = scene.nodes[id as AnyNodeId]
+        if (node?.type !== 'wall') continue
         let wall = this.walls.get(id)
+        const added = !wall
         if (!wall) {
+          const mesh = sceneRegistry.nodes.get(id) as Mesh | undefined
+          if (!mesh) continue
           wall = {
             mesh,
             node,
@@ -175,95 +233,99 @@ export class WallCutoutCache {
             negativeFacing: undefined,
             hidden: undefined,
             variantKey: undefined,
+            assignedMaterials: undefined,
             visibleVariant: { key: 'visible', materials: [] },
             hiddenVariant: { key: 'invisible', materials: [] },
           }
           this.walls.set(id, wall)
-          this.refreshNormal(wall)
-        } else if (nodesChanged || this.rebuilt.has(id)) {
-          this.refreshNormal(wall)
         }
+        const changed = pathChanged(id)
+        const rebuilt = this.rebuilt.has(id)
+        if (added || changed || rebuilt) this.refreshNormal(wall, visited)
         wall.node = node
-        const deleted = viewer.hoverHighlightMode === 'delete' && viewer.hoveredId === id
-        let selectionHighlighted = !deleted && selected.has(id)
-        if (selectionHighlighted) {
-          const levelId = resolveLevelId(node, scene.nodes)
-          const support = spatialGridManager.getSlabSupportForWall(
-            levelId,
-            node.start,
-            node.end,
-            node.curveOffset ?? 0,
-            node.thickness,
-            node.supportSlabId,
-          )
-          const height = resolveWallEffectiveHeight(
-            node,
-            getWallPlaneTop(node, levelId, scene.nodes),
-            support.elevation,
-          )
-          selectionHighlighted = !getWallFaceBandConfig(node, height).enabled
+        if (added || appearanceChanged || (nodesChanged && changed)) this.refreshAppearance(wall)
+        if (
+          added ||
+          appearanceChanged ||
+          changed ||
+          rebuilt ||
+          releasedPreview === id ||
+          cameraChanged
+        ) {
+          this.apply(wall, viewer.wallMode, added || appearanceChanged || (nodesChanged && changed))
         }
-        const materials = getMaterialsForWall(
-          node,
-          viewer.shading,
-          viewer.textures,
-          viewer.colorPreset,
-          viewer.sceneTheme,
-          scene.materials,
-        )
-        // Selection clones need to pick up textures that arrive after mount.
-        // Check only these few source materials, never every wall's material set.
-        if (selectionHighlighted) {
-          for (const material of materials.visible) {
-            this.highlightMaps.push({
-              material,
-              map: (material as Material & { map?: unknown }).map,
-            })
-          }
-        }
-        const variant = (hidden: boolean): Variant => {
-          const key = resolveWallMaterialVariant({
-            translucentMode: viewer.wallMode === 'translucent',
-            hidden,
-            deleteHighlighted: deleted,
-            selectionHighlighted,
-            hoverHighlighted: viewer.hoverHighlightMode === 'default' && viewer.hoveredId === id,
-          })
-          return { key, materials: materialsForVariant(key, materials) }
-        }
-        wall.visibleVariant = variant(false)
-        wall.hiddenVariant = variant(true)
-        this.apply(wall, viewer.wallMode, true)
       }
     } else {
-      for (const id of this.rebuilt) {
-        const wall = this.walls.get(id)
-        if (!wall) continue
-        this.refreshNormal(wall)
-        this.apply(wall, viewer.wallMode, true)
-      }
-      if (cameraChanged) {
-        for (const [id, wall] of this.walls) {
-          if (!this.rebuilt.has(id)) this.apply(wall, viewer.wallMode, false)
-        }
-      }
+      for (const wall of this.walls.values()) this.apply(wall, viewer.wallMode, false)
     }
     this.rebuilt.clear()
-    this.viewer = viewer
+    this.transformed.clear()
     this.nodes = scene.nodes
     this.materials = scene.materials
     this.registryRevision = sceneRegistry.revision
     this.wallCount = wallIds.size
     this.libraryVersion = libraryVersion
-    if (refresh || cameraChanged) {
+    this.textureVersion = getMaterialTextureVersion()
+    if (appearanceChanged || cameraChanged) {
       this.lastCameraPosition.copy(camera.position)
       this.lastCameraTarget.copy(this.cameraTarget)
       this.lastUpdateTime = time
     }
   }
 
-  private refreshNormal(wall: CachedWall): void {
-    wall.mesh.updateWorldMatrix(true, false)
+  private refreshAppearance(wall: CachedWall): void {
+    const viewer = this.viewer!
+    const scene = useScene.getState()
+    const node = wall.node
+    const deleted = viewer.hoverHighlightMode === 'delete' && viewer.hoveredId === node.id
+    let selectionHighlighted = !deleted && this.selected.has(node.id)
+    if (selectionHighlighted) {
+      const levelId = resolveLevelId(node, scene.nodes)
+      const support = spatialGridManager.getSlabSupportForWall(
+        levelId,
+        node.start,
+        node.end,
+        node.curveOffset ?? 0,
+        node.thickness,
+        node.supportSlabId,
+      )
+      const height = resolveWallEffectiveHeight(
+        node,
+        getWallPlaneTop(node, levelId, scene.nodes),
+        support.elevation,
+      )
+      selectionHighlighted = !getWallFaceBandConfig(node, height).enabled
+    }
+    const materials = getMaterialsForWall(
+      node,
+      viewer.shading,
+      viewer.textures,
+      viewer.colorPreset,
+      viewer.sceneTheme,
+      scene.materials,
+    )
+    const variant = (hidden: boolean): Variant => {
+      const key = resolveWallMaterialVariant({
+        translucentMode: viewer.wallMode === 'translucent',
+        hidden,
+        deleteHighlighted: deleted,
+        selectionHighlighted,
+        hoverHighlighted: viewer.hoverHighlightMode === 'default' && viewer.hoveredId === node.id,
+      })
+      return { key, materials: materialsForVariant(key, materials) }
+    }
+    wall.visibleVariant = variant(false)
+    wall.hiddenVariant = variant(true)
+  }
+
+  private refreshNormal(wall: CachedWall, visited: Set<Object3D>): void {
+    const update = (object: Object3D): void => {
+      if (visited.has(object)) return
+      if (object.parent) update(object.parent)
+      object.updateWorldMatrix(false, false)
+      visited.add(object)
+    }
+    update(wall.mesh)
     if (wall.matrix.equals(wall.mesh.matrixWorld) && wall.geometry === wall.mesh.geometry) return
     wall.matrix.copy(wall.mesh.matrixWorld)
     wall.geometry = wall.mesh.geometry
@@ -278,13 +340,22 @@ export class WallCutoutCache {
       )
     }
     const hidden = wallHiddenFromFacing(wall.node, mode, wall.negativeFacing ?? false)
-    if (!refresh && hidden === wall.hidden) return
     wall.hidden = hidden
     // The wall batch and pointer handlers consume this boolean, including
     // false on stamp lift; translucent walls must continue receiving events.
     const stamp = mode !== 'translucent' && hidden
     if (wall.mesh.userData.wallHidden !== stamp) wall.mesh.userData.wallHidden = stamp
     const variant = hidden ? wall.hiddenVariant : wall.visibleVariant
+    // Non-highlight hover owns a temporary material until its restore callback runs.
+    const viewer = this.viewer!
+    if (
+      viewer.hoveredId === wall.node.id &&
+      viewer.hoverHighlightMode !== 'default' &&
+      viewer.hoverHighlightMode !== 'delete'
+    ) {
+      if (refresh) wall.variantKey = undefined
+      return
+    }
     if (wall.variantKey !== variant.key || refresh) {
       if (
         wall.mesh.material !== variant.materials &&
@@ -293,6 +364,9 @@ export class WallCutoutCache {
         wall.mesh.material = variant.materials
       }
       wall.variantKey = variant.key
+      wall.assignedMaterials = wall.mesh.material
+    } else if (wall.mesh.material !== wall.assignedMaterials) {
+      wall.mesh.material = wall.assignedMaterials!
     }
   }
 }

--- a/packages/viewer/src/systems/wall/wall-cutout.tsx
+++ b/packages/viewer/src/systems/wall/wall-cutout.tsx
@@ -1,10 +1,15 @@
 import { type AnyNodeId, emitter, sceneRegistry, useScene, type WallNode } from '@pascal-app/core'
 import { useFrame } from '@react-three/fiber'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo } from 'react'
 import type { Material } from 'three'
 import { type Mesh, Vector3 } from 'three/webgpu'
 import useViewer, { type WallMode } from '../../store/use-viewer'
-import { sameMaterialArray, WallCutoutCache, wallHiddenFromFacing } from './wall-cutout-cache'
+import {
+  sameMaterialArray,
+  WallCutoutCache,
+  type WallCutoutViewerStore,
+  wallHiddenFromFacing,
+} from './wall-cutout-cache'
 import { getMaterialsForWall, getSelectionHighlightMaterials } from './wall-materials'
 import { subscribeWallRebuilds } from './wall-rebuild-notifications'
 
@@ -30,10 +35,12 @@ export function getWallHideState(
   return wallHiddenFromFacing(wallNode, wallMode, v.dot(cameraDir) < 0)
 }
 
-export const WallCutout = () => {
-  const cacheRef = useRef<WallCutoutCache | null>(null)
-  if (!cacheRef.current) cacheRef.current = new WallCutoutCache()
-  const cache = cacheRef.current
+export const WallCutout = ({
+  viewerStore = useViewer,
+}: {
+  viewerStore?: WallCutoutViewerStore
+}) => {
+  const cache = useMemo(() => new WallCutoutCache(viewerStore), [viewerStore])
 
   useEffect(() => subscribeWallRebuilds((id) => cache.rebuilt.add(id)), [cache])
 
@@ -54,10 +61,10 @@ export const WallCutout = () => {
         if (wallNode?.type !== 'wall') return
         const mats = getMaterialsForWall(
           wallNode,
-          useViewer.getState().shading,
-          useViewer.getState().textures,
-          useViewer.getState().colorPreset,
-          useViewer.getState().sceneTheme,
+          viewerStore.getState().shading,
+          viewerStore.getState().textures,
+          viewerStore.getState().colorPreset,
+          viewerStore.getState().sceneTheme,
           useScene.getState().materials,
         )
         const current = wallMesh.material as Material | Material[]
@@ -88,7 +95,7 @@ export const WallCutout = () => {
       emitter.off('thumbnail:before-capture', restoreForCapture)
       emitter.off('thumbnail:after-capture', reapplyAfterCapture)
     }
-  }, [])
+  }, [viewerStore])
 
   return null
 }

--- a/packages/viewer/src/systems/wall/wall-cutout.tsx
+++ b/packages/viewer/src/systems/wall/wall-cutout.tsx
@@ -1,7 +1,7 @@
 import { type AnyNodeId, emitter, sceneRegistry, useScene, type WallNode } from '@pascal-app/core'
 import { useFrame } from '@react-three/fiber'
 import { useEffect, useMemo } from 'react'
-import type { Material } from 'three'
+import type { Camera, Material } from 'three'
 import { type Mesh, Vector3 } from 'three/webgpu'
 import useViewer, { type WallMode } from '../../store/use-viewer'
 import {
@@ -14,6 +14,15 @@ import { getMaterialsForWall, getSelectionHighlightMaterials } from './wall-mate
 import { subscribeWallRebuilds } from './wall-rebuild-notifications'
 
 const v = new Vector3()
+
+export const WALL_CUTOUT_FRAME_PRIORITY = 0
+
+export function runWallCutoutFrame(
+  cache: WallCutoutCache,
+  { camera, clock }: { camera: Camera; clock: { elapsedTime: number } },
+) {
+  cache.update(camera, clock.elapsedTime)
+}
 
 /**
  * Whether a wall should be hidden or see-through for the current camera and
@@ -48,7 +57,7 @@ export const WallCutout = ({
 
   // Camera changes reach PostProcessing (1) in this frame. WallSystem (4)
   // notifies the next frame; WallBatchSystem (5) reads this frame's stamps.
-  useFrame(({ camera, clock }) => cache.update(camera, clock.elapsedTime), 0)
+  useFrame((state) => runWallCutoutFrame(cache, state), WALL_CUTOUT_FRAME_PRIORITY)
 
   useEffect(() => {
     const snapshot = new Map<Mesh, Material | Material[]>()

--- a/packages/viewer/src/systems/wall/wall-cutout.tsx
+++ b/packages/viewer/src/systems/wall/wall-cutout.tsx
@@ -1,32 +1,13 @@
-import {
-  type AnyNodeId,
-  emitter,
-  getLibraryMaterialsVersion,
-  getWallFaceBandConfig,
-  getWallPlaneTop,
-  resolveLevelId,
-  resolveWallEffectiveHeight,
-  sceneRegistry,
-  spatialGridManager,
-  useScene,
-  type WallNode,
-} from '@pascal-app/core'
+import { type AnyNodeId, emitter, sceneRegistry, useScene, type WallNode } from '@pascal-app/core'
 import { useFrame } from '@react-three/fiber'
 import { useEffect, useRef } from 'react'
 import type { Material } from 'three'
 import { type Mesh, Vector3 } from 'three/webgpu'
 import useViewer, { type WallMode } from '../../store/use-viewer'
-import { resolveWallMaterialVariant, type WallMaterialVariant } from './wall-material-variant'
-import {
-  getHoverHighlightMaterials,
-  getMaterialsForWall,
-  getSelectionHighlightMaterials,
-  getWallMaterialHash,
-  type WallMaterials,
-} from './wall-materials'
+import { sameMaterialArray, WallCutoutCache, wallHiddenFromFacing } from './wall-cutout-cache'
+import { getMaterialsForWall, getSelectionHighlightMaterials } from './wall-materials'
+import { subscribeWallRebuilds } from './wall-rebuild-notifications'
 
-const tmpVec = new Vector3()
-const u = new Vector3()
 const v = new Vector3()
 
 /**
@@ -43,239 +24,22 @@ export function getWallHideState(
   wallMode: WallMode,
   cameraDir: Vector3,
 ): boolean {
-  let hideWall = wallNode.frontSide === 'interior' && wallNode.backSide === 'interior'
-
-  if (wallMode === 'up') {
-    hideWall = false
-  } else if (wallMode === 'down') {
-    hideWall = true
-  } else {
-    wallMesh.getWorldDirection(v)
-    if (v.dot(cameraDir) < 0) {
-      if (wallNode.frontSide === 'exterior' && wallNode.backSide !== 'exterior') {
-        hideWall = true
-      }
-    } else if (wallNode.backSide === 'exterior' && wallNode.frontSide !== 'exterior') {
-      hideWall = true
-    }
-  }
-
-  return hideWall
-}
-
-function sameMaterialArray(a: Material | Material[], b: Material[]): boolean {
-  return Array.isArray(a) && a.length === b.length && a.every((material, i) => material === b[i])
-}
-
-/** Materialize a resolved variant from the wall's cached material set. */
-function materialsForVariant(variant: WallMaterialVariant, materials: WallMaterials) {
-  switch (variant) {
-    case 'visible':
-      return materials.visible
-    case 'invisible':
-      return materials.invisible
-    case 'translucent':
-      return materials.translucent
-    case 'delete-visible':
-      return materials.deleteVisible
-    case 'delete-invisible':
-      return materials.deleteInvisible
-    case 'delete-translucent':
-      return materials.deleteTranslucent
-    case 'selection-visible':
-      return getSelectionHighlightMaterials(materials.visible)
-    case 'selection-invisible':
-      return getSelectionHighlightMaterials(materials.invisible)
-    case 'selection-translucent':
-      return getSelectionHighlightMaterials(materials.translucent)
-    case 'hover-invisible':
-      return getHoverHighlightMaterials(materials.invisible)
-    default: {
-      const exhaustive: never = variant
-      return exhaustive
-    }
-  }
+  if (wallMode === 'up') return false
+  if (wallMode === 'down') return true
+  wallMesh.getWorldDirection(v)
+  return wallHiddenFromFacing(wallNode, wallMode, v.dot(cameraDir) < 0)
 }
 
 export const WallCutout = () => {
-  const lastCameraPosition = useRef(new Vector3())
-  const lastCameraTarget = useRef(new Vector3())
-  const lastUpdateTime = useRef(0)
-  const lastWallMode = useRef<string>(useViewer.getState().wallMode)
-  const lastShading = useRef(useViewer.getState().shading)
-  const lastNumberOfWalls = useRef(0)
-  const lastHighlightKey = useRef('')
-  const lastWallAppearanceKey = useRef('')
-  const wallAppearanceKeyRef = useRef('')
-  const wallAppearanceInputs = useRef({
-    nodes: null as object | null,
-    materials: null as object | null,
-    shading: null as unknown,
-    wallCount: -1,
-    libraryMaterialsVersion: -1,
-  })
-  const lastTextures = useRef(useViewer.getState().textures)
-  const lastColorPreset = useRef(useViewer.getState().colorPreset)
-  const lastSceneTheme = useRef(useViewer.getState().sceneTheme)
+  const cacheRef = useRef<WallCutoutCache | null>(null)
+  if (!cacheRef.current) cacheRef.current = new WallCutoutCache()
+  const cache = cacheRef.current
 
-  useFrame(({ camera, clock }) => {
-    const wallMode = useViewer.getState().wallMode
-    const shading = useViewer.getState().shading
-    const textures = useViewer.getState().textures
-    const colorPreset = useViewer.getState().colorPreset
-    const sceneTheme = useViewer.getState().sceneTheme
-    const selectedIds = useViewer.getState().selection.selectedIds
-    const previewSelectedIds = useViewer.getState().previewSelectedIds
-    const hoveredId = useViewer.getState().hoveredId
-    const hoverHighlightMode = useViewer.getState().hoverHighlightMode
-    const sceneState = useScene.getState()
-    const currentTime = clock.elapsedTime
-    const currentCameraPosition = camera.position
-    camera.getWorldDirection(tmpVec)
-    tmpVec.add(currentCameraPosition)
-    const highlightedWallIds = new Set(
-      [...selectedIds, ...previewSelectedIds].filter(
-        (id) => sceneState.nodes[id as AnyNodeId]?.type === 'wall',
-      ),
-    )
-    const deleteHoveredWallId =
-      hoverHighlightMode === 'delete' &&
-      hoveredId &&
-      sceneState.nodes[hoveredId as AnyNodeId]?.type === 'wall'
-        ? hoveredId
-        : null
-    // Select-mode hover on a wall — the affordance for HIDDEN walls, which
-    // are hover/selection ray targets in X-ray (nearest-first) but draw
-    // (almost) nothing: the hovered wall's stipple film glows so the user
-    // sees WHAT the click would select instead of the furniture behind it
-    // lighting up through the wall. Scoped to the default hover mode so the
-    // paint-preview flows (which snapshot + restore mesh.material
-    // themselves) never interleave with this swap.
-    const selectHoveredWallId =
-      hoverHighlightMode === 'default' &&
-      hoveredId &&
-      sceneState.nodes[hoveredId as AnyNodeId]?.type === 'wall'
-        ? hoveredId
-        : null
-    const highlightKey = `${Array.from(highlightedWallIds).sort().join('|')}::${deleteHoveredWallId ?? ''}::${selectHoveredWallId ?? ''}`
-    // Sorting every wall id, hashing each wall's material and JSON-dumping its
-    // face bands is a full-scene scan; its inputs are immutable store slices,
-    // so identity is enough to know the key cannot have changed.
-    const wallCount = sceneRegistry.byType.wall!.size
-    // Dynamic `library:mtl_*` materials register after mount; the version bump
-    // flips the `#unresolved` signature fragments so dangling paint re-resolves.
-    const libraryMaterialsVersion = getLibraryMaterialsVersion()
-    const appearanceInputs = wallAppearanceInputs.current
-    if (
-      appearanceInputs.nodes !== sceneState.nodes ||
-      appearanceInputs.materials !== sceneState.materials ||
-      appearanceInputs.shading !== shading ||
-      appearanceInputs.wallCount !== wallCount ||
-      appearanceInputs.libraryMaterialsVersion !== libraryMaterialsVersion
-    ) {
-      appearanceInputs.nodes = sceneState.nodes
-      appearanceInputs.materials = sceneState.materials
-      appearanceInputs.shading = shading
-      appearanceInputs.wallCount = wallCount
-      appearanceInputs.libraryMaterialsVersion = libraryMaterialsVersion
-      wallAppearanceKeyRef.current = Array.from(sceneRegistry.byType.wall!)
-        .sort()
-        .map((wallId) => {
-          const wallNode = sceneState.nodes[wallId as WallNode['id']]
-          if (wallNode?.type !== 'wall') return `${wallId}:missing`
-          return `${wallId}:${getWallMaterialHash(wallNode, shading, sceneState.materials)}:${JSON.stringify(wallNode.faceBands ?? null)}`
-        })
-        .join('|')
-    }
-    const wallAppearanceKey = wallAppearanceKeyRef.current
+  useEffect(() => subscribeWallRebuilds((id) => cache.rebuilt.add(id)), [cache])
 
-    const distanceMoved = currentCameraPosition.distanceTo(lastCameraPosition.current)
-    const directionChanged = tmpVec.distanceTo(lastCameraTarget.current)
-    const timeSinceUpdate = currentTime - lastUpdateTime.current
-
-    if (
-      ((distanceMoved > 0.5 || directionChanged > 0.3) && timeSinceUpdate > 0.1) ||
-      lastWallMode.current !== wallMode ||
-      lastShading.current !== shading ||
-      lastTextures.current !== textures ||
-      lastColorPreset.current !== colorPreset ||
-      lastSceneTheme.current !== sceneTheme ||
-      sceneRegistry.byType.wall!.size !== lastNumberOfWalls.current ||
-      lastHighlightKey.current !== highlightKey ||
-      lastWallAppearanceKey.current !== wallAppearanceKey
-    ) {
-      lastCameraPosition.current.copy(currentCameraPosition)
-      lastCameraTarget.current.copy(tmpVec)
-      lastUpdateTime.current = currentTime
-      camera.getWorldDirection(u)
-
-      const walls = sceneRegistry.byType.wall!
-      walls.forEach((wallId) => {
-        const wallMesh = sceneRegistry.nodes.get(wallId)
-        if (!wallMesh) return
-        const wallNode = sceneState.nodes[wallId as WallNode['id']]
-        if (wallNode?.type !== 'wall') return
-
-        const hideWall = getWallHideState(wallNode, wallMesh as Mesh, wallMode, u)
-        // Pointer transparency for hidden walls: the wall's full-height
-        // collision mesh keeps raycasting even when the wall draws with the
-        // invisible material ('down' mode, cutaway-hidden faces, auto-mode
-        // interior partitions), so it silently swallows clicks aimed at
-        // VISIBLE objects standing behind it — e.g. a plugin's wall-mounted
-        // device/service boxes in X-ray mode (night-5 D4: the arm click on a
-        // south-wall receptacle selected an invisible wall two meters in
-        // front of it instead, and the follow-up click committed a WALL
-        // move). The wall renderer's pointer handlers read this stamp and
-        // pass hidden walls through (delete mode excepted — hidden walls
-        // must stay hover-targetable for deletion). Translucent walls are
-        // visible, so they keep their events.
-        ;(wallMesh as Mesh).userData.wallHidden = wallMode !== 'translucent' && hideWall
-        const isDeleteHighlighted = deleteHoveredWallId === wallId
-        const isSelectionHighlighted = !isDeleteHighlighted && highlightedWallIds.has(wallId)
-        const levelId = resolveLevelId(wallNode, sceneState.nodes)
-        const support = spatialGridManager.getSlabSupportForWall(
-          levelId,
-          wallNode.start,
-          wallNode.end,
-          wallNode.curveOffset ?? 0,
-          wallNode.thickness,
-          wallNode.supportSlabId,
-        )
-        const effectiveWallHeight = resolveWallEffectiveHeight(
-          wallNode,
-          getWallPlaneTop(wallNode, levelId, sceneState.nodes),
-          support.elevation,
-        )
-        const shouldSelectionHighlight =
-          isSelectionHighlighted && !getWallFaceBandConfig(wallNode, effectiveWallHeight).enabled
-        const materials = getMaterialsForWall(
-          wallNode,
-          shading,
-          textures,
-          colorPreset,
-          sceneTheme,
-          sceneState.materials,
-        )
-
-        const variant = resolveWallMaterialVariant({
-          translucentMode: wallMode === 'translucent',
-          hidden: hideWall,
-          deleteHighlighted: isDeleteHighlighted,
-          selectionHighlighted: shouldSelectionHighlight,
-          hoverHighlighted: selectHoveredWallId === wallId,
-        })
-        ;(wallMesh as Mesh).material = materialsForVariant(variant, materials)
-      })
-      lastWallMode.current = wallMode
-      lastShading.current = shading
-      lastTextures.current = textures
-      lastColorPreset.current = colorPreset
-      lastSceneTheme.current = sceneTheme
-      lastNumberOfWalls.current = sceneRegistry.byType.wall!.size
-      lastHighlightKey.current = highlightKey
-      lastWallAppearanceKey.current = wallAppearanceKey
-    }
-  })
+  // Read completed transforms after WallSystem (4), before WallBatchSystem (5)
+  // consumes the hidden stamps and its independent rebuild queue.
+  useFrame(({ camera, clock }) => cache.update(camera, clock.elapsedTime), 4.5)
 
   useEffect(() => {
     const snapshot = new Map<Mesh, Material | Material[]>()

--- a/packages/viewer/src/systems/wall/wall-cutout.tsx
+++ b/packages/viewer/src/systems/wall/wall-cutout.tsx
@@ -37,9 +37,11 @@ export const WallCutout = () => {
 
   useEffect(() => subscribeWallRebuilds((id) => cache.rebuilt.add(id)), [cache])
 
-  // Read completed transforms after WallSystem (4), before WallBatchSystem (5)
-  // consumes the hidden stamps and its independent rebuild queue.
-  useFrame(({ camera, clock }) => cache.update(camera, clock.elapsedTime), 4.5)
+  useEffect(() => cache.subscribeLiveTransforms(), [cache])
+
+  // Camera changes reach PostProcessing (1) in this frame. WallSystem (4)
+  // notifies the next frame; WallBatchSystem (5) reads this frame's stamps.
+  useFrame(({ camera, clock }) => cache.update(camera, clock.elapsedTime), 0)
 
   useEffect(() => {
     const snapshot = new Map<Mesh, Material | Material[]>()

--- a/packages/viewer/src/systems/wall/wall-rebuild-notifications.ts
+++ b/packages/viewer/src/systems/wall/wall-rebuild-notifications.ts
@@ -1,3 +1,5 @@
+// New kind-specific modules belong in nodes; viewer must not depend on nodes.
+// This extracts the existing viewer-owned WallSystem rebuild signal.
 // Dirty marks disappear before later systems run. Keep the batch drain and
 // cutout subscribers independent, including deferred neighbour rebuilds.
 const rebuiltWalls = new Set<string>()

--- a/packages/viewer/src/systems/wall/wall-rebuild-notifications.ts
+++ b/packages/viewer/src/systems/wall/wall-rebuild-notifications.ts
@@ -1,0 +1,22 @@
+// Dirty marks disappear before later systems run. Keep the batch drain and
+// cutout subscribers independent, including deferred neighbour rebuilds.
+const rebuiltWalls = new Set<string>()
+const listeners = new Set<(wallId: string) => void>()
+
+export function notifyWallRebuilt(wallId: string): void {
+  rebuiltWalls.add(wallId)
+  for (const listener of listeners) listener(wallId)
+}
+
+export function subscribeWallRebuilds(listener: (wallId: string) => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Moves every rebuild notice collected so far into `into`. */
+export function drainRebuiltWalls(into: Set<string>): void {
+  for (const wallId of rebuiltWalls) into.add(wallId)
+  rebuiltWalls.clear()
+}

--- a/packages/viewer/src/systems/wall/wall-system.tsx
+++ b/packages/viewer/src/systems/wall/wall-system.tsx
@@ -48,6 +48,9 @@ import {
   getOpeningCutoutBottomPadding,
 } from './opening-cutout-geometry'
 import { sweepUnbuiltWalls, WALL_PLACEHOLDER_SWEEP_INTERVAL } from './wall-placeholder-sweep'
+import { notifyWallRebuilt } from './wall-rebuild-notifications'
+
+export { drainRebuiltWalls } from './wall-rebuild-notifications'
 
 // Reusable CSG evaluator for better performance
 const csgEvaluator = new Evaluator()
@@ -635,20 +638,6 @@ export function shouldDeferWallRebuild(
   return false
 }
 
-// Walls whose geometry this system replaced since the last drain.
-//
-// The store's dirty mark is cleared the moment a wall is rebuilt, so anything
-// running later in the same frame would never see it. This is that same
-// signal, held until a consumer picks it up. Neighbours rebuilt by the
-// trailing-edge flush land here too — those never carry a dirty mark at all.
-const rebuiltWalls = new Set<string>()
-
-/** Moves every rebuild notice collected so far into `into`. */
-export function drainRebuiltWalls(into: Set<string>): void {
-  for (const wallId of rebuiltWalls) into.add(wallId)
-  rebuiltWalls.clear()
-}
-
 /** Rebuilds this system still owes — neighbours deferred during a drag. */
 export function getPendingWallRebuildCount(): number {
   let count = 0
@@ -767,7 +756,7 @@ export const WallSystem = () => {
             properties: [['node', wallId]],
           })
           clearDirty(wallId as AnyNodeId)
-          rebuiltWalls.add(wallId)
+          notifyWallRebuilt(wallId)
           rebuiltWallIds.add(wallId)
           rebuiltWallsThisFrame += 1
         }
@@ -829,7 +818,7 @@ export const WallSystem = () => {
             timeSpan('wall-rebuild', () => updateWallGeometry(wallId, miterData), {
               properties: [['node', wallId]],
             })
-            rebuiltWalls.add(wallId)
+            notifyWallRebuilt(wallId)
           }
           pendingIds.delete(wallId)
           rebuiltAdjacentThisFrame += 1


### PR DESCRIPTION
## Why

`WallCutout.useFrame` early-outs while the camera is still, but once it moves it re-evaluated every wall each frame — world direction + dot, material-variant lookup and a `mesh.material =` reassignment per wall (which re-keys the render object) — even in full-height mode where nothing is ever hidden. On the rich-4× perf fixture (352 walls) that was 199 ms/s while orbiting, ≈ 5.7 ms per frame, the whole in-frame rise from 12.5 to 18.4 ms (50 → 35 fps). Charter row 14.

## What

- `packages/viewer/src/systems/wall/wall-cutout-cache.ts`: per-wall cache (mesh, world normal, hide state, variant key) invalidated by the scene-registry revision, the wall-rebuild notification the batch already drains (extracted into `wall-rebuild-notifications.ts` with subscribers), and the live-transform channel (building/level rotation publishes `useLiveTransforms` without a nodes change). Cutaway does one dot per wall per qualifying scan with ±0.001 hysteresis and writes `material`/`wallHidden` only on change; a per-scan identity check reconciles materials that paint/thumbnail flows snapshot and restore. Full-height, low and translucent modes skip camera scans; appearance refreshes use the old effective highlight key (paint hover previews survive). Node-map changes refresh only walls whose own node or an ancestor changed, ancestors visited once.
- Priority stays 0 (before the post-processing render at 1): camera-driven changes land the same frame; rebuilt walls refresh next frame via the notification, as before. The wall batch and its `wallHidden` stamp contract are unchanged.
- Module placement: the cache sits beside the legacy viewer cutout because `packages/viewer` must not depend on `@pascal-app/nodes`; header comments name the rule and the reason.

## Results

| rich-4× (full height), same session | before | after |
|---|---|---|
| parked → orbiting frame | 12.5 → 18.4 ms (50 → 35 fps) | 12.8 → 14.9 ms (50 fps held) |
| `WallCutout.useFrame` while orbiting | 199 ms/s | 0.3 ms/s |
| rich-2× cutaway orbit (author's run) | 18.6 ms | 14.9 ms |

Cutaway parity vs main on the rich-2× fixture (poses across Cutaway / Full height) 0.004–0.03 %; outline poses unchanged.

## Notes for review

- 206 viewer + 160 wall tests, incl. the cache: live rotations by π (site/building/level), material restore, paint-hover preview retention, R3F priority ordering, scoped refresh (100 walls / 4 ancestors), hysteresis, mode transitions.
- Gates: tsc, repo-wide biome; e2e pack + wall chain/plane/hover/batched/paint/undo specs on the integrated build.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core viewer rendering (wall visibility, materials, pointer `wallHidden` stamps) and frame ordering with rebuild notifications; behavior is heavily tested but regressions would show as wrong cutaway, highlights, or raycast pass-through.
> 
> **Overview**
> **Moves wall cutout work off a per-frame full-scene scan** into a `WallCutoutCache` that keeps per-wall normals, hide state, and material variants, and only runs when something actually invalidates (viewer appearance, scene nodes/materials, registry/rebuilds, live transforms, or cutaway camera moves past the existing distance/time gates).
> 
> In **full height / low / translucent** modes, a stationary or orbiting camera no longer walks every wall: materials and `wallHidden` update only when facing or appearance changes, with **±0.001 hysteresis** on the camera–normal dot to reduce edge-on flicker. **Scoped refresh** limits normal/appearance updates to walls whose node or ancestor changed; paint-hover previews are left alone until preview mode ends.
> 
> `WallCutout` becomes a thin R3F shell (`runWallCutoutFrame`, priority 0). **Wall rebuild signals** move to `wall-rebuild-notifications.ts` (`notifyWallRebuilt` / `subscribeWallRebuilds` / `drainRebuiltWalls`) so the cutout cache and batch drain stay in sync.
> 
> **`getMaterialTextureVersion()`** in `materials.ts` bumps when preset textures are assigned or cleared so **selected-wall highlight clones** can refresh after async texture loads without per-frame material polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa8d2fba68bde99ecfa4d15ba73d80a35f3cacd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->