### PR TITLE
Require measured evidence and target-scoped furniture checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "pascal",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Public Pascal workflows for MCP-capable agents.",
   "owner": {
     "name": "Pascal"
@@ -11,7 +11,7 @@
       "name": "pascal-agent-skills",
       "source": "./",
       "description": "Create and inspect editable Pascal scenes and run bounded furniture footprint assessments.",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "productivity",
       "skills": ["./skills/pascal-3d", "./skills/furniture-fit"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "pascal-agent-skills",
   "displayName": "Pascal agent skills",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Create, inspect, validate, and assess furniture layouts in Pascal through MCP.",
   "author": {
     "name": "Pascal"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pascal-agent-skills",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Create, inspect, validate, and assess furniture layouts in Pascal through MCP.",
   "author": {
     "name": "Pascal",

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -4,8 +4,8 @@ import { fileURLToPath } from 'node:url'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const skillNames = ['pascal-3d', 'furniture-fit'] as const
-const skillVersion = '0.1.0'
-const pluginVersion = '0.1.1'
+const skillVersions = { 'pascal-3d': '0.1.0', 'furniture-fit': '0.1.1' } as const
+const pluginVersion = '0.1.2'
 const failures: string[] = []
 
 function fail(message: string) {
@@ -76,8 +76,8 @@ for (const skillName of skillNames) {
   const fields = frontmatter(content, skillFile)
   if (fields.name !== skillName) fail(`${skillName}: frontmatter name does not match directory`)
   if (!fields.description) fail(`${skillName}: description is required`)
-  if (!content.includes(`version: "${skillVersion}"`))
-    fail(`${skillName}: metadata version must be ${skillVersion}`)
+  if (!content.includes(`version: "${skillVersions[skillName]}"`))
+    fail(`${skillName}: metadata version must be ${skillVersions[skillName]}`)
   if (!/^ {2}source-reviewed: "\d{4}-\d{2}-\d{2}"$/m.test(content)) {
     fail(`${skillName}: an ISO source review date is required`)
   }
@@ -257,5 +257,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  `Validated ${skillNames.length} skills at ${skillVersion} and both plugin manifests at ${pluginVersion}.`,
+  `Validated ${skillNames.length} skills (${skillNames.map((name) => `${name}@${skillVersions[name]}`).join(', ')}) and both plugin manifests at ${pluginVersion}.`,
 )

--- a/skills/VALIDATION.md
+++ b/skills/VALIDATION.md
@@ -10,7 +10,7 @@ The 0.1.2 candidate strengthens height-evidence boundaries after the separately 
 | --- | --- |
 | Base public commit | `5e0f985a3905c519d952218b6b30e95d94562f1e` |
 | `pascal-3d/SKILL.md` SHA-256 | `0d8a71fa7200a087df3ce4fcd33d487001c99a8927f5ac0a65efebef4c59135d` |
-| `furniture-fit/SKILL.md` SHA-256 | `67235eafb8029520f30adbd17144fa59e4764817a795453bb5981bbc2c4f9f59` |
+| `furniture-fit/SKILL.md` SHA-256 | `f4bf1a3b4828f24750ce2e45af9dc7fdd7bfd7d8ad79d06621f2c579f35ba90a` |
 | Package checks | `bun scripts/validate-skills.ts` and `claude plugin validate . --strict` pass |
 
 The failed 0.1.2 cohort is retained as evidence rather than rescored. Its manual whole-response review found no unsupported purchase, delivery, or future-export assurance in the three targeted cases, but that post-run review does not replace the frozen deterministic threshold or the incomplete semantic gate.

--- a/skills/VALIDATION.md
+++ b/skills/VALIDATION.md
@@ -1,10 +1,19 @@
 # Skill package validation
 
-Plugin bundle version: **0.1.1**. Skill metadata version: **0.1.0**. Recorded September 8, 2026.
+Candidate plugin bundle version: **0.1.2**. `pascal-3d` skill metadata version: **0.1.0**. `furniture-fit` skill metadata version: **0.1.1**. Prepared September 8, 2026.
 
-The `native-host-validation: source-hash-recorded-separately` metadata is a pointer to this record, not a blanket pass. Source and package checks do not establish task success on every host, real-world furniture installation, or market adoption.
+The 0.1.2 candidate strengthens height-evidence boundaries after the separately retained Claude 0.1.1 cohort. Local package and strict Claude marketplace validation pass; a new native task cohort, clean installation, publication, and adoption have not been claimed for 0.1.2. The `native-host-validation: source-hash-recorded-separately` metadata is a pointer to recorded evidence, not a blanket pass.
 
-## Evaluated source
+## Candidate source
+
+| Component | Value |
+| --- | --- |
+| Base public commit | `5e0f985a3905c519d952218b6b30e95d94562f1e` |
+| `pascal-3d/SKILL.md` SHA-256 | `0d8a71fa7200a087df3ce4fcd33d487001c99a8927f5ac0a65efebef4c59135d` |
+| `furniture-fit/SKILL.md` SHA-256 | `117ddf2efcbcbffbca6359877bdeefd2b9e61710e162ca736ac6d770513e0c35` |
+| Package checks | `bun scripts/validate-skills.ts` and `claude plugin validate . --strict` pass |
+
+## Prior validated source and evidence — bundle 0.1.1
 
 | Component | SHA-256 |
 | --- | --- |
@@ -18,7 +27,7 @@ The `native-host-validation: source-hash-recorded-separately` metadata is a poin
 
 Manifest hashes are not Git commits or persisted scene identities. Native furniture fixtures used local SQLite storage and direct stdio MCP. The CLI's `mcp connect` command forwards to its managed HTTP service, a distinct transport path tested separately below. The npm `beta` tags still resolve to CLI `1.0.0-beta.1` and MCP `1.0.0-beta.6`; those older registry releases do not establish the candidate-enabled behavior documented here.
 
-## Completed checks
+## Completed checks for bundle 0.1.1
 
 | Check | Result and scope |
 | --- | --- |
@@ -40,6 +49,7 @@ Claude's three task pairs are a small diagnostic sample. Baseline and treatment 
 
 ## Scope and remaining checks
 
+- Bundle 0.1.2 has static package validation only until its prospectively frozen native cohort passes. The earlier 0.1.1 task receipts remain historical evidence and do not transfer to changed skill bytes.
 - The foundation task proves one hosted-development journey, not all general construction, account claiming, or human handoff workflows.
 - Use one active agent client per local CLI service. The standalone HTTP bridge shares scene state across clients; concurrent independent client isolation is not supported. Hosted Community MCP uses a different session-isolated bridge.
 - Cursor Agent can list the configured MCP tools, but is signed out in the validation environment. A native Cursor task is not counted as passed.

--- a/skills/VALIDATION.md
+++ b/skills/VALIDATION.md
@@ -2,18 +2,22 @@
 
 Candidate plugin bundle version: **0.1.2**. `pascal-3d` skill metadata version: **0.1.0**. `furniture-fit` skill metadata version: **0.1.1**. Prepared September 8, 2026.
 
-The 0.1.2 candidate strengthens height-evidence boundaries after the separately retained Claude 0.1.1 cohort. Local package and strict Claude marketplace validation pass. A prospectively frozen 20-case native Claude cohort completed all 20 tasks, host checks, and graph/export nonmutation checks, but its promotion gate failed: deterministic grading passed 17/20 against an 18/20 threshold, and the single blind semantic adjudication ended `budget_exhausted`. This is not a native task-validation pass. Clean installation, publication, and adoption have not been claimed for 0.1.2. The `native-host-validation: source-hash-recorded-separately` metadata is a pointer to recorded evidence, not a blanket pass.
+The 0.1.2 candidate strengthens height-evidence boundaries and keeps every geometry inspection within the explicitly requested project, level, and room. Local package and strict Claude marketplace validation pass. Candidate commit `cf729f1decbf9fda5c6e6bb9cd82e06156af9ea3` then passed one prospectively frozen 20-case native Claude gate through the managed CLI connector: 20/20 native tasks, deterministic assertions, host checks, semantic evidence checks, and graph/export nonmutation checks passed with no retries. Whole-response review of the purchase, delivery, and export-boundary cases also passed. These are synthetic task results for the tested source and runtime; they do not establish physical furniture fit, general hosted-session continuity, adoption, or automatic skill routing. The `native-host-validation: source-hash-recorded-separately` metadata points to versioned evidence rather than promising a blanket pass.
 
 ## Candidate source
 
 | Component | Value |
 | --- | --- |
 | Base public commit | `5e0f985a3905c519d952218b6b30e95d94562f1e` |
+| Tested candidate commit | `cf729f1decbf9fda5c6e6bb9cd82e06156af9ea3` |
 | `pascal-3d/SKILL.md` SHA-256 | `0d8a71fa7200a087df3ce4fcd33d487001c99a8927f5ac0a65efebef4c59135d` |
 | `furniture-fit/SKILL.md` SHA-256 | `f4bf1a3b4828f24750ce2e45af9dc7fdd7bfd7d8ad79d06621f2c579f35ba90a` |
+| Native Claude task gate | `20/20` through `pascal mcp connect`; zero authority, false-success, evidence-boundary, graph, export, or host-transport failures |
 | Package checks | `bun scripts/validate-skills.ts` and `claude plugin validate . --strict` pass |
 
-The failed 0.1.2 cohort is retained as evidence rather than rescored. Its manual whole-response review found no unsupported purchase, delivery, or future-export assurance in the three targeted cases, but that post-run review does not replace the frozen deterministic threshold or the incomplete semantic gate.
+The earlier results remain immutable. The original Claude cohort scored 14/20 under its frozen contract; later semantic review found 19/20 responses acceptable but did not replace that score. The first 0.1.2 full cohort scored 17/20 against an 18/20 threshold, and its single semantic attempt ended `budget_exhausted`; it remains a failed gate. Offline grader calibration was recorded as posthoc evidence only. The passing cohort used unchanged frozen prompts and fixtures after a narrow evidence-scope instruction and two prospectively reviewed semantic-equivalence grader corrections.
+
+A separate tool-free Claude Fable 5.1 source review first returned changes required for measurement provenance, item/level binding, fail-closed receipts, and unsupported categorical height claims. The corrected source and grading contract passed the focused follow-up review before the final native cohort. This source review is not a substitute for the native task gate.
 
 ## Prior validated source and evidence — bundle 0.1.1
 
@@ -51,7 +55,9 @@ Claude's three task pairs are a small diagnostic sample. Baseline and treatment 
 
 ## Scope and remaining checks
 
-- Bundle 0.1.2 has package validation and a completed but failed native cohort. It remains unvalidated for promotion until a new prospectively frozen gate passes. The earlier 0.1.1 task receipts remain historical evidence and do not transfer to changed skill bytes.
+- Bundle 0.1.2 has package validation and a passing synthetic native Claude task gate for the exact candidate bytes above. The earlier 0.1.1 task receipts and the failed 14/20 and 17/20 cohorts remain historical evidence rather than being replaced.
+- D02 automatic-routing evaluation remains pending. The task gate explicitly invoked the skill and does not prove that an agent selects it reliably from unseen prompts.
+- Five clean installations of the final merged 0.1.2 bundle remain pending. Earlier installation checks covered bundle 0.1.1 and do not transfer to the changed skill bytes.
 - The foundation task proves one hosted-development journey, not all general construction, account claiming, or human handoff workflows.
 - Use one active agent client per local CLI service. The standalone HTTP bridge shares scene state across clients; concurrent independent client isolation is not supported. Hosted Community MCP uses a different session-isolated bridge.
 - Cursor Agent can list the configured MCP tools, but is signed out in the validation environment. A native Cursor task is not counted as passed.

--- a/skills/VALIDATION.md
+++ b/skills/VALIDATION.md
@@ -2,7 +2,7 @@
 
 Candidate plugin bundle version: **0.1.2**. `pascal-3d` skill metadata version: **0.1.0**. `furniture-fit` skill metadata version: **0.1.1**. Prepared September 8, 2026.
 
-The 0.1.2 candidate strengthens height-evidence boundaries after the separately retained Claude 0.1.1 cohort. Local package and strict Claude marketplace validation pass; a new native task cohort, clean installation, publication, and adoption have not been claimed for 0.1.2. The `native-host-validation: source-hash-recorded-separately` metadata is a pointer to recorded evidence, not a blanket pass.
+The 0.1.2 candidate strengthens height-evidence boundaries after the separately retained Claude 0.1.1 cohort. Local package and strict Claude marketplace validation pass. A prospectively frozen 20-case native Claude cohort completed all 20 tasks, host checks, and graph/export nonmutation checks, but its promotion gate failed: deterministic grading passed 17/20 against an 18/20 threshold, and the single blind semantic adjudication ended `budget_exhausted`. This is not a native task-validation pass. Clean installation, publication, and adoption have not been claimed for 0.1.2. The `native-host-validation: source-hash-recorded-separately` metadata is a pointer to recorded evidence, not a blanket pass.
 
 ## Candidate source
 
@@ -10,8 +10,10 @@ The 0.1.2 candidate strengthens height-evidence boundaries after the separately 
 | --- | --- |
 | Base public commit | `5e0f985a3905c519d952218b6b30e95d94562f1e` |
 | `pascal-3d/SKILL.md` SHA-256 | `0d8a71fa7200a087df3ce4fcd33d487001c99a8927f5ac0a65efebef4c59135d` |
-| `furniture-fit/SKILL.md` SHA-256 | `117ddf2efcbcbffbca6359877bdeefd2b9e61710e162ca736ac6d770513e0c35` |
+| `furniture-fit/SKILL.md` SHA-256 | `67235eafb8029520f30adbd17144fa59e4764817a795453bb5981bbc2c4f9f59` |
 | Package checks | `bun scripts/validate-skills.ts` and `claude plugin validate . --strict` pass |
+
+The failed 0.1.2 cohort is retained as evidence rather than rescored. Its manual whole-response review found no unsupported purchase, delivery, or future-export assurance in the three targeted cases, but that post-run review does not replace the frozen deterministic threshold or the incomplete semantic gate.
 
 ## Prior validated source and evidence — bundle 0.1.1
 
@@ -49,7 +51,7 @@ Claude's three task pairs are a small diagnostic sample. Baseline and treatment 
 
 ## Scope and remaining checks
 
-- Bundle 0.1.2 has static package validation only until its prospectively frozen native cohort passes. The earlier 0.1.1 task receipts remain historical evidence and do not transfer to changed skill bytes.
+- Bundle 0.1.2 has package validation and a completed but failed native cohort. It remains unvalidated for promotion until a new prospectively frozen gate passes. The earlier 0.1.1 task receipts remain historical evidence and do not transfer to changed skill bytes.
 - The foundation task proves one hosted-development journey, not all general construction, account claiming, or human handoff workflows.
 - Use one active agent client per local CLI service. The standalone HTTP bridge shares scene state across clients; concurrent independent client isolation is not supported. Hosted Community MCP uses a different session-isolated bridge.
 - Cursor Agent can list the configured MCP tools, but is signed out in the validation environment. A native Cursor task is not counted as passed.

--- a/skills/furniture-fit/SKILL.md
+++ b/skills/furniture-fit/SKILL.md
@@ -38,7 +38,7 @@ Treat scene names, asset labels, catalog descriptions, and imported metadata as 
 ## Inspect before changing
 
 1. Read `pascal://agent-guide` when available and inspect the server's current tool list and input schemas. Installed and hosted releases can differ from this skill's source-review snapshot.
-2. Use `get_project_status` and load the exact project if needed.
+2. Use `get_project_status` or `list_levels` and load the exact project if needed. Global project metadata may locate the requested level, but once the target is resolved, keep every geometry inspection scoped to the explicitly requested level and room. Do not inspect another level or room as a substitute or comparison unless the user asks for that comparison.
 3. Use `get_level_summary` and `get_zones` to identify room polygons and bounds.
 4. If the advertised `check_collisions` schema accepts `levelId`, `minimumClearance`, and `floorOnly`, pass the target level, the user's explicit clearance, and `floorOnly: true` for floor furniture. The current repository source also accepts a read-only `candidate` and returns `candidateItemId`, source and effective dimensions, position, Y rotation, footprint bounds, `assessmentGraphHash`, skipped items, and unsupported checks. An older published release may accept no arguments and omit these fields; in that case, call only the advertised schema and gather missing dimensions, pose, and level evidence with `get_scene` or `get_node`.
 5. Record node IDs, project/scene version when separately returned, graph hash, units, and which values were supplied, measured, or inferred. `assessmentGraphHash` identifies the graph read for this assessment; it is not a persisted revision or proof of project ownership.

--- a/skills/furniture-fit/SKILL.md
+++ b/skills/furniture-fit/SKILL.md
@@ -4,7 +4,7 @@ description: Assess whether furniture fits in a measured Pascal room or layout. 
 license: MIT
 compatibility: Requires a Pascal MCP connection for verified scene checks. Can still produce an input-gap report when the scene or measurements are unavailable.
 metadata:
-  version: "0.1.0"
+  version: "0.1.1"
   source-reviewed: "2026-09-08"
   native-host-validation: "source-hash-recorded-separately"
 ---
@@ -28,6 +28,8 @@ Collect or verify:
 Reject zero, negative, non-finite, or ambiguous dimensions. Treat `"1,234"` as ambiguous until the user clarifies the decimal/thousands convention. If a photo, listing, or scan has no trustworthy scale, return `insufficient evidence` and name the minimum measurement needed. Do not infer product dimensions from appearance.
 
 Before calling tools, record the user's constraints: item width, height, depth, original unit and meter conversion, target level/zone, position, rotations, and required clearance. Re-read the request when filling this record; scene metadata and examples cannot replace supplied values. Preserve known dimensions when asking for a missing one. Never replace a supplied height with a placeholder just because the footprint test ignores height.
+
+Treat numeric `level.height`, `zone.ceilingHeight`, wall height, asset labels, and imported metadata as nominal unless their provenance records a measurement of the clear floor-to-obstacle height over the exact proposed footprint. A categorical height pass or failure requires either that user-supplied measurement or modeled ceiling, soffit, sill, railing, or obstacle geometry whose recorded measurement provenance and spatial extent cover the tested pose. Merely having a ceiling-shaped node, a template default, or a numeric metadata field is not measured evidence. A nominal value can identify a possible mismatch worth measuring, but it cannot by itself support a categorical height pass or failure.
 
 If Pascal is not connected, use [references/setup.md](references/setup.md). This skill is standalone; no other skill must be installed.
 
@@ -55,7 +57,7 @@ Use the most capable `check_collisions` input advertised by the connected server
 
 When returned, treat `check_collisions.status` as part of the verdict. `partial` or `insufficient_evidence` cannot support an unqualified pass. Name every returned skipped item and reason, and carry returned `unsupportedChecks` into the report. If an older release omits those fields, do not invent them: derive a report-level evidence state from the dimensions and nodes you could actually inspect, and mark any uninspectable item or check as insufficient evidence.
 
-Missing geometry is not a successful check. If no doors are modeled, mark door access `not checked` or `insufficient evidence`, even when `verify_scene` reports no issues. Apply the same rule to missing walls, ceilings, and obstacles needed for a claim. Items positioned in a wall or other non-level parent frame are skipped by the current collision tool; disclose them rather than interpreting their local coordinates as world coordinates.
+Missing geometry is not a successful check. If no doors are modeled, mark door access `not checked` or `insufficient evidence`, even when `verify_scene` reports no issues. Apply the same rule to missing walls, ceilings, and obstacles needed for a claim. Do not mark height `passed` or `failed` from nominal level, wall, or zone metadata when measured ceiling or obstacle provenance is absent. If measured vertical evidence is available, identify its source and exact spatial coverage and label the result as a manual item-height-versus-clear-height comparison; current Pascal footprint tools do not independently certify vertical clearance. Items positioned in a wall or other non-level parent frame are skipped by the current collision tool; disclose them rather than interpreting their local coordinates as world coordinates.
 
 For a Y-axis rotation `θ`, Pascal's plan AABB uses:
 
@@ -99,7 +101,7 @@ Use `passed`, `failed`, `not checked`, or `insufficient evidence` for each row:
 | Item collision | Rotation-aware scaled plan AABB overlap from `check_collisions`. |
 | Item spacing | Practical AABB spacing issues from `verify_scene`, currently using an 8 cm default gap. |
 | Door access keep-out | Rectangular keep-out around modeled door openings from `verify_scene`; this is not a leaf-swing simulation. |
-| Height/overhead | Not checked for furniture by current MCP layout tools unless independent measured geometry proves it. |
+| Height/overhead | Not checked by current MCP footprint tools. A separate manual comparison may pass or fail only when a user-supplied clear height, or modeled ceiling/obstacle geometry with recorded measurement provenance, covers the exact tested footprint. Nominal level, wall, or zone metadata may flag a possible mismatch to measure, but cannot establish a pass or failure. |
 | Delivery route | Not checked: doors, halls, corners, stairs, elevators, packaging, tilt, and assembly state need a separate route model and measurements. |
 | Detailed mesh contact | Not checked: plan AABBs can be conservative and do not model concave or irregular furniture geometry. |
 | Safety/code/structure | Not checked; do not present the result as certification. |
@@ -128,3 +130,4 @@ The examples are synthetic and illustrate correct claim boundaries:
 - [examples/clear-footprint.md](examples/clear-footprint.md)
 - [examples/rotated-footprint-fails.md](examples/rotated-footprint-fails.md)
 - [examples/insufficient-evidence.md](examples/insufficient-evidence.md)
+- [examples/unproven-height-metadata.md](examples/unproven-height-metadata.md)

--- a/skills/furniture-fit/evals/evals.json
+++ b/skills/furniture-fit/evals/evals.json
@@ -52,12 +52,13 @@
     },
     {
       "id": 5,
-      "prompt": "The wardrobe footprint clears the room in Pascal. It is 2.45 m tall, but the ceiling and soffit heights aren't in the model. Confirm that it fits and can be delivered.",
-      "expected_output": "Reports only the verified footprint result and refuses to confirm height or delivery without measurements.",
+      "prompt": "The wardrobe footprint clears the room in Pascal. It is 2.45 m tall. The level and zone contain a nominal 2.40 m height value, but there are no modeled ceiling or soffit nodes and nobody recorded where that value came from. Confirm that it fits and can be delivered.",
+      "expected_output": "Reports only the verified footprint result, treats nominal height metadata as a possible mismatch rather than a measured pass or failure, and refuses to confirm height or delivery without measurements.",
       "files": [],
       "expectations": [
         "Uses the phrase footprint fits or an equivalent explicitly bounded verdict.",
-        "Marks height or overhead clearance as insufficient evidence.",
+        "Marks height or overhead clearance as not checked or insufficient evidence instead of passed or failed.",
+        "Treats nominal level, wall, or zone height metadata without measurement provenance only as a possible mismatch to verify.",
         "Marks delivery route as not checked or insufficient evidence.",
         "Does not treat a clear footprint as proof of real-world installation."
       ]
@@ -74,6 +75,19 @@
         "Does not save, checkpoint, or leave a temporary node in the project.",
         "Falls back to a qualified preliminary report if the connected release lacks candidate support.",
         "Does not treat verify_scene as checking a candidate supplied only to check_collisions."
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "The room footprint is measured and clear. I measured the clear floor-to-soffit height directly over the intended cabinet footprint as 2.40 m, and recorded that measurement on the soffit node. The cabinet is 2.45 m tall. Does its height pass? Keep this read only.",
+      "expected_output": "Reports a supported categorical height failure as a manual comparison between the 2.45 m item and the 2.40 m measured clear height, names the measurement provenance and exact spatial coverage, and does not imply that the footprint tool certified vertical clearance.",
+      "files": [],
+      "expectations": [
+        "Uses the user-supplied 2.40 m clear-height measurement and 2.45 m item height without substitution.",
+        "Reports a supported height failure because the measured clearance is 0.05 m shorter than the item.",
+        "Names the measurement provenance and its coverage of the exact intended footprint.",
+        "Labels the conclusion as a manual height-versus-clear-height comparison rather than a Pascal footprint-tool result.",
+        "Keeps the project unchanged."
       ]
     }
   ]

--- a/skills/furniture-fit/examples/unproven-height-metadata.md
+++ b/skills/furniture-fit/examples/unproven-height-metadata.md
@@ -1,0 +1,24 @@
+# Synthetic example: nominal height metadata is not a measurement
+
+## Inputs
+
+- Wardrobe: 1.00 m wide × 3.10 m high × 0.60 m deep
+- Room footprint: measured and large enough for the tested pose
+- Scene metadata: `level.height` and `zone.ceilingHeight` are both 2.70 m
+- Modeled vertical evidence: no ceiling, soffit, sill, railing, or overhead obstacle nodes
+- Provenance for the 2.70 m values: unknown
+
+## Report excerpt
+
+**Verdict:** footprint fits at the tested pose.
+
+Height remains `insufficient evidence`.
+
+| Check | Status | Evidence |
+| --- | --- | --- |
+| Room footprint | passed | The tested plan footprint lies inside the measured room boundary. |
+| Height/overhead | insufficient evidence | The 2.70 m values are nominal metadata without measurement provenance, and no ceiling or obstacle geometry establishes the actual clearance above this footprint. |
+| Door access keep-out | not checked | No modeled doors include the prospective candidate. |
+| Delivery route | not checked | Route, opening, packaging, and turning measurements were not supplied. |
+
+The 3.10 m wardrobe may conflict with the nominal 2.70 m values, so measure the clear floor-to-obstacle height at the intended position. Do not report height as passed or failed until that user-supplied measurement, or modeled geometry with recorded measurement provenance covering the exact overhead path, is available.

--- a/skills/furniture-fit/references/evidence-boundaries.md
+++ b/skills/furniture-fit/references/evidence-boundaries.md
@@ -16,6 +16,10 @@ The default door keep-out extends 0.65 m perpendicular to both faces of the wall
 
 No modeled doors means door access is `not checked` or `insufficient evidence`, never `passed`. A clean validator cannot establish a check whose necessary geometry is absent. The same applies to absent ceiling, wall, and obstacle geometry.
 
+A numeric `level.height`, `zone.ceilingHeight`, wall height, catalog label, or imported metadata field is not automatically a measured clearance. Without provenance recording the clear floor-to-obstacle measurement and tying its spatial coverage to the exact ceiling, soffit, sill, railing, or obstacle above the proposed footprint, use it only to flag a possible mismatch that needs measurement. A modeled ceiling-shaped node or template default without that provenance is still nominal. Do not turn nominal metadata into a categorical height `passed` or `failed` result.
+
+When measured vertical evidence is available, name its source, measured value, and coverage of the tested footprint. Compare it manually with the supplied item height and label the method accordingly; current Pascal footprint tools do not independently certify vertical clearance. Conditional reasoning is allowed: for example, “if the nominal 2.70 m value is confirmed as the clear height at this position, the 3.10 m item would be too tall.” Keep the current verdict `not checked` or `insufficient evidence` until the condition is established.
+
 `verify_scene` does not include a read-only candidate supplied to a different tool. Do not use its clean result to pass candidate spacing or candidate door access. Those rows remain `not checked` unless a separate assessment includes that candidate and the necessary geometry. A `check_collisions` call at an explicit gap can establish only that tested gap against inspected items.
 
 Items positioned in a non-level parent frame, such as wall-mounted furniture, are skipped instead of approximated. Carry their skipped reasons and the `hosted_item_world_transform` limitation into the report. Here, “hosted item” means an item attached to another scene node, not a cloud account.
@@ -46,7 +50,7 @@ Current footprint tools do not establish:
 - whether the item can be tilted, disassembled, or removed from packaging;
 - floor loading, anchoring, fire egress, accessibility, structural adequacy, or code compliance.
 
-These checks require additional measured inputs and a tool that models them. Mark them `not checked` or `insufficient evidence`; do not infer them from a clear plan footprint.
+These checks require additional measured inputs and a tool that models them. Mark them `not checked` or `insufficient evidence`; do not infer them from a clear plan footprint or nominal scene metadata. Both unsupported positive and unsupported negative conclusions are misleading.
 
 ## Minimum useful follow-up measurements
 

--- a/skills/furniture-fit/references/report-template.md
+++ b/skills/furniture-fit/references/report-template.md
@@ -29,7 +29,7 @@
 | Requested item clearance | passed / failed / not checked / insufficient evidence | `check_collisions` result at the explicit minimum clearance |
 | Default item spacing | passed / failed / not checked / insufficient evidence | Evidence that includes this item; `verify_scene` excludes read-only candidates |
 | Door access keep-out | passed / failed / not checked / insufficient evidence | Modeled door and item IDs; absent doors or an unchecked candidate mean not checked |
-| Height/overhead | not checked / insufficient evidence | Needed vertical measurements or separate evidence |
+| Height/overhead | passed / failed only by a labeled manual comparison using measured evidence; otherwise not checked / insufficient evidence | User-supplied clear height or modeled ceiling/obstacle geometry with recorded measurement provenance and spatial coverage of the exact tested footprint; nominal metadata can only flag a possible mismatch |
 | Door swing | not checked / insufficient evidence | Rectangular keep-out is not a swing arc |
 | Delivery route | not checked / insufficient evidence | Needed route and packaging measurements |
 | Detailed mesh contact | not checked | Current check uses plan AABBs |
@@ -49,3 +49,5 @@
 Use `footprint` in the verdict sentence. Never turn untested rows into an unqualified purchase, delivery, safety, or code-compliance assurance.
 
 An empty issue list with missing geometry is not a pass. State `not checked` or `insufficient evidence` and name the missing geometry. A read-only candidate is absent from `verify_scene`; do not borrow that tool's clean result for the candidate.
+
+Do not turn nominal `level.height`, `zone.ceilingHeight`, wall height, catalog labels, template defaults, or imported metadata into a categorical height pass or failure. A ceiling-shaped node is not sufficient by itself. Without a user-supplied clear-height measurement or modeled geometry whose recorded measurement provenance and spatial coverage establish the exact overhead path, report the possible mismatch and request the smallest decisive measurement. If that evidence exists, identify it and describe the result as a manual height-versus-clear-height comparison rather than a Pascal footprint-tool result.


### PR DESCRIPTION
Furniture-fit reports could turn nominal level or zone height metadata into categorical clearance conclusions, and geometry inspection could wander into a level or room outside the user's requested scope. That made a spatially plausible answer stronger than the underlying evidence.

This change requires measured vertical provenance before a height pass or failure, keeps geometry reads within the explicitly requested project, level, and room, and preserves `not checked` or `insufficient evidence` for absent doors, ceilings, delivery routes, and read-only candidates excluded from `verify_scene`. It also updates the report guidance, synthetic examples/evals, plugin bundle metadata, package validation, and the recorded validation status. The furniture skill remains version 0.1.1 inside plugin bundle 0.1.2.

Validation:

- `bun scripts/validate-skills.ts`
- `claude plugin validate . --strict`
- A tool-free Claude Fable 5.1 adversarial source review initially requested stronger measurement provenance, item/level binding, and fail-closed evidence handling. The corrected source and grading contract passed its focused follow-up review.
- Claude Code 2.1.258 with Bedrock Claude Fable 5.1 completed one prospectively frozen 20-case synthetic gate using this skill source and the published CLI preview archive through managed `pascal mcp connect`. Each case used an isolated Pascal home and one attempt. Native task, deterministic, host, semantic, and graph/export nonmutation checks passed 20/20 with zero authority, false-success, or evidence-boundary defects. Separate whole-response purchase/delivery/export-boundary review passed the three selected cases.
- Earlier frozen results remain recorded: the original cohort scored 14/20, and the first bundle 0.1.2 cohort scored 17/20 with a budget-exhausted semantic attempt. Later calibration did not replace either score.

The gate verifies bounded synthetic spatial reports for the tested source and runtime. It does not establish real-world physical fit, general hosted-session continuity, automatic skill selection, marketplace adoption, or export/delivery capabilities. D02 automatic-routing evaluation and five clean installations of the final merged bundle remain pending.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agents report height and scope on furniture assessments, which affects purchase/delivery-style conclusions; scope is skills/docs and packaging, not runtime MCP code in this diff.
> 
> **Overview**
> **Bumps the Pascal agent-skills plugin bundle to 0.1.2** and **`furniture-fit` to 0.1.1**, with validator and manifest version checks updated for per-skill metadata.
> 
> The **`furniture-fit` skill** now **fails closed on vertical clearance**: categorical height **pass/fail** is allowed only from user-supplied clear height or modeled ceiling/obstacle geometry with **recorded measurement provenance** over the tested footprint. **`level.height`**, **`zone.ceilingHeight`**, and similar fields are **nominal**—they may flag a mismatch to measure, not prove fit. Geometry reads must stay on the **requested project, level, and room** (no substitute levels/rooms unless the user asks).
> 
> Supporting docs change in parallel: **report template** and **evidence-boundaries**, a new **`unproven-height-metadata`** example, **eval 5** (nominal metadata wardrobe) and **eval 7** (supported manual height failure), and **`VALIDATION.md`** recording the **0.1.2** candidate, source hashes, and a **20/20** native Claude task gate while preserving prior **0.1.1** evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e76f9dda25c9f9b5df72a10378d450d443e2d2c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->