### PR TITLE
perf(viewer): zone and overlay passes render from indexed roots

### DIFF
--- a/packages/viewer/src/components/viewer/post-processing.tsx
+++ b/packages/viewer/src/components/viewer/post-processing.tsx
@@ -33,6 +33,7 @@ import { LayerPassIndex, LayerPassNode } from '../../lib/layer-pass'
 import { GRID_LAYER, OVERLAY_LAYER, SCENE_LAYER, ZONE_LAYER } from '../../lib/layers'
 import { mergedOutline } from '../../lib/merged-outline-node'
 import { recordPerfSample, timeSpan } from '../../lib/perf-tracks'
+import { PostProcessingResources } from '../../lib/post-processing-resources'
 import { getSceneTheme } from '../../lib/scene-themes'
 import { packNormalToRGB, unpackRGBToNormal } from '../../lib/tsl-compat'
 import useViewer from '../../store/use-viewer'
@@ -193,7 +194,7 @@ const PostProcessingPasses = ({
   disablePostFx?: boolean
 }) => {
   const { gl: renderer, invalidate, scene, camera, size } = useThree()
-  const renderPipelineRef = useRef<RenderPipeline | null>(null)
+  const resourcesRef = useRef<PostProcessingResources | null>(null)
   const hasPipelineErrorRef = useRef(false)
   const retryCountRef = useRef(0)
   const rebuildTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -337,10 +338,8 @@ const PostProcessingPasses = ({
     if (width < 1 || height < 1) {
       skippedZeroSizeRef.current = true
       hasPipelineErrorRef.current = false
-      if (renderPipelineRef.current) {
-        renderPipelineRef.current.dispose()
-      }
-      renderPipelineRef.current = null
+      resourcesRef.current?.dispose()
+      resourcesRef.current = null
       return
     }
 
@@ -356,10 +355,8 @@ const PostProcessingPasses = ({
     // allocated every pass.
     if (disablePostFx || perfDisable.postFx) {
       hasPipelineErrorRef.current = false
-      if (renderPipelineRef.current) {
-        renderPipelineRef.current.dispose()
-      }
-      renderPipelineRef.current = null
+      resourcesRef.current?.dispose()
+      resourcesRef.current = null
       return
     }
     const ssgiEnabled = shading === 'rendered' && SSGI_PARAMS.enabled && !perfDisable.ao
@@ -403,7 +400,7 @@ const PostProcessingPasses = ({
     const hasWebGPU = typeof navigator !== 'undefined' && 'gpu' in navigator
     if (!hasWebGPU) {
       hasPipelineErrorRef.current = true
-      renderPipelineRef.current = null
+      resourcesRef.current = null
       return
     }
 
@@ -415,20 +412,22 @@ const PostProcessingPasses = ({
     outliner.selectedObjects.length = 0
     outliner.hoveredObjects.length = 0
 
-    let outlineNode: ReturnType<typeof mergedOutline> | null = null
-    const layerIndex = new LayerPassIndex(scene, [ZONE_LAYER, OVERLAY_LAYER])
-    const layerPasses: LayerPassNode[] = []
+    const resources = new PostProcessingResources()
+    resourcesRef.current = resources
     try {
+      const layerIndex = new LayerPassIndex(scene, [ZONE_LAYER, OVERLAY_LAYER])
+      resources.layerIndex = layerIndex
       const scenePass = pass(scene, camera)
+      resources.passes.push(scenePass)
       scenePass.setLayers(sceneOnlyLayers)
       const zonePass = new LayerPassNode(layerIndex, camera, ZONE_LAYER, scenePass)
-      layerPasses.push(zonePass)
+      resources.passes.push(zonePass)
       zonePass.setLayers(zoneLayers)
       // Editor overlays (gizmos, move handles, tool previews, grid) on their own
       // layer, kept out of the depth/normal MRT above so the ink + SSGI ignore
       // them, then composited on top of the final image below.
       const overlayPass = new LayerPassNode(layerIndex, camera, OVERLAY_LAYER, scenePass)
-      layerPasses.push(overlayPass)
+      resources.passes.push(overlayPass)
       overlayPass.setLayers(overlayLayers)
       const overlayColor = overlayPass.getTextureNode('output')
 
@@ -562,13 +561,15 @@ const PostProcessingPasses = ({
       let compositeWithOutlines = sceneColor
       let visualAlpha = contentAlpha
       if (outlineEnabled) {
-        outlineNode = mergedOutline(scene, camera, {
+        const outlineNode = mergedOutline(scene, camera, {
           sceneDepthNode: scenePassDepth,
           primaryObjects: outliner.selectedObjects,
           secondaryObjects: outliner.hoveredObjects,
           primaryEdgeThickness: uniform(1),
           secondaryEdgeThickness: uniform(1.5),
         })
+
+        resources.outline = outlineNode
 
         // Selected: white visible, yellow hidden
         const selectedVisibleColor = uniform(new Color(0xff_ff_ff))
@@ -641,16 +642,12 @@ const PostProcessingPasses = ({
       }
 
       const renderPipeline = new RenderPipeline(renderer as unknown as WebGPURenderer)
+      resources.pipeline = renderPipeline
       renderPipeline.outputColorTransform = !transparentBackground
       renderPipeline.outputNode = finalOutput
-      renderPipelineRef.current = renderPipeline
       retryCountRef.current = 0
     } catch (error) {
-      layerIndex.dispose()
-      for (const layerPass of layerPasses) layerPass.dispose()
-      layerPasses.length = 0
-      outlineNode?.dispose()
-      outlineNode = null
+      resources.dispose()
       hasPipelineErrorRef.current = true
       console.error(
         '[viewer/post-processing] Failed to set up post-processing pipeline. Rendering without post FX.',
@@ -661,20 +658,12 @@ const PostProcessingPasses = ({
         },
         error,
       )
-      if (renderPipelineRef.current) {
-        renderPipelineRef.current.dispose()
-      }
-      renderPipelineRef.current = null
+      resourcesRef.current = null
     }
 
     return () => {
-      layerIndex.dispose()
-      for (const layerPass of layerPasses) layerPass.dispose()
-      outlineNode?.dispose()
-      if (renderPipelineRef.current) {
-        renderPipelineRef.current.dispose()
-      }
-      renderPipelineRef.current = null
+      resources.dispose()
+      if (resourcesRef.current === resources) resourcesRef.current = null
     }
   }, [
     // NOTE: hoverHighlightMode intentionally excluded — the hover style is
@@ -755,7 +744,7 @@ const PostProcessingPasses = ({
       disablePostFx ||
       PERF_POST_FX_DISABLED ||
       hasPipelineErrorRef.current ||
-      !renderPipelineRef.current
+      !resourcesRef.current?.pipeline
     ) {
       try {
         const clearAlpha = transparentBackground ? 0 : 1
@@ -775,7 +764,7 @@ const PostProcessingPasses = ({
       return
     }
 
-    const pipeline = renderPipelineRef.current
+    const pipeline = resourcesRef.current.pipeline
     try {
       // Clear alpha=0 so background pixels in the output MRT attachment (index 0) get a=0,
       // making scenePassColor.a a reliable geometry mask (geometry pixels write a=1 via output node).
@@ -794,10 +783,8 @@ const PostProcessingPasses = ({
         rendererCtor: (renderer as any).constructor?.name,
         error,
       })
-      if (renderPipelineRef.current) {
-        renderPipelineRef.current.dispose()
-      }
-      renderPipelineRef.current = null
+      resourcesRef.current?.dispose()
+      resourcesRef.current = null
 
       if (retryCountRef.current < MAX_PIPELINE_RETRIES) {
         // Auto-retry: schedule a pipeline rebuild if we haven't exceeded the retry limit

--- a/packages/viewer/src/components/viewer/post-processing.tsx
+++ b/packages/viewer/src/components/viewer/post-processing.tsx
@@ -29,6 +29,7 @@ import { backdropGradient, deepSkyColor, horizonHazeColor } from '../../lib/back
 import { edgeColorFor, edgeOpacityScaleFor } from '../../lib/edge-style'
 import { PERF_OVERLAY_ENABLED } from '../../lib/gpu-perf'
 import { inkedEdges } from '../../lib/ink-edges'
+import { LayerPassIndex, LayerPassNode } from '../../lib/layer-pass'
 import { GRID_LAYER, OVERLAY_LAYER, SCENE_LAYER, ZONE_LAYER } from '../../lib/layers'
 import { mergedOutline } from '../../lib/merged-outline-node'
 import { recordPerfSample, timeSpan } from '../../lib/perf-tracks'
@@ -415,15 +416,19 @@ const PostProcessingPasses = ({
     outliner.hoveredObjects.length = 0
 
     let outlineNode: ReturnType<typeof mergedOutline> | null = null
+    const layerIndex = new LayerPassIndex(scene, [ZONE_LAYER, OVERLAY_LAYER])
+    const layerPasses: LayerPassNode[] = []
     try {
       const scenePass = pass(scene, camera)
       scenePass.setLayers(sceneOnlyLayers)
-      const zonePass = pass(scene, camera)
+      const zonePass = new LayerPassNode(layerIndex, camera, ZONE_LAYER, scenePass)
+      layerPasses.push(zonePass)
       zonePass.setLayers(zoneLayers)
       // Editor overlays (gizmos, move handles, tool previews, grid) on their own
       // layer, kept out of the depth/normal MRT above so the ink + SSGI ignore
       // them, then composited on top of the final image below.
-      const overlayPass = pass(scene, camera)
+      const overlayPass = new LayerPassNode(layerIndex, camera, OVERLAY_LAYER, scenePass)
+      layerPasses.push(overlayPass)
       overlayPass.setLayers(overlayLayers)
       const overlayColor = overlayPass.getTextureNode('output')
 
@@ -641,6 +646,9 @@ const PostProcessingPasses = ({
       renderPipelineRef.current = renderPipeline
       retryCountRef.current = 0
     } catch (error) {
+      layerIndex.dispose()
+      for (const layerPass of layerPasses) layerPass.dispose()
+      layerPasses.length = 0
       outlineNode?.dispose()
       outlineNode = null
       hasPipelineErrorRef.current = true
@@ -660,6 +668,8 @@ const PostProcessingPasses = ({
     }
 
     return () => {
+      layerIndex.dispose()
+      for (const layerPass of layerPasses) layerPass.dispose()
       outlineNode?.dispose()
       if (renderPipelineRef.current) {
         renderPipelineRef.current.dispose()

--- a/packages/viewer/src/index.ts
+++ b/packages/viewer/src/index.ts
@@ -92,6 +92,7 @@ export {
   isIsolationActive,
 } from './lib/isolation'
 export { configureKtx2Support, ensureKtx2Support } from './lib/ktx2-loader'
+export { LayerPassIndex } from './lib/layer-pass'
 export {
   BATCHED_LAYER,
   GRID_LAYER,

--- a/packages/viewer/src/lib/layer-pass.test.ts
+++ b/packages/viewer/src/lib/layer-pass.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, spyOn, test } from 'bun:test'
 import {
   DirectionalLight,
   Group,
   Layers,
+  Matrix4,
   Mesh,
   MeshBasicMaterial,
   PerspectiveCamera,
@@ -322,7 +323,7 @@ function renderFixture() {
   zoneLayers.set(ZONE_LAYER)
   zone.setLayers(zoneLayers)
   const frame = new NodeFrame()
-  const renders: { root: Scene; mask: number; positions: number[] }[] = []
+  const renders: { root: Scene; mask: number; positions: number[]; matrices: Matrix4[] }[] = []
   let target: unknown = null
   let mrt: unknown = null
   const renderer = {
@@ -341,6 +342,7 @@ function renderFixture() {
       if (root.matrixWorldAutoUpdate) root.updateMatrixWorld()
       root.onBeforeRender(renderer as never, root, renderCamera, target as never)
       const positions: number[] = []
+      const matrices: Matrix4[] = []
       root.traverseVisible((object) => {
         if (!(object instanceof Mesh && object.layers.test(renderCamera.layers))) return
         object.onBeforeRender(
@@ -352,6 +354,7 @@ function renderFixture() {
           null as never,
         )
         positions.push(object.matrixWorld.elements[12]!)
+        matrices.push(object.matrixWorld.clone())
         object.onAfterRender(
           renderer as never,
           root,
@@ -361,7 +364,7 @@ function renderFixture() {
           null as never,
         )
       })
-      renders.push({ root, mask: renderCamera.layers.mask, positions })
+      renders.push({ root, mask: renderCamera.layers.mask, positions, matrices })
       root.onAfterRender(renderer as never, root, renderCamera)
     },
   }
@@ -441,6 +444,73 @@ test('refreshes private roots, ancestors and descendants after main object callb
   expect(f.renders[1]?.positions).toEqual([12])
   expect(f.renders.filter(({ mask }) => mask === 1).length).toBe(1)
   f.dispose()
+})
+
+for (const layer of [OVERLAY_LAYER, ZONE_LAYER]) {
+  for (const movedObject of ['root', 'ancestor'] as const) {
+    for (const manual of [false, true]) {
+      test(`layer ${layer} refreshes descendant matrices after ${movedObject} moves (manual: ${manual})`, () => {
+        const f = renderFixture()
+        const ancestor = new Group()
+        f.scene.add(ancestor)
+        ancestor.add(f.parent)
+        f.parent.layers.set(layer)
+        f.mesh.layers.set(layer)
+        const chain = [f.scene, ancestor, f.parent, f.mesh]
+        for (const [i, object] of chain.entries()) {
+          object.position.set(i + 1, i + 2, i + 3)
+          object.rotation.set(i * 0.1, i * 0.2, i * 0.3)
+          object.scale.set(1 + i * 0.1, 1, 2)
+          object.updateMatrix()
+          object.matrixAutoUpdate = !manual
+        }
+        const mover = new Mesh()
+        f.scene.add(mover)
+        let expected = new Matrix4()
+        mover.onAfterRender = () => {
+          const moved = movedObject === 'root' ? f.parent : f.scene
+          if (manual) moved.matrix.makeRotationZ(0.8).setPosition(7, 8, 9)
+          else moved.position.set(7, 8, 9)
+          expected = chain.reduce(
+            (product, object) =>
+              product.multiply(
+                object.matrixAutoUpdate
+                  ? new Matrix4().compose(object.position, object.quaternion, object.scale)
+                  : object.matrix,
+              ),
+            new Matrix4(),
+          )
+        }
+        f.tick()
+        const rendered = f.renders.find(({ mask }) => mask === 1 << layer)!
+        expect(rendered.root).not.toBe(f.scene)
+        expect(rendered.root.children).toEqual([f.parent])
+        expect(rendered.matrices).toEqual([expected])
+        f.dispose()
+      })
+    }
+  }
+}
+
+test('refreshes shared ancestors only once per preparation and again on the next frame', () => {
+  const f = renderFixture()
+  const second = new Mesh()
+  f.parent.add(second)
+  f.mesh.layers.set(OVERLAY_LAYER)
+  second.layers.set(OVERLAY_LAYER)
+  const sceneUpdate = spyOn(f.scene, 'updateWorldMatrix')
+  const parentUpdate = spyOn(f.parent, 'updateWorldMatrix')
+  try {
+    for (let frame = 1; frame <= 2; frame++) {
+      f.tick()
+      expect(sceneUpdate).toHaveBeenCalledTimes(frame)
+      expect(parentUpdate).toHaveBeenCalledTimes(frame)
+    }
+  } finally {
+    sceneUpdate.mockRestore()
+    parentUpdate.mockRestore()
+    f.dispose()
+  }
 })
 
 test('matrix refresh honors manual local and world matrices after ancestors move', () => {

--- a/packages/viewer/src/lib/layer-pass.test.ts
+++ b/packages/viewer/src/lib/layer-pass.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DirectionalLight,
+  Group,
+  Layers,
+  Mesh,
+  MeshBasicMaterial,
+  PerspectiveCamera,
+  Scene,
+  Texture,
+} from 'three'
+import PassNode from 'three/src/nodes/display/PassNode.js'
+import { NodeFrame } from 'three/webgpu'
+import { LayerPassIndex, LayerPassNode } from './layer-pass'
+import { OVERLAY_LAYER, SCENE_LAYER, ZONE_LAYER } from './layers'
+
+function fixture() {
+  const scene = new Scene()
+  const parent = new Group()
+  const mesh = new Mesh()
+  parent.add(mesh)
+  scene.add(parent)
+  const index = new LayerPassIndex(scene, [OVERLAY_LAYER, ZONE_LAYER])
+  const roots: Mesh[] = []
+  return { scene, parent, mesh, index, roots }
+}
+
+describe('layer pass membership', () => {
+  test('tracks preexisting, late, direct and disabled layer assignments; releases detached trees', () => {
+    const { scene, parent, mesh, index, roots } = fixture()
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+    mesh.layers.set(OVERLAY_LAYER)
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+    expect(roots).toEqual([mesh])
+    mesh.layers.mask = 1 << ZONE_LAYER
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+    expect(index.prepare(ZONE_LAYER, roots).drawable).toBe(true)
+    scene.remove(parent)
+    expect(index.prepare(ZONE_LAYER, roots).drawable).toBe(false)
+    expect(Object.getOwnPropertyDescriptor(mesh.layers, 'mask')?.get).toBeUndefined()
+    scene.add(parent)
+    expect(index.prepare(ZONE_LAYER, roots).drawable).toBe(true)
+    mesh.layers.disableAll()
+    expect(index.prepare(ZONE_LAYER, roots).drawable).toBe(false)
+    const late = new Mesh()
+    late.layers.enable(OVERLAY_LAYER)
+    parent.add(late)
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+    expect(roots).toEqual([late])
+    index.dispose()
+    expect(Object.getOwnPropertyDescriptor(late.layers, 'mask')?.value).toBe(3)
+  })
+
+  test('retains original transforms, inherited visibility and material visibility', () => {
+    const { parent, mesh, index, roots, scene } = fixture()
+    parent.position.set(2, 3, 4)
+    mesh.position.set(5, 6, 7)
+    mesh.layers.set(OVERLAY_LAYER)
+    scene.updateMatrixWorld()
+    index.prepare(OVERLAY_LAYER, roots)
+    expect(roots[0]).toBe(mesh)
+    expect(mesh.matrixWorld.elements.slice(12, 15)).toEqual([7, 9, 11])
+    expect(mesh.parent).toBe(parent)
+    parent.visible = false
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+    parent.visible = true
+    mesh.material = [new MeshBasicMaterial({ visible: false })]
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+    mesh.material.push(new MeshBasicMaterial())
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+    index.dispose()
+  })
+
+  test('keeps matching ancestor groups once, and preserves scene order after layer changes', () => {
+    const { parent, mesh, index, roots } = fixture()
+    const second = new Mesh()
+    parent.add(second)
+    second.layers.set(OVERLAY_LAYER)
+    mesh.layers.set(OVERLAY_LAYER)
+    index.prepare(OVERLAY_LAYER, roots)
+    expect(roots).toEqual([mesh, second])
+    parent.layers.set(OVERLAY_LAYER)
+    parent.renderOrder = 37
+    index.prepare(OVERLAY_LAYER, roots)
+    expect(roots).toEqual([parent])
+    expect(roots[0]?.renderOrder).toBe(37)
+    parent.layers.set(SCENE_LAYER)
+    const next = new Group()
+    parent.add(next)
+    next.add(mesh)
+    index.prepare(OVERLAY_LAYER, roots)
+    expect(roots).toEqual([second, mesh])
+    index.dispose()
+  })
+
+  test('does not visit unrelated branches during frame preparation', () => {
+    const { scene, mesh, index, roots } = fixture()
+    const unrelated = new Group()
+    scene.add(unrelated)
+    mesh.layers.set(OVERLAY_LAYER)
+    const children = unrelated.children
+    Object.defineProperty(unrelated, 'children', {
+      configurable: true,
+      get: () => {
+        throw new Error('whole-scene walk')
+      },
+    })
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+    Object.defineProperty(unrelated, 'children', { configurable: true, value: children })
+    index.dispose()
+  })
+})
+
+test('private pass orders the main update, retains scene properties, and clears only on empty transitions/resizes', () => {
+  const { scene, mesh, index } = fixture()
+  scene.environment = new Texture()
+  const camera = new PerspectiveCamera()
+  const main = new PassNode(PassNode.COLOR, scene, camera)
+  const calls: string[] = []
+  main.updateBefore = () => {
+    calls.push('main')
+    scene.updateMatrixWorld()
+    return undefined
+  }
+  const layer = new LayerPassNode(index, camera, OVERLAY_LAYER, main)
+  const layers = new Layers()
+  layers.set(OVERLAY_LAYER)
+  layer.setLayers(layers)
+  const frame = new NodeFrame()
+  let width = 100
+  let target: unknown = null
+  let mrt: unknown = null
+  const renderer = {
+    getOutputRenderTarget: () => null,
+    getDrawingBufferSize: (size: { set: (x: number, y: number) => void }) => size.set(width, 100),
+    getRenderTarget: () => target,
+    setRenderTarget: (value: unknown) => {
+      target = value
+    },
+    getMRT: () => mrt,
+    setMRT: (value: unknown) => {
+      mrt = value
+    },
+    clear: () => {
+      calls.push('clear')
+      expect(target).toBe(layer.renderTarget)
+    },
+    render: (root: Scene) => {
+      calls.push('render')
+      expect(root.children).toEqual([mesh])
+      expect(root.environment).toBe(scene.environment)
+      expect(root.matrixWorldAutoUpdate).toBe(false)
+      expect(mesh.parent).not.toBe(root)
+    },
+  }
+  frame.renderer = renderer as unknown as NonNullable<NodeFrame['renderer']>
+  const tick = () => {
+    frame.frameId++
+    layer.updateBefore(frame)
+    expect(target).toBeNull()
+    expect(mrt).toBeNull()
+  }
+  tick()
+  tick()
+  expect(calls).toEqual(['main', 'clear', 'main'])
+  mesh.layers.set(OVERLAY_LAYER)
+  tick()
+  expect(calls.at(-1)).toBe('render')
+  expect(camera.layers.mask).toBe(1)
+  mesh.visible = false
+  tick()
+  tick()
+  expect(calls.slice(-3)).toEqual(['main', 'clear', 'main'])
+  width = 200
+  tick()
+  expect(calls.at(-1)).toBe('clear')
+  index.dispose()
+  layer.dispose()
+})
+
+test('collects only layer-eligible lights and retains a full-scene shadow requirement', () => {
+  const { scene, mesh, index, roots } = fixture()
+  const light = new DirectionalLight()
+  scene.add(light)
+  mesh.layers.set(OVERLAY_LAYER)
+  expect(index.prepare(OVERLAY_LAYER, roots).shadowLight).toBe(false)
+  expect(roots).toEqual([mesh])
+  light.layers.enable(OVERLAY_LAYER)
+  expect(index.prepare(OVERLAY_LAYER, roots).shadowLight).toBe(false)
+  expect(roots).toEqual([mesh, light])
+  light.castShadow = true
+  expect(index.prepare(OVERLAY_LAYER, roots).shadowLight).toBe(true)
+  light.visible = false
+  expect(index.prepare(OVERLAY_LAYER, roots).shadowLight).toBe(false)
+  index.dispose()
+})

--- a/packages/viewer/src/lib/layer-pass.test.ts
+++ b/packages/viewer/src/lib/layer-pass.test.ts
@@ -9,8 +9,8 @@ import {
   Scene,
   Texture,
 } from 'three'
-import PassNode from 'three/src/nodes/display/PassNode.js'
-import { NodeFrame } from 'three/webgpu'
+import { pass } from 'three/tsl'
+import { NodeFrame, PassNode } from 'three/webgpu'
 import { LayerPassIndex, LayerPassNode } from './layer-pass'
 import { OVERLAY_LAYER, SCENE_LAYER, ZONE_LAYER } from './layers'
 
@@ -193,4 +193,351 @@ test('collects only layer-eligible lights and retains a full-scene shadow requir
   light.visible = false
   expect(index.prepare(OVERLAY_LAYER, roots).shadowLight).toBe(false)
   index.dispose()
+})
+
+test('uses the WebGPU PassNode and TSL texture node identities', () => {
+  const { scene, index } = fixture()
+  const camera = new PerspectiveCamera()
+  const main = pass(scene, camera)
+  const layer = new LayerPassNode(index, camera, OVERLAY_LAYER, main)
+  expect(main).toBeInstanceOf(PassNode)
+  expect(layer).toBeInstanceOf(PassNode)
+  expect(layer.isPassNode).toBe(true)
+  expect(layer.getTextureNode().isNode).toBe(true)
+  expect(layer.getTextureNode().passNode).toBe(layer)
+  index.dispose()
+  layer.dispose()
+  main.dispose()
+})
+
+test('drops raw removals before sorting and restores descendant accessors', () => {
+  const { scene, parent, mesh, index, roots } = fixture()
+  mesh.layers.set(OVERLAY_LAYER)
+  const retained = new Mesh()
+  retained.layers.set(OVERLAY_LAYER)
+  scene.add(retained)
+  parent.parent = null
+  scene.children.splice(scene.children.indexOf(parent), 1)
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+  expect(roots).toEqual([retained])
+  expect(Object.getOwnPropertyDescriptor(mesh.layers, 'mask')?.get).toBeUndefined()
+  expect(Object.getOwnPropertyDescriptor(parent.layers, 'mask')?.get).toBeUndefined()
+  scene.add(parent)
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+  expect(roots).toEqual([retained, mesh])
+  index.dispose()
+})
+
+test('registers eventless subtree insertions and reattaches replaced Layers', () => {
+  const { parent, mesh, index, roots } = fixture()
+  const group = new Group()
+  const late = new Mesh()
+  late.layers.set(OVERLAY_LAYER)
+  group.add(late)
+  group.parent = parent
+  parent.children.push(group)
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+  index.register(group)
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+  expect(roots).toEqual([late])
+  const previousLayers = late.layers
+  late.layers = new Layers()
+  late.layers.set(ZONE_LAYER)
+  expect(index.prepare(ZONE_LAYER, roots).drawable).toBe(true)
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+  expect(Object.getOwnPropertyDescriptor(previousLayers, 'mask')?.get).toBeUndefined()
+  late.layers.set(OVERLAY_LAYER)
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+  mesh.layers = new Layers()
+  mesh.layers.set(OVERLAY_LAYER)
+  index.register(mesh)
+  index.prepare(OVERLAY_LAYER, roots)
+  expect(roots).toEqual([mesh, late])
+  index.dispose()
+})
+
+test('rejects overlapping indexes without altering the original observer or mask', () => {
+  const { scene, mesh, index, roots } = fixture()
+  const accessor = Object.getOwnPropertyDescriptor(scene.layers, 'mask')?.get
+  expect(() => new LayerPassIndex(scene, [OVERLAY_LAYER])).toThrow('one index per scene')
+  expect(Object.getOwnPropertyDescriptor(scene.layers, 'mask')?.get).toBe(accessor)
+  mesh.layers.set(OVERLAY_LAYER)
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+  index.dispose()
+  expect(mesh.layers.mask).toBe(1 << OVERLAY_LAYER)
+  const replacement = new LayerPassIndex(scene, [OVERLAY_LAYER])
+  expect(replacement.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+  replacement.dispose()
+})
+
+test('rejects shared Layers and rolls back partial index construction', () => {
+  const { mesh, index } = fixture()
+  const other = new Scene()
+  const ordinary = new Mesh()
+  const shared = new Mesh()
+  shared.layers = mesh.layers
+  other.add(ordinary, shared)
+  const accessor = Object.getOwnPropertyDescriptor(mesh.layers, 'mask')?.get
+  expect(() => new LayerPassIndex(other, [OVERLAY_LAYER])).toThrow('unshared Layers')
+  expect(Object.getOwnPropertyDescriptor(mesh.layers, 'mask')?.get).toBe(accessor)
+  expect(Object.getOwnPropertyDescriptor(other.layers, 'mask')?.get).toBeUndefined()
+  expect(Object.getOwnPropertyDescriptor(ordinary.layers, 'mask')?.get).toBeUndefined()
+  index.dispose()
+})
+
+test('observes every mask operation, Three attach and ancestor clear', () => {
+  const { scene, parent, mesh, index, roots } = fixture()
+  for (const operation of ['enable', 'toggle', 'set'] as const) {
+    mesh.layers.disableAll()
+    mesh.layers[operation](OVERLAY_LAYER)
+    expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+  }
+  mesh.layers.disable(OVERLAY_LAYER)
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+  mesh.layers.enableAll()
+  expect(index.prepare(ZONE_LAYER, roots).drawable).toBe(true)
+  scene.attach(mesh)
+  index.prepare(OVERLAY_LAYER, roots)
+  expect(roots).toEqual([mesh])
+  parent.attach(mesh)
+  scene.clear()
+  expect(index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+  expect(Object.getOwnPropertyDescriptor(mesh.layers, 'mask')?.get).toBeUndefined()
+  index.dispose()
+})
+
+function renderFixture() {
+  const f = fixture()
+  const camera = new PerspectiveCamera()
+  const main = new PassNode(PassNode.COLOR, f.scene, camera)
+  const mainLayers = new Layers()
+  mainLayers.set(SCENE_LAYER)
+  main.setLayers(mainLayers)
+  const overlay = new LayerPassNode(f.index, camera, OVERLAY_LAYER, main)
+  const overlayLayers = new Layers()
+  overlayLayers.set(OVERLAY_LAYER)
+  overlay.setLayers(overlayLayers)
+  const zone = new LayerPassNode(f.index, camera, ZONE_LAYER, main)
+  const zoneLayers = new Layers()
+  zoneLayers.set(ZONE_LAYER)
+  zone.setLayers(zoneLayers)
+  const frame = new NodeFrame()
+  const renders: { root: Scene; mask: number; positions: number[] }[] = []
+  let target: unknown = null
+  let mrt: unknown = null
+  const renderer = {
+    getOutputRenderTarget: () => null,
+    getDrawingBufferSize: (size: { set(x: number, y: number): void }) => size.set(100, 100),
+    getRenderTarget: () => target,
+    setRenderTarget: (value: unknown) => {
+      target = value
+    },
+    getMRT: () => mrt,
+    setMRT: (value: unknown) => {
+      mrt = value
+    },
+    clear: () => {},
+    render: (root: Scene, renderCamera: PerspectiveCamera) => {
+      if (root.matrixWorldAutoUpdate) root.updateMatrixWorld()
+      root.onBeforeRender(renderer as never, root, renderCamera, target as never)
+      const positions: number[] = []
+      root.traverseVisible((object) => {
+        if (!(object instanceof Mesh && object.layers.test(renderCamera.layers))) return
+        object.onBeforeRender(
+          renderer as never,
+          root,
+          renderCamera,
+          object.geometry,
+          object.material as MeshBasicMaterial,
+          null as never,
+        )
+        positions.push(object.matrixWorld.elements[12]!)
+        object.onAfterRender(
+          renderer as never,
+          root,
+          renderCamera,
+          object.geometry,
+          object.material as MeshBasicMaterial,
+          null as never,
+        )
+      })
+      renders.push({ root, mask: renderCamera.layers.mask, positions })
+      root.onAfterRender(renderer as never, root, renderCamera)
+    },
+  }
+  frame.renderer = renderer as unknown as NonNullable<NodeFrame['renderer']>
+  const tick = () => {
+    frame.frameId++
+    overlay.updateBefore(frame)
+    zone.updateBefore(frame)
+  }
+  const dispose = () => {
+    f.index.dispose()
+    overlay.dispose()
+    zone.dispose()
+    main.dispose()
+  }
+  return { ...f, camera, main, overlay, zone, frame, renders, renderer, tick, dispose }
+}
+
+test('custom scene callbacks can enable an empty layer with original identity, receiver and graph', () => {
+  const f = renderFixture()
+  f.mesh.name = 'overlay'
+  const before = f.scene.onBeforeRender
+  const after = f.scene.onAfterRender
+  const calls: string[] = []
+  f.scene.onBeforeRender = function (_renderer, scene, camera) {
+    expect(this).toBe(f.scene)
+    expect(scene).toBe(f.scene)
+    expect(this.getObjectByName('overlay')).toBe(f.mesh)
+    calls.push(`before:${camera.layers.mask}`)
+    if (camera.layers.mask === 1 << OVERLAY_LAYER) f.mesh.layers.enable(OVERLAY_LAYER)
+  }
+  f.scene.onAfterRender = function (_renderer, scene, camera) {
+    expect(this).toBe(f.scene)
+    expect(scene).toBe(f.scene)
+    calls.push(`after:${camera.layers.mask}`)
+  }
+  const callback = f.scene.onBeforeRender
+  f.tick()
+  expect(calls).toEqual(['before:1', 'after:1', 'before:2', 'after:2', 'before:4', 'after:4'])
+  expect(f.renders[1]?.positions).toEqual([0])
+  expect(f.renders.every(({ root }) => root === f.scene)).toBe(true)
+  expect(f.scene.onBeforeRender).toBe(callback)
+  expect(f.camera.layers.mask).toBe(1)
+  f.scene.onBeforeRender = before
+  f.scene.onAfterRender = after
+  f.tick()
+  expect(f.renders.at(-1)?.root).not.toBe(f.scene)
+  f.dispose()
+})
+
+test('a scene after-callback alone keeps empty passes and refreshes moved overlay transforms', () => {
+  const f = renderFixture()
+  f.mesh.layers.set(OVERLAY_LAYER)
+  f.scene.onAfterRender = (_renderer, _scene, camera) => {
+    if (camera.layers.mask === 1 << SCENE_LAYER) f.mesh.position.x = 7
+  }
+  f.tick()
+  expect(f.renders[1]?.positions).toEqual([7])
+  expect(f.renders[1]?.root).toBe(f.scene)
+  expect(f.renders[2]?.mask).toBe(1 << ZONE_LAYER)
+  f.dispose()
+})
+
+test('refreshes private roots, ancestors and descendants after main object callbacks', () => {
+  const f = renderFixture()
+  const mover = new Mesh()
+  f.scene.add(mover)
+  f.parent.layers.set(OVERLAY_LAYER)
+  f.mesh.layers.set(OVERLAY_LAYER)
+  mover.onAfterRender = () => {
+    f.scene.position.x = 2
+    f.parent.position.x = 3
+    f.mesh.position.x = 7
+  }
+  f.tick()
+  expect(f.renders[1]?.root).not.toBe(f.scene)
+  expect(f.renders[1]?.positions).toEqual([12])
+  expect(f.renders.filter(({ mask }) => mask === 1).length).toBe(1)
+  f.dispose()
+})
+
+test('matrix refresh honors manual local and world matrices after ancestors move', () => {
+  const f = renderFixture()
+  f.mesh.layers.set(OVERLAY_LAYER)
+  f.mesh.matrixAutoUpdate = false
+  f.mesh.matrix.makeTranslation(4, 0, 0)
+  f.mesh.position.x = 99
+  const mover = new Mesh()
+  f.scene.add(mover)
+  mover.onAfterRender = () => {
+    f.parent.position.x += 3
+  }
+  f.tick()
+  expect(f.renders[1]?.positions).toEqual([7])
+  f.mesh.matrixWorldAutoUpdate = false
+  f.mesh.matrixWorld.makeTranslation(22, 0, 0)
+  f.tick()
+  expect(f.renders.at(-1)?.positions).toEqual([22])
+  f.dispose()
+})
+
+test('renders the original scene for shadow lights and restores the proxy afterward', () => {
+  const f = renderFixture()
+  f.mesh.layers.set(OVERLAY_LAYER)
+  const light = new DirectionalLight()
+  light.layers.set(OVERLAY_LAYER)
+  light.castShadow = true
+  f.scene.add(light)
+  const proxy = f.overlay.scene
+  f.tick()
+  expect(f.renders[1]?.root).toBe(f.scene)
+  expect(f.overlay.scene).toBe(proxy)
+  light.castShadow = false
+  f.tick()
+  expect(f.renders.at(-1)?.root).toBe(proxy)
+  f.dispose()
+})
+
+test('backgrounds prevent empty skipping and private scene properties remain forwarded', () => {
+  const f = renderFixture()
+  f.scene.background = new Texture()
+  f.tick()
+  expect(f.renders.length).toBe(3)
+  expect(f.renders[1]?.root.background).toBe(f.scene.background)
+  f.dispose()
+})
+
+test('clear failure restores target/MRT and retries clearing on the next frame', () => {
+  const f = renderFixture()
+  const target = { name: 'previous target' }
+  const mrt = { name: 'previous MRT' }
+  f.renderer.setRenderTarget(target)
+  f.renderer.setMRT(mrt)
+  f.renderer.clear = () => {
+    throw new Error('clear failed')
+  }
+  expect(f.tick).toThrow('clear failed')
+  expect(f.renderer.getRenderTarget()).toBe(target)
+  expect(f.renderer.getMRT()).toBe(mrt)
+  let clears = 0
+  f.renderer.clear = () => {
+    clears++
+  }
+  f.tick()
+  expect(clears).toBe(2)
+  f.dispose()
+})
+
+test('render failure restores the private scene view', () => {
+  const f = renderFixture()
+  f.scene.onAfterRender = () => {}
+  const proxy = f.overlay.scene
+  f.main.updateBefore = () => undefined
+  f.renderer.render = () => {
+    throw new Error('render failed')
+  }
+  expect(f.tick).toThrow('render failed')
+  expect(f.overlay.scene).toBe(proxy)
+  f.dispose()
+})
+
+test('private rendering and matrix refresh do not visit unrelated subtrees', () => {
+  const f = renderFixture()
+  const unrelated = new Group()
+  f.scene.add(unrelated)
+  f.mesh.layers.set(OVERLAY_LAYER)
+  f.main.updateBefore = () => undefined
+  const children = unrelated.children
+  Object.defineProperty(unrelated, 'children', {
+    configurable: true,
+    get: () => {
+      throw new Error('unrelated traversal')
+    },
+  })
+  f.tick()
+  expect(f.renders[0]?.positions).toEqual([0])
+  Object.defineProperty(unrelated, 'children', { configurable: true, value: children })
+  f.dispose()
 })

--- a/packages/viewer/src/lib/layer-pass.ts
+++ b/packages/viewer/src/lib/layer-pass.ts
@@ -1,6 +1,18 @@
-import { type Camera, type Material, type Object3D, type Scene, Vector2 } from 'three'
-import PassNode from 'three/src/nodes/display/PassNode.js'
-import type { NodeFrame } from 'three/webgpu'
+// Only one index may observe a scene, and observed objects must own their Layers.
+// Insertions without childadded are not observed: call register(subtree) afterward.
+// Replaced Layers are repaired for known members during prepare(); other objects
+// need register(object), since discovering them would require a full-scene scan.
+import { type Camera, type Material, Object3D, type Scene, Vector2 } from 'three'
+import { type NodeFrame, PassNode } from 'three/webgpu'
+
+const maskObserver = Symbol('LayerPassIndex.maskObserver')
+
+function maskOwner(object: Object3D) {
+  const get = Object.getOwnPropertyDescriptor(object.layers, 'mask')?.get as
+    | ((() => number) & { [maskObserver]?: Object3D })
+    | undefined
+  return get?.[maskObserver]
+}
 
 type RenderObject = Object3D & {
   material?: Material | Material[]
@@ -20,12 +32,30 @@ export class LayerPassIndex {
     layers: number[],
   ) {
     for (const layer of layers) this.members.set(1 << layer, new Set())
-    this.attach(source)
+    try {
+      this.attach(source)
+    } catch (error) {
+      this.dispose()
+      throw error
+    }
+  }
+
+  register(subtree: Object3D) {
+    this.detach(subtree)
+    for (let object: Object3D | null = subtree; object; object = object.parent) {
+      if (object === this.source) {
+        this.attach(subtree)
+        return
+      }
+    }
   }
 
   private attach = (object: Object3D) => {
     if (this.cleanups.has(object)) return
     const layers = object.layers
+    if (maskOwner(object)) {
+      throw new Error('LayerPassIndex requires one index per scene and unshared Layers')
+    }
     let mask = layers.mask
     const sync = () => {
       for (const [bit, members] of this.members) {
@@ -33,10 +63,11 @@ export class LayerPassIndex {
         else members.delete(object)
       }
     }
+    const getMask = Object.assign(() => mask, { [maskObserver]: object })
     Object.defineProperty(layers, 'mask', {
       configurable: true,
       enumerable: true,
-      get: () => mask,
+      get: getMask,
       set: (value: number) => {
         if (mask === value) return
         mask = value
@@ -50,12 +81,14 @@ export class LayerPassIndex {
     this.cleanups.set(object, () => {
       object.removeEventListener('childadded', added)
       object.removeEventListener('childremoved', removed)
-      Object.defineProperty(layers, 'mask', {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: mask,
-      })
+      if (Object.getOwnPropertyDescriptor(layers, 'mask')?.get === getMask) {
+        Object.defineProperty(layers, 'mask', {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: mask,
+        })
+      }
       for (const members of this.members.values()) members.delete(object)
     })
     sync()
@@ -71,6 +104,15 @@ export class LayerPassIndex {
   prepare(layer: number, roots: Object3D[]) {
     roots.length = 0
     const members = this.members.get(1 << layer)!
+    // Repairs can change membership, so finish them before choosing nested roots.
+    for (const tracked of this.members.values()) {
+      for (const object of [...tracked]) {
+        let root = object
+        while (root.parent && root !== this.source) root = root.parent
+        if (root !== this.source) this.detach(root)
+        else if (maskOwner(object) !== object) this.register(object)
+      }
+    }
     let drawable = false
     let shadowLight = false
     for (const object of members) {
@@ -139,6 +181,11 @@ export class LayerPassNode extends PassNode {
     })
   }
 
+  override dispose() {
+    this.roots.length = 0
+    super.dispose()
+  }
+
   override updateBefore(frame: NodeFrame): undefined {
     // NodeFrame deduplicates FRAME updates. Make the dependency explicit rather
     // than relying on which composite expression the TSL builder visits first.
@@ -148,13 +195,23 @@ export class LayerPassNode extends PassNode {
     const source = this.index.source
     const hasBackground =
       source.background !== null || ('backgroundNode' in source && source.backgroundNode != null)
-    if (drawable || hasBackground) {
+    const hasSceneCallbacks =
+      source.onBeforeRender !== Object3D.prototype.onBeforeRender ||
+      source.onAfterRender !== Object3D.prototype.onAfterRender
+    if (drawable || hasBackground || hasSceneCallbacks) {
       this.needsClear = true
-      // A shadow-casting light on this layer needs all source shadow casters.
-      // The viewer's lights currently use only SCENE_LAYER.
+      // Shadows need all source casters; custom callbacks need the original
+      // scene receiver and graph, including when they enable an empty layer.
       const root = this.scene
-      if (shadowLight) this.scene = this.index.source
+      if (shadowLight || hasSceneCallbacks) this.scene = source
       try {
+        if (this.scene !== source) {
+          for (const root of this.roots) {
+            // r185 needs this even for a manual local matrix when an ancestor moved.
+            root.matrixWorldNeedsUpdate = true
+            root.updateWorldMatrix(true, true)
+          }
+        }
         super.updateBefore(frame)
       } finally {
         this.scene = root

--- a/packages/viewer/src/lib/layer-pass.ts
+++ b/packages/viewer/src/lib/layer-pass.ts
@@ -206,10 +206,18 @@ export class LayerPassNode extends PassNode {
       if (shadowLight || hasSceneCallbacks) this.scene = source
       try {
         if (this.scene !== source) {
+          const updatedAncestors = new Set<Object3D>()
+          const updateAncestor = (object: Object3D | null) => {
+            if (!object || updatedAncestors.has(object)) return
+            updateAncestor(object.parent)
+            // Force world refreshes even when a manual local matrix is clean.
+            object.matrixWorldNeedsUpdate = true
+            object.updateWorldMatrix(false, false)
+            updatedAncestors.add(object)
+          }
           for (const root of this.roots) {
-            // r185 needs this even for a manual local matrix when an ancestor moved.
-            root.matrixWorldNeedsUpdate = true
-            root.updateWorldMatrix(true, true)
+            updateAncestor(root.parent)
+            root.updateMatrixWorld(true)
           }
         }
         super.updateBefore(frame)

--- a/packages/viewer/src/lib/layer-pass.ts
+++ b/packages/viewer/src/lib/layer-pass.ts
@@ -1,0 +1,188 @@
+import { type Camera, type Material, type Object3D, type Scene, Vector2 } from 'three'
+import PassNode from 'three/src/nodes/display/PassNode.js'
+import type { NodeFrame } from 'three/webgpu'
+
+type RenderObject = Object3D & {
+  material?: Material | Material[]
+  isLight?: boolean
+  castShadow: boolean
+}
+
+// Observe mask writes as well as child events: R3F's numeric `layers` prop calls
+// Layers.set(), while imperative producers also use enable() and direct masks.
+// Nothing on Object3D/Layers.prototype is patched, and detach restores the field.
+export class LayerPassIndex {
+  private readonly members = new Map<number, Set<Object3D>>()
+  private readonly cleanups = new Map<Object3D, () => void>()
+
+  constructor(
+    readonly source: Scene,
+    layers: number[],
+  ) {
+    for (const layer of layers) this.members.set(1 << layer, new Set())
+    this.attach(source)
+  }
+
+  private attach = (object: Object3D) => {
+    if (this.cleanups.has(object)) return
+    const layers = object.layers
+    let mask = layers.mask
+    const sync = () => {
+      for (const [bit, members] of this.members) {
+        if ((mask & bit) !== 0 && object !== this.source) members.add(object)
+        else members.delete(object)
+      }
+    }
+    Object.defineProperty(layers, 'mask', {
+      configurable: true,
+      enumerable: true,
+      get: () => mask,
+      set: (value: number) => {
+        if (mask === value) return
+        mask = value
+        sync()
+      },
+    })
+    const added = ({ child }: { child: Object3D }) => this.attach(child)
+    const removed = ({ child }: { child: Object3D }) => this.detach(child)
+    object.addEventListener('childadded', added)
+    object.addEventListener('childremoved', removed)
+    this.cleanups.set(object, () => {
+      object.removeEventListener('childadded', added)
+      object.removeEventListener('childremoved', removed)
+      Object.defineProperty(layers, 'mask', {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: mask,
+      })
+      for (const members of this.members.values()) members.delete(object)
+    })
+    sync()
+    for (const child of object.children) this.attach(child)
+  }
+
+  private detach(object: Object3D) {
+    for (const child of object.children) this.detach(child)
+    this.cleanups.get(object)?.()
+    this.cleanups.delete(object)
+  }
+
+  prepare(layer: number, roots: Object3D[]) {
+    roots.length = 0
+    const members = this.members.get(1 << layer)!
+    let drawable = false
+    let shadowLight = false
+    for (const object of members) {
+      let visible = object.visible
+      let nested = false
+      for (let parent = object.parent; parent; parent = parent.parent) {
+        if (!parent.visible) visible = false
+        if (members.has(parent)) nested = true
+      }
+      if (!visible) continue
+      const { material, isLight, castShadow } = object as RenderObject
+      if (material) {
+        drawable ||= Array.isArray(material) ? material.some((m) => m.visible) : material.visible
+      }
+      shadowLight ||= isLight === true && castShadow
+      if (!nested) roots.push(object)
+    }
+    // Keep source traversal order even when a producer switches layers after
+    // mounting. Ancestors on this layer remain intact, retaining group order,
+    // clipping and LOD behavior; layers do not inherit through other ancestors.
+    roots.sort(compareSceneOrder)
+    return { drawable, shadowLight }
+  }
+
+  dispose() {
+    for (const cleanup of this.cleanups.values()) cleanup()
+    this.cleanups.clear()
+  }
+}
+
+function compareSceneOrder(a: Object3D, b: Object3D): number {
+  const pathA: Object3D[] = []
+  const pathB: Object3D[] = []
+  for (let object: Object3D | null = a; object; object = object.parent) pathA.push(object)
+  for (let object: Object3D | null = b; object; object = object.parent) pathB.push(object)
+  let i = pathA.length - 1
+  let j = pathB.length - 1
+  while (i >= 0 && j >= 0 && pathA[i] === pathB[j]) {
+    i--
+    j--
+  }
+  const siblings = pathA[i + 1]!.children
+  return siblings.indexOf(pathA[i]!) - siblings.indexOf(pathB[j]!)
+}
+
+export class LayerPassNode extends PassNode {
+  private readonly roots: Object3D[] = []
+  private readonly size = new Vector2()
+  private needsClear = true
+
+  constructor(
+    private readonly index: LayerPassIndex,
+    camera: Camera,
+    private readonly layer: number,
+    private readonly mainPass: PassNode,
+  ) {
+    super(PassNode.COLOR, index.source, camera)
+    // A scene view, not cloned meshes: callbacks, environment, fog, materials,
+    // skeletons and world matrices retain their original owners and values.
+    this.scene = new Proxy(index.source, {
+      get: (source, key) => {
+        if (key === 'children') return this.roots
+        if (key === 'matrixWorldAutoUpdate') return false
+        return Reflect.get(source, key, source)
+      },
+    })
+  }
+
+  override updateBefore(frame: NodeFrame): undefined {
+    // NodeFrame deduplicates FRAME updates. Make the dependency explicit rather
+    // than relying on which composite expression the TSL builder visits first.
+    frame.updateBeforeNode(this.mainPass)
+    const { drawable, shadowLight } = this.index.prepare(this.layer, this.roots)
+    const renderer = frame.renderer!
+    const source = this.index.source
+    const hasBackground =
+      source.background !== null || ('backgroundNode' in source && source.backgroundNode != null)
+    if (drawable || hasBackground) {
+      this.needsClear = true
+      // A shadow-casting light on this layer needs all source shadow casters.
+      // The viewer's lights currently use only SCENE_LAYER.
+      const root = this.scene
+      if (shadowLight) this.scene = this.index.source
+      try {
+        super.updateBefore(frame)
+      } finally {
+        this.scene = root
+      }
+      return
+    }
+
+    const outputTarget = renderer.getOutputRenderTarget()
+    if (outputTarget && 'isXRRenderTarget' in outputTarget && outputTarget.isXRRenderTarget)
+      this.size.set(outputTarget.width, outputTarget.height)
+    else renderer.getDrawingBufferSize(this.size)
+    const width = this.renderTarget.width
+    const height = this.renderTarget.height
+    this.setSize(this.size.x, this.size.y)
+    if (width !== this.renderTarget.width || height !== this.renderTarget.height)
+      this.needsClear = true
+    if (!this.needsClear) return
+
+    const target = renderer.getRenderTarget()
+    const mrt = renderer.getMRT()
+    try {
+      renderer.setRenderTarget(this.renderTarget)
+      renderer.setMRT(null)
+      renderer.clear(true, true, true)
+      this.needsClear = false
+    } finally {
+      renderer.setRenderTarget(target)
+      renderer.setMRT(mrt)
+    }
+  }
+}

--- a/packages/viewer/src/lib/post-processing-resources.test.ts
+++ b/packages/viewer/src/lib/post-processing-resources.test.ts
@@ -1,0 +1,102 @@
+import { expect, mock, test } from 'bun:test'
+import { Layers, Mesh, PerspectiveCamera, Scene } from 'three'
+import { NodeFrame, PassNode, RenderPipeline } from 'three/webgpu'
+import { LayerPassIndex, LayerPassNode } from './layer-pass'
+import { OVERLAY_LAYER, ZONE_LAYER } from './layers'
+import { PostProcessingResources } from './post-processing-resources'
+
+function fixture() {
+  const scene = new Scene()
+  const mesh = new Mesh()
+  mesh.layers.set(OVERLAY_LAYER)
+  scene.add(mesh)
+  const resources = new PostProcessingResources()
+  const index = new LayerPassIndex(scene, [OVERLAY_LAYER, ZONE_LAYER])
+  resources.layerIndex = index
+  const main = new PassNode(PassNode.COLOR, scene, new PerspectiveCamera())
+  resources.passes.push(main)
+  const passes = [OVERLAY_LAYER, ZONE_LAYER].map((layer) => {
+    const pass = new LayerPassNode(index, main.camera, layer, main)
+    const layers = new Layers()
+    layers.set(layer)
+    pass.setLayers(layers)
+    resources.passes.push(pass)
+    return pass
+  })
+  const targetDisposals = resources.passes.map((pass) => {
+    const dispose = mock(() => {})
+    pass.renderTarget.addEventListener('dispose', dispose)
+    return dispose
+  })
+  return { scene, mesh, resources, index, main, passes, targetDisposals }
+}
+
+test('runtime disposal releases targets, observers and retained roots; later teardown is idempotent', () => {
+  const f = fixture()
+  const pipeline = new RenderPipeline({} as never)
+  f.resources.pipeline = pipeline
+  const pipelineDispose = mock(pipeline.dispose.bind(pipeline))
+  pipeline.dispose = pipelineDispose
+  const outlineDispose = mock(() => {})
+  f.resources.outline = { dispose: outlineDispose }
+  const frame = new NodeFrame()
+  f.main.updateBefore = () => undefined
+  frame.renderer = {
+    getOutputRenderTarget: () => null,
+    getDrawingBufferSize: (size: { set(x: number, y: number): void }) => size.set(1, 1),
+    getRenderTarget: () => null,
+    getMRT: () => null,
+    setRenderTarget: () => {},
+    setMRT: () => {},
+    render: () => {},
+  } as never
+  f.passes[0]!.updateBefore(frame)
+  const privateRoots = f.passes[0]!.scene.children
+  expect(privateRoots).toEqual([f.mesh])
+  f.scene.remove(f.mesh)
+  expect(privateRoots).toEqual([f.mesh])
+  const cleanup = () => f.resources.dispose()
+  pipeline.render = () => {
+    throw new Error('runtime failure after retries')
+  }
+  try {
+    pipeline.render()
+  } catch {
+    cleanup()
+  }
+  expect(privateRoots).toEqual([])
+  expect(f.resources.pipeline).toBeNull()
+  expect(f.resources.layerIndex).toBeNull()
+  expect(f.resources.passes).toEqual([])
+  expect(f.resources.outline).toBeNull()
+  expect(Object.getOwnPropertyDescriptor(f.scene.layers, 'mask')?.get).toBeUndefined()
+  f.scene.add(f.mesh)
+  expect(Object.getOwnPropertyDescriptor(f.mesh.layers, 'mask')?.get).toBeUndefined()
+  cleanup()
+  for (const dispose of f.targetDisposals) expect(dispose).toHaveBeenCalledTimes(1)
+  expect(pipelineDispose).toHaveBeenCalledTimes(1)
+  expect(outlineDispose).toHaveBeenCalledTimes(1)
+})
+
+test('construction failure can dispose partial resources before a pipeline exists', () => {
+  const f = fixture()
+  f.resources.dispose()
+  f.resources.dispose()
+  for (const dispose of f.targetDisposals) expect(dispose).toHaveBeenCalledTimes(1)
+  expect(Object.getOwnPropertyDescriptor(f.mesh.layers, 'mask')?.get).toBeUndefined()
+  const roots: Mesh[] = []
+  f.scene.add(new Mesh())
+  expect(f.index.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+})
+
+test('teardown permits a fresh index on the same scene without old cleanup affecting it', () => {
+  const f = fixture()
+  f.resources.dispose()
+  const next = new LayerPassIndex(f.scene, [OVERLAY_LAYER])
+  f.resources.dispose()
+  const roots: Mesh[] = []
+  expect(next.prepare(OVERLAY_LAYER, roots).drawable).toBe(true)
+  f.mesh.layers.disableAll()
+  expect(next.prepare(OVERLAY_LAYER, roots).drawable).toBe(false)
+  next.dispose()
+})

--- a/packages/viewer/src/lib/post-processing-resources.ts
+++ b/packages/viewer/src/lib/post-processing-resources.ts
@@ -1,0 +1,22 @@
+import type { PassNode, RenderPipeline } from 'three/webgpu'
+import type { LayerPassIndex } from './layer-pass'
+
+// RenderPipeline.dispose() only releases its fullscreen material, so the owner
+// must also release the passes and scene observers on failure and teardown.
+export class PostProcessingResources {
+  layerIndex: LayerPassIndex | null = null
+  readonly passes: PassNode[] = []
+  outline: { dispose(): void } | null = null
+  pipeline: RenderPipeline | null = null
+
+  dispose() {
+    this.layerIndex?.dispose()
+    this.layerIndex = null
+    for (const pass of this.passes) pass.dispose()
+    this.passes.length = 0
+    this.outline?.dispose()
+    this.outline = null
+    this.pipeline?.dispose()
+    this.pipeline = null
+  }
+}


### PR DESCRIPTION
Re-opened against main: #773 was merged while its base was still `perf/hover-outline`, so its two commits landed on that side branch after #772 had already been squashed into main. Same two commits, cherry-picked onto main.

## Why

`post-processing.tsx` builds three `pass(scene, camera)` nodes over the same scene. Per-pass attribution on the rich-4× perf fixture (select mode, pointer parked, 11.8 ms frame): shadow map 4.8 ms / 1 059 objects, main pass 4.3 ms / 1 727, **zone pass 1.7 ms / 0 objects, overlay pass 1.3 ms / 10 objects**. Two full walks of a ~7 000-object graph to draw ten objects — 25 % of the idle frame. Charter row 12.

## What

- `packages/viewer/src/lib/layer-pass.ts`: a `LayerPassIndex` keeps membership of layer-1/2 objects (an accessor on each object's `layers.mask` plus `childadded`/`childremoved` listeners; one scan per pipeline build, no per-frame traversal) and a `LayerPassNode` (extends `three/webgpu` `PassNode`) renders each pass from a proxy view of the scene that exposes only the indexed roots, refreshing their world matrices after the main pass. An empty layer clears its target once and skips the render call.
- Fallbacks to the full-scene path: custom `scene.onBeforeRender/onAfterRender`, shadow-casting lights on the layer. Graph insertions that bypass three's events are not observed — `LayerPassIndex.register(subtree)` is exported for such producers (none exist today); disconnected members are dropped on the next prepare. One index per scene; shared/replaced `Layers` instances are guarded.
- Cleanup is shared (idempotent) across effect teardown, construction failure and the runtime pipeline-failure path.

## Results (rich-4×, select mode parked)

| pass | before | after |
|---|---|---|
| zone | 1.7 ms / 0 objects | no render call |
| overlay | 1.3 ms / 10 objects | 0.10 ms / 10 objects |
| panel frame (same session) | 14.7 ms | 9.6 ms |

Pixel parity vs the outline build ≤ 0.014 % on every pose with identical stroke counts (gizmo handles present in the selected pose). No fixture carries zone nodes, so the zone pass was exercised with a synthetic layer-2 object (3 → 3 material groups, identical pixels).

## Notes for review

- `packages/viewer/src/components/viewer/post-processing.tsx` keeps the same targets, texture nodes and alpha compositing; only the pass construction changed.
- Gates: viewer suite, tsc, repo-wide biome; e2e pack + placement/paint/undo specs on the integrated build.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebGPU post-processing and monkey-patches `layers.mask` on observed objects; incorrect membership or proxy rendering could cause missing overlays/zones or visual regressions, though coverage is extensive.
> 
> **Overview**
> **Zone and overlay WebGPU passes no longer traverse the full scene** — they use a new `LayerPassIndex` / `LayerPassNode` path so only objects on `ZONE_LAYER` and `OVERLAY_LAYER` are drawn (empty layers clear and skip render).
> 
> `LayerPassIndex` tracks membership via per-object `layers.mask` observers and scene graph events (with `register()` for insertions that bypass Three events). `LayerPassNode` renders through a proxy scene that exposes indexed roots, runs after the main pass, and falls back to the full scene when shadow casters or custom `onBeforeRender` / `onAfterRender` require it.
> 
> `post-processing.tsx` still composes the same TSL graph; pass construction now goes through **`PostProcessingResources`**, which disposes the layer index, all passes, outline, and pipeline together on teardown, build failure, or runtime errors. **`LayerPassIndex`** is exported from the viewer package for hosts that need manual registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c25d24fa1da70f1c09923e3b32118f607a6cb4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->