### PR TITLE
ci: enable trusted publishing for MCP and CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
     environment: npm
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,6 +83,14 @@ jobs:
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
+
+      - name: Enable npm trusted publishing
+        run: |
+          npm install --global npm@11.19.1
+          node --version
+          npm --version
+          test -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -312,8 +321,6 @@ jobs:
       - name: Build & publish mcp
         if: inputs.package == 'mcp' || inputs.package == 'all'
         working-directory: packages/mcp
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           bun run build
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -347,8 +354,6 @@ jobs:
 
       - name: Publish CLI
         if: inputs.package == 'cli' || inputs.package == 'all'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd packages/cli
           if [ "${{ inputs.dry-run }}" = "true" ]; then


### PR DESCRIPTION
## What does this PR do?

The MCP beta release failed with npm `EOTP` after its build and tests passed. The workflow used npm 10.9.8 and had no OIDC permission, so it could not use npm trusted publishing.

Grant the release job `id-token: write`, pin npm 11.19.1, and verify that GitHub exposes its OIDC request variables. MCP and CLI publishing now use trusted publishing without the existing long-lived token fallback. Other packages retain their credential configuration until separately migrated.

npm package owners must configure the matching GitHub publisher on each of `@pascal-app/mcp` and `@pascal-app/cli`: organization `pascalorg`, repository `editor`, workflow `release.yml`, environment `npm`, with `npm publish` allowed. This workflow change does not establish that npm has accepted that mapping or published a version. Two-factor authentication remains enabled.

## How to test

- YAML parsing and structural checks pass: OIDC permission is limited to the release job, MCP/CLI have no token mapping, and seven other publishing steps retain theirs.
- The unchanged runtime source passed full CI in #777, including types, build, tests, and the packed CLI smoke test.
- After merge, dispatch the MCP beta release and verify successful OIDC publication and the registry dist-tag. A dry run alone does not prove npm authorization.
- CI quality and packed CLI smoke checks passed on `4462595d`.
- Bugbot's setup-node token-placeholder concern was checked against npm 11.19.1 (`3acf9a7`). `publish` calls OIDC before reading credentials, and a successful exchange replaces the placeholder. A local mock with setup-node's exact config shape verified that subsequent registry requests used the exchanged token. No additional workflow change is needed for that finding.

## Screenshots / screen recording

Workflow-only change.

## Checklist

- [x] The workflow configuration has been checked locally.
- [x] Existing runtime validation is recorded in #777.
- [x] This PR targets the `main` branch.
