### PR TITLE
docs: add verified candidate CLI preview

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "pascal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Public Pascal workflows for MCP-capable agents.",
   "owner": {
     "name": "Pascal"
@@ -11,7 +11,7 @@
       "name": "pascal-agent-skills",
       "source": "./",
       "description": "Create and inspect editable Pascal scenes and run bounded furniture footprint assessments.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "productivity",
       "skills": ["./skills/pascal-3d", "./skills/furniture-fit"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "pascal-agent-skills",
   "displayName": "Pascal agent skills",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Create, inspect, validate, and assess furniture layouts in Pascal through MCP.",
   "author": {
     "name": "Pascal"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pascal-agent-skills",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Create, inspect, validate, and assess furniture layouts in Pascal through MCP.",
   "author": {
     "name": "Pascal",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,38 @@ The CLI starts the editor and an authenticated MCP service in the background, se
 collision-free loopback ports, and keeps projects in `~/.pascal/data/pascal.db`. Configure
 an agent to launch `pascal mcp connect`. See [Run Pascal locally](https://editor.pascal.app/docs/developers/local-editor)
 for pnpm/Bun commands, project management, MCP setup, updates, storage paths, and
-troubleshooting.
+troubleshooting. The npm release is the older runtime described below; use the verified
+GitHub preview when a task needs the new read-only furniture candidate check.
+
+## Candidate-enabled CLI preview
+
+The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, which predates the read-only furniture candidate input in this repository. To use that capability before the next npm release, install the verified GitHub prerelease built from commit `aa653f2f523f81f361ac20cb42b745faf7e46844`:
+
+```bash
+PASCAL_PREVIEW_VERSION='1.0.0-beta.1.agent-skills.0'
+PASCAL_PREVIEW_PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/pascal-preview"
+PASCAL_PREVIEW_DOWNLOAD="$(mktemp -d)"
+cd "$PASCAL_PREVIEW_DOWNLOAD"
+
+curl --fail --location --remote-name \
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+curl --fail --location --remote-name \
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/SHA256SUMS.txt"
+
+# macOS
+shasum -a 256 -c SHA256SUMS.txt
+# Linux: use `sha256sum -c SHA256SUMS.txt` instead.
+
+npm install --global --prefix "$PASCAL_PREVIEW_PREFIX" --ignore-scripts \
+  "./pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
+pascal --version
+pascal editor --no-open
+```
+
+The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. Keep the preview prefix on the agent host's `PATH` before running `pascal mcp setup claude`, `pascal mcp setup codex`, or configuring `pascal mcp connect` manually. This GitHub prerelease is not an npm version.
+
+Use one active agent client per local CLI service. The standalone local HTTP runtime shares active scene state between clients; use separate `PASCAL_HOME` directories and service processes when independent concurrent work is required.
 
 ## Agent skills
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ npm install --global --prefix "$PASCAL_PREVIEW_PREFIX" --ignore-scripts \
   "./pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
 export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
 pascal --version
+pascal update --version "$PASCAL_PREVIEW_VERSION"
 pascal editor --no-open
 ```
 
-The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. Keep the preview prefix on the agent host's `PATH` before running `pascal mcp setup claude`, `pascal mcp setup codex`, or configuring `pascal mcp connect` manually. This GitHub prerelease is not an npm version.
+The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. Keep an existing `PASCAL_HOME` unchanged so stored projects remain in the same data directory; `pascal editor` alone reuses any healthy service, including an older one. Keep the preview prefix on the agent host's `PATH` before running `pascal mcp setup claude`, `pascal mcp setup codex`, or configuring `pascal mcp connect` manually. This GitHub prerelease is not an npm version.
 
 Use one active agent client per local CLI service. The standalone local HTTP runtime shares active scene state between clients; use separate `PASCAL_HOME` directories and service processes when independent concurrent work is required.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,9 +37,39 @@ the runtime, so updating the CLI does not replace your work.
 - npm, including when the CLI itself is launched with pnpm or Bun
 - A browser, unless you pass `--no-open`
 
-The initial supported release is macOS. The packed runtime also passes automated
-release smoke tests on Ubuntu; broader Linux and Windows support is still being
-verified.
+The initial supported release is macOS. The GitHub preview below also passed an
+installed managed-service smoke in a Linux arm64 container. This is not an x86_64 or
+Windows result.
+
+## Candidate-enabled CLI preview
+
+The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, which predates the read-only furniture candidate input in this repository. To use that capability before the next npm release, install the verified GitHub prerelease built from commit `aa653f2f523f81f361ac20cb42b745faf7e46844`:
+
+```bash
+PASCAL_PREVIEW_VERSION='1.0.0-beta.1.agent-skills.0'
+PASCAL_PREVIEW_PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/pascal-preview"
+PASCAL_PREVIEW_DOWNLOAD="$(mktemp -d)"
+cd "$PASCAL_PREVIEW_DOWNLOAD"
+
+curl --fail --location --remote-name \
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+curl --fail --location --remote-name \
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/SHA256SUMS.txt"
+
+# macOS
+shasum -a 256 -c SHA256SUMS.txt
+# Linux: use `sha256sum -c SHA256SUMS.txt` instead.
+
+npm install --global --prefix "$PASCAL_PREVIEW_PREFIX" --ignore-scripts \
+  "./pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
+pascal --version
+pascal editor --no-open
+```
+
+The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. Keep the preview prefix on the agent host's `PATH` before running `pascal mcp setup claude`, `pascal mcp setup codex`, or configuring `pascal mcp connect` manually. This GitHub prerelease is not an npm version.
+
+Use one active agent client per local CLI service. The standalone local HTTP runtime shares active scene state between clients; use separate `PASCAL_HOME` directories and service processes when independent concurrent work is required.
 
 ## Install and run
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,10 +64,11 @@ npm install --global --prefix "$PASCAL_PREVIEW_PREFIX" --ignore-scripts \
   "./pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
 export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
 pascal --version
+pascal update --version "$PASCAL_PREVIEW_VERSION"
 pascal editor --no-open
 ```
 
-The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. Keep the preview prefix on the agent host's `PATH` before running `pascal mcp setup claude`, `pascal mcp setup codex`, or configuring `pascal mcp connect` manually. This GitHub prerelease is not an npm version.
+The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. Keep an existing `PASCAL_HOME` unchanged so stored projects remain in the same data directory; `pascal editor` alone reuses any healthy service, including an older one. Keep the preview prefix on the agent host's `PATH` before running `pascal mcp setup claude`, `pascal mcp setup codex`, or configuring `pascal mcp connect` manually. This GitHub prerelease is not an npm version.
 
 Use one active agent client per local CLI service. The standalone local HTTP runtime shares active scene state between clients; use separate `PASCAL_HOME` directories and service processes when independent concurrent work is required.
 
@@ -121,7 +122,7 @@ npx @pascal-app/cli editor --foreground --no-open
 | `pascal resume [project]` | Open the latest project, or a selected project. |
 | `pascal projects [--json]` | List local projects. |
 | `pascal logs [--follow]` | Read or follow the managed editor log. |
-| `pascal update [--version <version>]` | Health-check and activate a published runtime. |
+| `pascal update [--version <version>]` | Health-check and activate the current CLI's bundled runtime or an npm-published target. |
 | `pascal doctor [--json]` | Diagnose Node.js, storage, runtime, process, and plugin state. |
 | `pascal info [--json]` | Print platform, paths, runtime, and plugin context. |
 | `pascal project list [--json]` | Explicit form of `pascal projects`. |

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -4,7 +4,8 @@ import { fileURLToPath } from 'node:url'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const skillNames = ['pascal-3d', 'furniture-fit'] as const
-const version = '0.1.0'
+const skillVersion = '0.1.0'
+const pluginVersion = '0.1.1'
 const failures: string[] = []
 
 function fail(message: string) {
@@ -75,8 +76,8 @@ for (const skillName of skillNames) {
   const fields = frontmatter(content, skillFile)
   if (fields.name !== skillName) fail(`${skillName}: frontmatter name does not match directory`)
   if (!fields.description) fail(`${skillName}: description is required`)
-  if (!content.includes(`version: "${version}"`))
-    fail(`${skillName}: metadata version must be ${version}`)
+  if (!content.includes(`version: "${skillVersion}"`))
+    fail(`${skillName}: metadata version must be ${skillVersion}`)
   if (!/^ {2}source-reviewed: "\d{4}-\d{2}-\d{2}"$/m.test(content)) {
     fail(`${skillName}: an ISO source review date is required`)
   }
@@ -197,7 +198,7 @@ for (const [label, manifest] of [
   ['Codex plugin', codexPlugin],
 ] as const) {
   if (manifest.name !== 'pascal-agent-skills') fail(`${label}: unexpected name`)
-  if (manifest.version !== version) fail(`${label}: version must be ${version}`)
+  if (manifest.version !== pluginVersion) fail(`${label}: version must be ${pluginVersion}`)
 }
 
 if (codexPlugin.skills !== './skills/') fail('Codex plugin must point to canonical ./skills/')
@@ -219,12 +220,18 @@ if (!Array.isArray(codexEntries) || codexEntries.length !== 1) {
   if (entry.category !== 'Productivity') fail('Codex marketplace category must be declared')
 }
 if (claudeMarketplace.name !== 'pascal') fail('Claude marketplace name must be pascal')
+if (claudeMarketplace.version !== pluginVersion) {
+  fail(`Claude marketplace version must be ${pluginVersion}`)
+}
 const marketplacePlugins = claudeMarketplace.plugins
 if (!Array.isArray(marketplacePlugins) || marketplacePlugins.length !== 1) {
   fail('Claude marketplace must contain exactly one plugin')
 } else {
   const plugin = marketplacePlugins[0] as Record<string, unknown>
   if (plugin.source !== './') fail('Claude marketplace plugin must use the repository root')
+  if (plugin.version !== pluginVersion) {
+    fail(`Claude marketplace plugin version must be ${pluginVersion}`)
+  }
   const packagedSkills = plugin.skills
   for (const skillName of skillNames) {
     if (!Array.isArray(packagedSkills) || !packagedSkills.includes(`./skills/${skillName}`)) {
@@ -250,5 +257,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  `Validated ${skillNames.length} skills and both plugin manifests at version ${version}.`,
+  `Validated ${skillNames.length} skills at ${skillVersion} and both plugin manifests at ${pluginVersion}.`,
 )

--- a/skills/README.md
+++ b/skills/README.md
@@ -44,6 +44,8 @@ codex plugin add pascal-agent-skills@pascal
 
 The plugin installs the instructions from the canonical `skills/` directory. Connect Pascal MCP separately by following the setup reference included in either skill. Installation alone never creates an account, uploads a project, or authorizes paid work.
 
+The npm `beta` CLI remains on the older runtime contract. For the read-only `check_collisions.candidate` capability used by the current furniture workflow, follow the checksum-verified [GitHub preview instructions](pascal-3d/references/setup.md#candidate-enabled-github-preview). The preview archive is published on GitHub, not npm.
+
 Use one active agent client per local CLI service. Its standalone HTTP runtime shares active scene state; the hosted endpoint uses a separate session-isolated bridge.
 
 ## Included skills

--- a/skills/VALIDATION.md
+++ b/skills/VALIDATION.md
@@ -13,21 +13,25 @@ The `native-host-validation: source-hash-recorded-separately` metadata is a poin
 | MCP source and journey-harness manifest | `aff910b9e1db08f0eef35bea8d33d04469d822b8b0c42d79bc2dd660b6eebdba` |
 | Compiled MCP runtime used by native tasks | `cd91d1c638e7928936a45ca2f0ef066a7c763b2d74eded960d38b17ed6d6ec03` |
 | MCP executable entry | `dd1cc14ace754bd0a6edabb4e22bf2c7989928f3c4a4f883607922fc2bc79aef` |
+| Public skill release commit | `aa653f2f523f81f361ac20cb42b745faf7e46844` |
+| Candidate-enabled GitHub CLI archive | `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d` |
 
-Manifest hashes are not Git commits or persisted scene identities. Native furniture fixtures used local SQLite storage and direct stdio MCP. The CLI's `mcp connect` command forwards to its managed HTTP service, a distinct transport path tested separately below. These observations were collected before beta publication; they do not establish the behavior of every published or deployed version.
+Manifest hashes are not Git commits or persisted scene identities. Native furniture fixtures used local SQLite storage and direct stdio MCP. The CLI's `mcp connect` command forwards to its managed HTTP service, a distinct transport path tested separately below. The npm `beta` tags still resolve to CLI `1.0.0-beta.1` and MCP `1.0.0-beta.6`; those older registry releases do not establish the candidate-enabled behavior documented here.
 
 ## Completed checks
 
 | Check | Result and scope |
 | --- | --- |
 | Package structure | Repository validator and Claude Code 2.1.258 strict marketplace validation pass. |
-| Public branch installation | skills CLI 1.5.24 installed both skills from public commit `ef1d03188ab98e8eba550a9ed4618c8c794eb0b3` for Claude and Codex. Every installed skill file and reference matched the source. |
+| Public branch installation | skills CLI 1.5.24, Claude Code 2.1.258, and Codex CLI 0.153.4 installed both skills from public `main` at `aa653f2f523f81f361ac20cb42b745faf7e46844`. Every installed skill file and reference matched the source. |
 | Claude installation | Claude Code 2.1.258 strictly validated, installed, and discovered both skills from a fresh public Git clone at the same commit, using isolated configuration. |
 | Codex installation | Codex CLI 0.153.4 installed and listed the native marketplace package from that public commit in a fresh Linux container. No login or credential prompt was required for this skills-only package. |
 | MCP runtime | 356 unit tests and 20 real stdio transport cases pass, including candidate nonmutation and reconnect persistence. |
-| Claude native tasks | Claude Code 2.1.258 with Bedrock Claude Fable 5.1 completed three paired synthetic tasks on the recorded skill. Treatment: 3/3 tasks and 22/22 automated assertions. All six runs used real MCP calls and preserved scene hash, version, and node count. |
+| Claude native tasks | Claude Code 2.1.258 with Bedrock Claude Fable 5.1 completed three paired synthetic tasks on the recorded skill. Treatment: 3/3 tasks and 22/22 automated assertions; independent semantic review scored the baseline 20/22. All six runs used real MCP calls and preserved scene hash, version, and node count. This is not a causal quality-uplift result. |
 | Codex native release gate | Codex CLI 0.153.4 with `gpt-5.6-sol` at medium reasoning passed 20/20 frozen synthetic cases. Independent Claude Fable 5.1 adjudication also passed 20/20. Graph hashes, versions, and exported graph digests were unchanged; no authority defect or critical false-success was found. |
 | Packed CLI native task | A clean packed CLI installation completed one native Codex candidate assessment through its managed HTTP connector. Exact dimensions and requested clearance were preserved. SQLite graph bytes and the complete REST response were unchanged. |
+| GitHub CLI prerelease | The archive at tag `cli-v1.0.0-beta.1-agent-skills.0`, built from `aa653f2f`, was downloaded anonymously and matched SHA-256 `814ffa8c…a33d`. A fresh install passed managed editor/MCP/doctor checks. The identical bytes had already passed one native Claude furniture task and a Linux arm64 managed-service smoke. |
+| Linux hosted-HTTP diagnostic | A separate `node:22-bookworm-slim` SDK client passed against a local hosted-development server. This is transport evidence, not a native Linux agent-host or production result. |
 | Foundation native task | A native Codex session used the hosted development server to register an owned fixture, create a 3.60 m by 2.80 m room, validate, and save. Fresh MCP and REST reads independently confirmed the same ten-node scene. Owned fixtures were removed afterward. |
 
 The first Codex gate scored 17/20 after independent adjudication. The corrected skill preserves supplied dimensions and clearance and cross-checks exact returned source IDs. The second batch used the same frozen prompts and fixtures; both batches and grading errors were retained. Eight corrected responses had minor review observations, none classified as a failed task or critical defect.
@@ -39,7 +43,7 @@ Claude's three task pairs are a small diagnostic sample. Baseline and treatment 
 - The foundation task proves one hosted-development journey, not all general construction, account claiming, or human handoff workflows.
 - Use one active agent client per local CLI service. The standalone HTTP bridge shares scene state across clients; concurrent independent client isolation is not supported. Hosted Community MCP uses a different session-isolated bridge.
 - Cursor Agent can list the configured MCP tools, but is signed out in the validation environment. A native Cursor task is not counted as passed.
-- Production hosted MCP, installation from the published beta/default branch, official marketplace listing, external users, and retention require their own receipts. A public Git install is not proof of directory approval or indexing.
+- Production hosted MCP, newer npm CLI/MCP releases, official marketplace listing, external users, and retention require their own receipts. Public Git installation and a GitHub prerelease are not proof of npm publication, directory approval, or indexing.
 - Headless GLB export, delivery-route analysis, full door-swing geometry, and vertical clearance remain unsupported by the assessed layout tools.
 
 Run the package checks with `bun scripts/validate-skills.ts` and `claude plugin validate . --strict`. Runtime regression cases live in `packages/mcp/scripts/furniture-fit-journey.ts`; native task prompts and expectations are bundled under each skill's `evals/` directory.

--- a/skills/VALIDATION.md
+++ b/skills/VALIDATION.md
@@ -1,6 +1,6 @@
 # Skill package validation
 
-Package version: **0.1.0**. Recorded September 8, 2026.
+Plugin bundle version: **0.1.1**. Skill metadata version: **0.1.0**. Recorded September 8, 2026.
 
 The `native-host-validation: source-hash-recorded-separately` metadata is a pointer to this record, not a blanket pass. Source and package checks do not establish task success on every host, real-world furniture installation, or market adoption.
 
@@ -46,4 +46,4 @@ Claude's three task pairs are a small diagnostic sample. Baseline and treatment 
 - Production hosted MCP, newer npm CLI/MCP releases, official marketplace listing, external users, and retention require their own receipts. Public Git installation and a GitHub prerelease are not proof of npm publication, directory approval, or indexing.
 - Headless GLB export, delivery-route analysis, full door-swing geometry, and vertical clearance remain unsupported by the assessed layout tools.
 
-Run the package checks with `bun scripts/validate-skills.ts` and `claude plugin validate . --strict`. Runtime regression cases live in `packages/mcp/scripts/furniture-fit-journey.ts`; native task prompts and expectations are bundled under each skill's `evals/` directory.
+Run the package checks with `bun scripts/validate-skills.ts` and `claude plugin validate . --strict`. Runtime regression cases live in `packages/mcp/scripts/furniture-fit-journey.ts`. Each public `evals/` directory contains representative prompts and expectations; the private 20-case release gate is not distributed there.

--- a/skills/furniture-fit/references/setup.md
+++ b/skills/furniture-fit/references/setup.md
@@ -6,14 +6,36 @@ Source and public-documentation review date: 2026-09-08. Native task results are
 
 Use the local path when the project should remain on the machine:
 
+### Candidate-enabled GitHub preview
+
+The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, an older runtime that may not expose `check_collisions.candidate`. For the candidate-enabled path verified with this skill, install the GitHub prerelease built from public commit `aa653f2f523f81f361ac20cb42b745faf7e46844`:
+
 ```bash
-npm install --global @pascal-app/cli@beta
+PASCAL_PREVIEW_VERSION='1.0.0-beta.1.agent-skills.0'
+PASCAL_PREVIEW_PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/pascal-preview"
+PASCAL_PREVIEW_DOWNLOAD="$(mktemp -d)"
+cd "$PASCAL_PREVIEW_DOWNLOAD"
+
+curl --fail --location --remote-name \
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+curl --fail --location --remote-name \
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/SHA256SUMS.txt"
+
+# macOS
+shasum -a 256 -c SHA256SUMS.txt
+# Linux: use `sha256sum -c SHA256SUMS.txt` instead.
+
+npm install --global --prefix "$PASCAL_PREVIEW_PREFIX" --ignore-scripts \
+  "./pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
+pascal --version
 pascal editor --no-open
-pascal mcp setup claude
-pascal mcp setup codex
+pascal mcp setup claude # or: pascal mcp setup codex
 ```
 
-Run the setup command for the active host. The MCP command installed in host configuration is `pascal mcp connect`. Local use needs no hosted account and does not upload projects automatically.
+The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. This preview is not published on npm.
+
+Run the setup command for the active host. The MCP command installed in host configuration is `pascal mcp connect`. Local use needs no hosted account and does not upload projects automatically. If the connected MCP schema lacks `check_collisions.candidate`, report the narrower supported result rather than implying the candidate was tested.
 
 Use only one active agent client with each local CLI service. The standalone HTTP service shares active scene state across clients; do not run concurrent agents against that process. Separate processes need separate local data stores for independent work. The hosted endpoint below uses a different session-isolated bridge.
 

--- a/skills/furniture-fit/references/setup.md
+++ b/skills/furniture-fit/references/setup.md
@@ -29,11 +29,12 @@ npm install --global --prefix "$PASCAL_PREVIEW_PREFIX" --ignore-scripts \
   "./pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
 export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
 pascal --version
+pascal update --version "$PASCAL_PREVIEW_VERSION"
 pascal editor --no-open
 pascal mcp setup claude # or: pascal mcp setup codex
 ```
 
-The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. This preview is not published on npm.
+The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. Keep an existing `PASCAL_HOME` unchanged so stored projects remain in the same data directory; `pascal editor` alone reuses any healthy service, including an older one. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. This preview is not published on npm.
 
 Run the setup command for the active host. The MCP command installed in host configuration is `pascal mcp connect`. Local use needs no hosted account and does not upload projects automatically. If the connected MCP schema lacks `check_collisions.candidate`, report the narrower supported result rather than implying the candidate was tested.
 

--- a/skills/pascal-3d/references/setup.md
+++ b/skills/pascal-3d/references/setup.md
@@ -8,12 +8,41 @@ Choose one path. Do not switch storage boundaries without the user's instruction
 
 Use local mode when the project should remain on the current machine. It requires Node.js 22.13 or newer and does not require a Pascal account or API key.
 
+The npm beta is suitable for its published tool contract:
+
 ```bash
 npm install --global @pascal-app/cli@beta
 pascal editor --no-open
-pascal mcp setup claude
-pascal mcp setup codex
 ```
+
+### Candidate-enabled GitHub preview
+
+The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, an older runtime that may not expose `check_collisions.candidate`. For the candidate-enabled path verified with this skill, install the GitHub prerelease built from public commit `aa653f2f523f81f361ac20cb42b745faf7e46844`:
+
+```bash
+PASCAL_PREVIEW_VERSION='1.0.0-beta.1.agent-skills.0'
+PASCAL_PREVIEW_PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/pascal-preview"
+PASCAL_PREVIEW_DOWNLOAD="$(mktemp -d)"
+cd "$PASCAL_PREVIEW_DOWNLOAD"
+
+curl --fail --location --remote-name \
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+curl --fail --location --remote-name \
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/SHA256SUMS.txt"
+
+# macOS
+shasum -a 256 -c SHA256SUMS.txt
+# Linux: use `sha256sum -c SHA256SUMS.txt` instead.
+
+npm install --global --prefix "$PASCAL_PREVIEW_PREFIX" --ignore-scripts \
+  "./pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
+pascal --version
+pascal editor --no-open
+pascal mcp setup claude # or: pascal mcp setup codex
+```
+
+The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. This preview is not published on npm.
 
 Run only the setup command for the active host. For a JSON-based MCP client, use:
 

--- a/skills/pascal-3d/references/setup.md
+++ b/skills/pascal-3d/references/setup.md
@@ -38,11 +38,12 @@ npm install --global --prefix "$PASCAL_PREVIEW_PREFIX" --ignore-scripts \
   "./pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
 export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
 pascal --version
+pascal update --version "$PASCAL_PREVIEW_VERSION"
 pascal editor --no-open
 pascal mcp setup claude # or: pascal mcp setup codex
 ```
 
-The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. This preview is not published on npm.
+The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. Keep an existing `PASCAL_HOME` unchanged so stored projects remain in the same data directory; `pascal editor` alone reuses any healthy service, including an older one. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. This preview is not published on npm.
 
 Run only the setup command for the active host. For a JSON-based MCP client, use:
 


### PR DESCRIPTION
The public furniture-fit skill now depends on a read-only candidate check that the current npm beta predates. This adds a checksum-verified GitHub prerelease install path to the root, CLI, and skill setup docs, while keeping the older npm runtime boundary explicit and documenting the one-active-client local HTTP constraint.

An older healthy service is reused by `pascal editor` before the invoking CLI installs its bundled runtime. The preview instructions now run `pascal update --version 1.0.0-beta.1.agent-skills.0` in the existing `PASCAL_HOME`; an isolated upgrade test confirmed that this activates the preview runtime, restarts the old service, and preserves the stored project. A same-version Claude plugin update test also confirmed that changed bundled references remain cached, so the plugin bundle metadata moves to `0.1.1` while both frozen `SKILL.md` files remain at `0.1.0`.

Evidence:
- Release tag: `cli-v1.0.0-beta.1-agent-skills.0`
- Runtime source: `aa653f2f523f81f361ac20cb42b745faf7e46844`
- Published archive SHA-256: `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`
- Anonymous download matched both `SHA256SUMS.txt` and GitHub's recorded digest.
- A fresh isolated-prefix install passed managed editor/MCP startup and reuse, project list/resume, all doctor checks, graph nonmutation during inspection, and clean stop.
- The downloaded bytes match the archive previously used for the native Claude furniture task and Linux arm64 managed-service smoke; those tasks were not rerun after publication.

Validation:
- `bun scripts/validate-skills.ts`
- `claude plugin validate . --strict`
- `git diff --check`
- Isolated old-service upgrade: npm CLI `1.0.0-beta.1` was reused by plain `editor`; the documented update switched to `1.0.0-beta.1.agent-skills.0`, restarted the service, and preserved the same project ID, version, and node count.
- Isolated Claude plugin update: unchanged `0.1.0` did not refresh modified references; `0.1.1` did.
- Furniture-fit `SKILL.md` remains `dc5a424d99f952411c98adc3df6490fdefedc9fefa972e541c18375d8f2add32`.
- Pascal foundation `SKILL.md` remains `0d8a71fa7200a087df3ce4fcd33d487001c99a8927f5ac0a65efebef4c59135d`.

This does not claim npm publication, marketplace listing, x86_64 coverage, or external adoption.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, validation script, and manifest version bumps only; no application or MCP runtime code changes.
> 
> **Overview**
> Documents how to run the **read-only furniture `check_collisions.candidate` flow** before the next npm CLI release, because **`@pascal-app/cli@beta` still points at `1.0.0-beta.1`**, which predates that MCP input.
> 
> Adds a shared **Candidate-enabled GitHub preview** section (root `README`, `packages/cli/README`, `skills/pascal-3d` and `furniture-fit` setup references, `skills/README`) with checksum-verified install steps for tag `cli-v1.0.0-beta.1-agent-skills.0`, pinned commit, and archive SHA-256. Clarifies **`pascal update`** as activating the bundled runtime or an npm target, **`PASCAL_HOME`/PATH** behavior, and **one active agent client per local CLI service** (shared scene state).
> 
> Bumps **plugin bundle version to 0.1.1** in Claude/Codex manifests and marketplace JSON while **skill metadata stays 0.1.0**. Updates `scripts/validate-skills.ts` to enforce separate skill vs plugin versions and marketplace plugin entries. Refreshes `skills/VALIDATION.md` with prerelease and installation evidence and tighter scope limits (GitHub preview ≠ npm publication).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de36370985c59b1a9ad748741777ad91f657211d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->