### PR TITLE
Carry collections through Save Build / Load Build

### DIFF
--- a/packages/core/src/validation/validate-build-json.test.ts
+++ b/packages/core/src/validation/validate-build-json.test.ts
@@ -174,3 +174,60 @@ describe('scene materials', () => {
     expect(result.warnings.some((w) => w.code === 'invalid_materials')).toBe(true)
   })
 })
+
+describe('collections', () => {
+  const minimalGraph = () => ({
+    nodes: {
+      building_1: { id: 'building_1', type: 'building', children: ['level_1'] },
+      level_1: { id: 'level_1', type: 'level', children: [] },
+    },
+    rootNodeIds: ['building_1'],
+  })
+
+  test('carries valid collections through to parsed', () => {
+    const result = validateBuildJson({
+      ...minimalGraph(),
+      collections: {
+        collection_a: {
+          id: 'collection_a',
+          name: 'Kitchen set',
+          color: '#ff0000',
+          nodeIds: ['item_1', 'item_2'],
+        },
+      },
+    })
+    expect(result.ok).toBe(true)
+    expect(result.parsed?.collections?.collection_a?.name).toBe('Kitchen set')
+    expect(result.parsed?.collections?.collection_a?.nodeIds).toEqual(['item_1', 'item_2'])
+  })
+
+  test('skips invalid collection entries with a warning, keeps the rest', () => {
+    const result = validateBuildJson({
+      ...minimalGraph(),
+      collections: {
+        collection_ok: { id: 'collection_ok', name: 'Fine', nodeIds: [] },
+        collection_bad: { id: 'collection_bad', name: 'Broken', nodeIds: [42] },
+        collection_worse: 'nope',
+      },
+    })
+    expect(result.ok).toBe(true)
+    expect(Object.keys(result.parsed?.collections ?? {})).toEqual(['collection_ok'])
+    const warning = result.warnings.find((w) => w.code === 'invalid_collections')
+    expect(warning).toBeDefined()
+    expect(warning?.message).toContain('collection_bad')
+    expect(warning?.message).toContain('collection_worse')
+  })
+
+  test('warns when collections is not an object', () => {
+    const result = validateBuildJson({ ...minimalGraph(), collections: [] })
+    expect(result.ok).toBe(true)
+    expect(result.parsed?.collections).toBeUndefined()
+    expect(result.warnings.some((w) => w.code === 'invalid_collections')).toBe(true)
+  })
+
+  test('omits collections from parsed when absent', () => {
+    const result = validateBuildJson(minimalGraph())
+    expect(result.ok).toBe(true)
+    expect('collections' in (result.parsed ?? {})).toBe(false)
+  })
+})

--- a/packages/core/src/validation/validate-build-json.ts
+++ b/packages/core/src/validation/validate-build-json.ts
@@ -1,4 +1,5 @@
 import { nodeRegistry } from '../registry'
+import type { Collection } from '../schema/collections'
 import { SceneMaterial } from '../schema/scene-material'
 import { AnyNode, type AnyNodeType, nodeKindOf } from '../schema/types'
 import { healSceneNodes } from '../utils/heal-scene-graph'
@@ -27,6 +28,8 @@ export type ParsedBuildJson = {
   installedPlugins?: string[]
   /** Scene materials referenced by node `slots` (`scene:<id>`). */
   materials?: Record<string, SceneMaterial>
+  /** Item collections; member nodes carry the matching `collectionIds`. */
+  collections?: Record<string, Collection>
 }
 
 export type SchemaIssue = {
@@ -50,6 +53,18 @@ const KNOWN_TYPES = new Set<string>(AnyNode.options.map(nodeKindOf))
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isCollection(value: unknown): value is Collection {
+  if (!isPlainObject(value)) return false
+  return (
+    typeof value.id === 'string' &&
+    typeof value.name === 'string' &&
+    Array.isArray(value.nodeIds) &&
+    value.nodeIds.every((nodeId) => typeof nodeId === 'string') &&
+    (value.color === undefined || typeof value.color === 'string') &&
+    (value.controlNodeId === undefined || typeof value.controlNodeId === 'string')
+  )
 }
 
 function polygonAreaM2(points: ReadonlyArray<readonly [number, number]>): number {
@@ -113,6 +128,7 @@ export function validateBuildJson(input: unknown): ValidateBuildJsonResult {
   const rootNodeIdsRaw = input.rootNodeIds
   const installedPluginsRaw = input.installedPlugins
   const materialsRaw = input.materials
+  const collectionsRaw = input.collections
 
   if (!isPlainObject(nodesRaw)) {
     errors.push({
@@ -203,6 +219,35 @@ export function validateBuildJson(input: unknown): ValidateBuildJsonResult {
       severity: 'warning',
       code: 'invalid_materials',
       message: 'Ignored invalid "materials" — expected an object of id → material.',
+    })
+  }
+
+  let collections: Record<string, Collection> | undefined
+  if (isPlainObject(collectionsRaw)) {
+    const skippedIds: string[] = []
+    const kept: Record<string, Collection> = {}
+    for (const [id, value] of Object.entries(collectionsRaw)) {
+      if (isCollection(value)) {
+        kept[id] = value
+      } else {
+        skippedIds.push(id)
+      }
+    }
+    if (Object.keys(kept).length > 0) collections = kept
+    if (skippedIds.length > 0) {
+      warnings.push({
+        severity: 'warning',
+        code: 'invalid_collections',
+        message: `Ignored ${skippedIds.length} invalid collection${
+          skippedIds.length === 1 ? '' : 's'
+        }: ${skippedIds.join(', ')}.`,
+      })
+    }
+  } else if (collectionsRaw !== undefined) {
+    warnings.push({
+      severity: 'warning',
+      code: 'invalid_collections',
+      message: 'Ignored invalid "collections" — expected an object of id → collection.',
     })
   }
 
@@ -420,6 +465,7 @@ export function validateBuildJson(input: unknown): ValidateBuildJsonResult {
           rootNodeIds,
           ...(installedPlugins ? { installedPlugins } : {}),
           ...(materials ? { materials } : {}),
+          ...(collections ? { collections } : {}),
         }
       : null,
     stats,

--- a/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/settings-panel/index.tsx
@@ -193,6 +193,7 @@ export function SettingsPanel({
   const rootNodeIds = useScene((state) => state.rootNodeIds)
   const installedPlugins = useScene((state) => state.installedPlugins)
   const materials = useScene((state) => state.materials)
+  const collections = useScene((state) => state.collections)
   const setScene = useScene((state) => state.setScene)
   const clearScene = useScene((state) => state.clearScene)
   const resetSelection = useViewer((state) => state.resetSelection)
@@ -236,7 +237,7 @@ export function SettingsPanel({
     // Materials ride along: nodes reference them by `scene:<id>` slot
     // refs, so a save without the table produces a file whose custom
     // finishes revert to defaults on the very Load Build path below.
-    const sceneData = { nodes, rootNodeIds, installedPlugins, materials }
+    const sceneData = { nodes, rootNodeIds, installedPlugins, materials, collections }
     const json = JSON.stringify(sceneData, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
@@ -302,6 +303,7 @@ export function SettingsPanel({
         // pointed at a material that no longer existed — custom finishes
         // silently reverted to defaults on import.
         materials: parsed.materials,
+        collections: parsed.collections,
         installedPlugins: parsed.installedPlugins ?? currentScene.installedPlugins,
         hasExplicitPluginInstallState:
           parsed.installedPlugins !== undefined || currentScene.hasExplicitPluginInstallState,


### PR DESCRIPTION
## What does this PR do?

Fixes #734 — Save Build / Load Build dropped collections on both sides. Same shape as #729 (materials):

- `handleSaveBuild` now includes `collections` in the saved `sceneData`.
- `validateBuildJson` gets a `collections` pass: each entry is checked against the `Collection` shape (`id`, `name`, `nodeIds: string[]`, optional `color`/`controlNodeId`); invalid entries are skipped with an `invalid_collections` warning that names the skipped ids, a non-object `collections` is ignored with a warning. Valid entries land on `parsed.collections`.
- `handleConfirmImport` passes `parsed.collections` through to `setScene` (which already accepted `extra.collections`).

## How to test

1. Create a collection in the editor, Save Build, then Load Build the same file → the collection is still there (before: gone).
2. `bun --cwd packages/core run test` — 4 new tests in `validate-build-json.test.ts` under `collections` (carry-through, per-entry skip with warning, non-object warning, absent → omitted from `parsed`).
3. Reverting the `validate-build-json.ts` change makes 3 of those tests fail; with it they pass. Full `packages/core` suite: 1430 pass / 0 fail. `packages/editor` tests: 836 pass / 0 fail, `tsc --noEmit` for `packages/editor` clean.

## Screenshots / screen recording

n/a — no UI change, only the saved file contents and the import pass.

## Checklist

- [ ] I've tested this locally with `bun dev` (verified via the package test suites + `tsc --noEmit` instead; happy to add a clip if you'd like one)
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to build JSON validation and settings-panel save/import wiring; no auth or security paths, and invalid collection data is warn-and-skip rather than hard-failing import.
> 
> **Overview**
> Fixes **collections being dropped** on Save Build and Load Build, mirroring the existing materials round-trip.
> 
> **Save Build** now writes `collections` from the scene store into the exported JSON alongside nodes, materials, and plugins. **Load Build** passes `parsed.collections` into `setScene` after import validation.
> 
> **`validateBuildJson`** gains a collections pass: valid entries (required `id`, `name`, `nodeIds: string[]`, optional `color` / `controlNodeId`) appear on `parsed.collections`; bad entries are skipped with an **`invalid_collections`** warning that lists skipped ids; a non-object `collections` field is ignored with a warning; absent collections stay omitted from `parsed`. Four unit tests cover carry-through, partial skip, invalid top-level shape, and omission when missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5bf174810ba3a5978bdeebc8948ba68b452778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->