### PR TITLE
perf(editor): instance the ceiling corner brackets per level

### DIFF
--- a/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.test.ts
+++ b/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, test } from 'bun:test'
-import { Color, Group, InstancedMesh, Matrix4, Mesh, Raycaster, Vector3 } from 'three'
+import {
+  type BufferAttribute,
+  Color,
+  Group,
+  InstancedMesh,
+  Matrix4,
+  Mesh,
+  Raycaster,
+  StaticDrawUsage,
+  Vector3,
+} from 'three'
+import Attributes from 'three/src/renderers/common/Attributes.js'
+import { AttributeType } from 'three/src/renderers/common/Constants.js'
+import Info from 'three/src/renderers/common/Info.js'
 import {
   BRACKET_Y_OFFSET,
   BracketPointerState,
@@ -309,4 +322,81 @@ describe('ceiling bracket pointer identities', () => {
     pointer.pointerDown([])
     expect(pointer.canClick(first)).toBe(false)
   })
+})
+
+test('each batch owns and disposes its geometry on capacity growth and teardown', () => {
+  const store = new CeilingBracketBatchStore()
+  const [initialNormal, highlighted] = store.getSnapshot()
+  expect(initialNormal!.geometry).not.toBe(highlighted!.geometry)
+  expect(initialNormal!.geometry.attributes.position!.array).not.toBe(
+    highlighted!.geometry.attributes.position!.array,
+  )
+  let retiredDisposals = 0
+  initialNormal!.geometry.addEventListener('dispose', () => {
+    retiredDisposals++
+  })
+  for (let index = 0; index < 3; index++) {
+    store.setGeometry(`ceiling:${index}` as BracketTarget['ceilingId'], corners, 3)
+  }
+  expect(retiredDisposals).toBe(1)
+  expect(store.getSnapshot()[0]!.geometry).not.toBe(initialNormal!.geometry)
+  let finalDisposals = 0
+  for (const mesh of store.getSnapshot()) {
+    mesh.geometry.addEventListener('dispose', () => {
+      finalDisposals++
+    })
+  }
+  store.dispose()
+  expect(finalDisposals).toBe(2)
+  expect(retiredDisposals).toBe(1)
+})
+
+test('WebGPU attribute updates skip resting frames and upload only written slots after a change', () => {
+  const store = new CeilingBracketBatchStore()
+  store.setGeometry(ceilingId, corners, 3)
+  const uploads: Array<{
+    attribute: BufferAttribute
+    ranges: Array<{ start: number; count: number }>
+  }> = []
+  const attributes = new Attributes(
+    {
+      createAttribute() {},
+      updateAttribute(attribute: BufferAttribute) {
+        uploads.push({ attribute, ranges: attribute.updateRanges.map((range) => ({ ...range })) })
+        attribute.clearUpdateRanges()
+      },
+    } as unknown as ConstructorParameters<typeof Attributes>[0],
+    new Info(),
+  )
+  const render = () => {
+    for (const mesh of store.getSnapshot()) {
+      for (const attribute of [mesh.instanceMatrix, mesh.instanceColor!]) {
+        expect(attribute.usage).toBe(StaticDrawUsage)
+        attributes.update(attribute, AttributeType.VERTEX)
+      }
+      mesh.onAfterRender(...([] as unknown as Parameters<typeof mesh.onAfterRender>))
+    }
+  }
+  render()
+  for (let frame = 0; frame < 20; frame++) render()
+  expect(uploads).toHaveLength(0)
+  store.setHighlight(ceilingId, 0)
+  render()
+  expect(uploads).toHaveLength(4)
+  for (const upload of uploads) {
+    expect(upload.ranges.length).toBeGreaterThan(0)
+    expect(upload.ranges.length).toBeLessThanOrEqual(7)
+    for (const range of upload.ranges) {
+      expect(range.count).toBe(upload.attribute.itemSize)
+      expect(range.start % upload.attribute.itemSize).toBe(0)
+    }
+  }
+  uploads.length = 0
+  for (let frame = 0; frame < 20; frame++) render()
+  expect(uploads).toHaveLength(0)
+  for (const mesh of store.getSnapshot()) {
+    expect(mesh.instanceMatrix.updateRanges).toEqual([])
+    expect(mesh.instanceColor!.updateRanges).toEqual([])
+  }
+  store.dispose()
 })

--- a/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.test.ts
+++ b/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, test } from 'bun:test'
+import { Color, Group, InstancedMesh, Matrix4, Mesh, Raycaster, Vector3 } from 'three'
+import {
+  BRACKET_Y_OFFSET,
+  BracketPointerState,
+  type BracketTarget,
+  bracketTargetKey,
+  buildCornerBrackets,
+  CeilingBracketBatchStore,
+  getBracketHighlights,
+  getBracketMatrix,
+  growBracketCapacity,
+} from './ceiling-bracket-batch'
+
+const polygon: Array<[number, number]> = [
+  [0, 0],
+  [4, 0],
+  [4, 4],
+  [0, 4],
+]
+const ceilingId = 'ceiling:first' as BracketTarget['ceilingId']
+const otherId = 'ceiling:second' as BracketTarget['ceilingId']
+const corners = buildCornerBrackets(polygon)
+const target = (
+  cornerIndex: number,
+  part: BracketTarget['part'] = 'cube',
+  id = ceilingId,
+): BracketTarget => ({ ceilingId: id, cornerIndex, part })
+
+function expectMatrix(actual: Matrix4, expected: Matrix4, precision = 10) {
+  actual.elements.forEach((value, index) => {
+    expect(value).toBeCloseTo(expected.elements[index]!, precision)
+  })
+}
+
+function expectIndex(store: CeilingBracketBatchStore, ids = [ceilingId, otherId]) {
+  const seen = new Set<string>()
+  for (const mesh of store.getSnapshot()) {
+    for (let index = 0; index < mesh.count; index++) {
+      const hit = store.getTarget(mesh, index)!
+      expect(hit).toBeDefined()
+      expect(ids).toContain(hit.ceilingId)
+      expect(store.getLocation(hit)).toEqual({ mesh, instanceId: index })
+      seen.add(bracketTargetKey(hit))
+      const matrix = new Matrix4()
+      mesh.getMatrixAt(index, matrix)
+      expectMatrix(matrix, getBracketMatrix(corners[hit.cornerIndex]!, hit.part, 3), 6)
+    }
+    expect(store.getTarget(mesh, mesh.count)).toBeUndefined()
+  }
+  expect(seen.size).toBe(ids.length * 12)
+}
+
+describe('ceiling bracket layout', () => {
+  test('leg matrices match the old nested level/corner/BracketLeg transforms', () => {
+    const sample: Array<[number, number]> = [
+      [2, -3],
+      [2.3, -2.6],
+      [5, 1],
+      [-1, 2],
+    ]
+    for (const corner of buildCornerBrackets(sample)) {
+      for (const part of ['incoming', 'outgoing'] as const) {
+        const neighborIndex =
+          part === 'incoming'
+            ? (corner.index - 1 + sample.length) % sample.length
+            : (corner.index + 1) % sample.length
+        const neighbor = sample[neighborIndex]!
+        const dx = neighbor[0] - corner.corner[0]
+        const dz = neighbor[1] - corner.corner[1]
+        const edgeLength = Math.hypot(dx, dz)
+        const direction = [dx / edgeLength, dz / edgeLength]
+        const length = Math.max(0.14, Math.min(0.38, edgeLength * 0.22))
+        const level = new Group()
+        level.position.y = 3 + 0.035
+        const cornerGroup = new Group()
+        cornerGroup.position.set(corner.corner[0], 0, corner.corner[1])
+        const leg = new Mesh()
+        leg.position.set((direction[0]! * length) / 2, 0, (direction[1]! * length) / 2)
+        leg.rotation.y = -Math.atan2(direction[1]!, direction[0]!)
+        leg.scale.set(length, 0.04, 0.04)
+        level.add(cornerGroup)
+        cornerGroup.add(leg)
+        level.updateMatrixWorld(true)
+        expectMatrix(getBracketMatrix(corner, part, 3), leg.matrixWorld)
+      }
+    }
+  })
+
+  test('cube matrix uses the same offset and dimensions', () => {
+    const expected = new Matrix4().makeScale(0.28, 0.08, 0.28)
+    expected.setPosition(4, 3.035, 4)
+    expectMatrix(getBracketMatrix(corners[2]!, 'cube', 3), expected)
+  })
+
+  test('length clamps, degenerate edges, and invalid polygons match the original', () => {
+    const sample = buildCornerBrackets([
+      [0, 0],
+      [0, 0],
+      [1, 0],
+      [10, 10],
+    ])
+    expect(sample[0]!.outgoingDirection).toEqual([1, 0])
+    expect(sample[0]!.outgoingLength).toBe(0.14)
+    expect(sample[1]!.outgoingLength).toBe(0.22)
+    expect(sample[2]!.outgoingLength).toBe(0.38)
+    expect(buildCornerBrackets([])).toEqual([])
+    expect(
+      buildCornerBrackets([
+        [0, 0],
+        [1, 1],
+      ]),
+    ).toEqual([])
+  })
+})
+
+describe('ceiling bracket highlights', () => {
+  test('wraps both incident edges and linked cubes for every corner', () => {
+    for (const count of [3, 4, 7]) {
+      for (let active = 0; active < count; active++) {
+        const highlights = getBracketHighlights(count, active)
+        expect(highlights.edges).toEqual(new Set([active, (active - 1 + count) % count]))
+        expect(highlights.corners).toEqual(
+          new Set([active, (active - 1 + count) % count, (active + 1) % count]),
+        )
+      }
+    }
+    expect(getBracketHighlights(4, null)).toEqual({ edges: new Set(), corners: new Set() })
+    expect(getBracketHighlights(1, 0)).toEqual({ edges: new Set(), corners: new Set() })
+  })
+
+  test('highlights both ends of each edge and only the three linked cubes', () => {
+    const store = new CeilingBracketBatchStore()
+    store.setGeometry(ceilingId, corners, 3)
+    store.setGeometry(otherId, corners, 3)
+    const snapshot = store.getSnapshot()
+    store.setHighlight(ceilingId, 0)
+    const [normal, highlighted] = store.getSnapshot()
+    expect(store.getSnapshot()).toBe(snapshot)
+    expect(normal!.count).toBe(17)
+    expect(highlighted!.count).toBe(7)
+    const parts = Array.from({ length: highlighted!.count }, (_, index) => {
+      const hit = store.getTarget(highlighted!, index)!
+      expect(hit.ceilingId).toBe(ceilingId)
+      return `${hit.cornerIndex}/${hit.part}`
+    })
+    expect(new Set(parts)).toEqual(
+      new Set([
+        '0/incoming',
+        '0/outgoing',
+        '0/cube',
+        '1/incoming',
+        '1/cube',
+        '3/outgoing',
+        '3/cube',
+      ]),
+    )
+    for (const mesh of store.getSnapshot()) {
+      const expected = new Color(mesh === highlighted ? '#818cf8' : '#d4d4d4')
+      for (let index = 0; index < mesh.count; index++) {
+        const color = new Color()
+        mesh.getColorAt(index, color)
+        expect(color.r).toBeCloseTo(expected.r, 6)
+        expect(color.g).toBeCloseTo(expected.g, 6)
+        expect(color.b).toBeCloseTo(expected.b, 6)
+      }
+    }
+    store.setHighlight(ceilingId, null)
+    expect(normal!.count).toBe(24)
+    expect(highlighted!.count).toBe(0)
+    store.dispose()
+  })
+})
+
+describe('ceiling bracket batches', () => {
+  test('round-trips instance indices through highlighting, swap removal, and removal of a ceiling', () => {
+    const store = new CeilingBracketBatchStore()
+    store.setGeometry(ceilingId, corners, 3)
+    store.setGeometry(otherId, corners, 3)
+    expectIndex(store)
+    for (const active of [0, 1, 3, null]) {
+      store.setHighlight(ceilingId, active)
+      expectIndex(store)
+    }
+    store.setHighlight(otherId, 2)
+    store.removeCeiling(ceilingId)
+    expectIndex(store, [otherId])
+    expect(store.getLocation(target(0))).toBeUndefined()
+    expect(store.getTarget(new Group(), 0)).toBeUndefined()
+    expect(store.getTarget(store.getSnapshot()[0]!, undefined)).toBeUndefined()
+    store.removeCeiling(otherId)
+    expect(store.getSnapshot().map((mesh) => mesh.count)).toEqual([0, 0])
+    store.dispose()
+  })
+
+  test('capacity has headroom, grows only on overflow, and never shrinks', () => {
+    expect(growBracketCapacity(0, 0)).toBe(0)
+    expect(growBracketCapacity(0, 1)).toBe(32)
+    expect(growBracketCapacity(32, 32)).toBe(32)
+    expect(growBracketCapacity(32, 33)).toBe(66)
+    expect(growBracketCapacity(66, 12)).toBe(66)
+    const store = new CeilingBracketBatchStore()
+    let reallocations = 0
+    const unsubscribe = store.subscribe(() => reallocations++)
+    const initial = store.getSnapshot()
+    for (let index = 0; index < 103; index++) {
+      const id = `ceiling:${index}` as BracketTarget['ceilingId']
+      store.setGeometry(id, corners, 3)
+    }
+    const [normal, highlighted] = store.getSnapshot()
+    expect(normal).not.toBe(initial[0])
+    expect(highlighted).toBe(initial[1])
+    expect(normal!.count).toBe(1236)
+    expect(normal!.instanceMatrix.count).toBeGreaterThan(1236)
+    expect(reallocations).toBeLessThan(7)
+    const grown = store.getSnapshot()
+    const versions = grown.map((mesh) => mesh.instanceMatrix.version)
+    store.setHighlight('ceiling:0' as BracketTarget['ceilingId'], 0)
+    expect(store.getSnapshot()).toBe(grown)
+    expect(normal!.instanceMatrix.version - versions[0]!).toBeLessThanOrEqual(7)
+    expect(highlighted!.instanceMatrix.version - versions[1]!).toBe(7)
+    unsubscribe()
+    store.dispose()
+  })
+
+  test('geometry changes preserve targets, update heights, and keep native raycasts in bounds', () => {
+    const store = new CeilingBracketBatchStore()
+    store.setGeometry(ceilingId, corners, 3)
+    const oldTarget = store.getTarget(store.getSnapshot()[0]!, 2)
+    const shifted = buildCornerBrackets(polygon.map(([x, z]) => [x + 1000, z - 1000]))
+    store.setGeometry(ceilingId, shifted, 8)
+    expect(store.getTarget(store.getSnapshot()[0]!, 2)).toBe(oldTarget)
+    const level = new Group()
+    level.position.set(20, 4, 30)
+    for (const mesh of store.getSnapshot()) level.add(mesh)
+    level.updateMatrixWorld(true)
+    const ray = new Raycaster(new Vector3(1020, 20, -970), new Vector3(0, -1, 0))
+    for (const active of [null, 0, 1, null]) {
+      store.setHighlight(ceilingId, active)
+      const hits = ray.intersectObjects(store.getSnapshot())
+      expect(hits.length).toBeGreaterThan(0)
+      expect(hits.some((hit) => store.getTarget(hit.object, hit.instanceId)?.part === 'cube')).toBe(
+        true,
+      )
+      expect(hits[0]!.point.y).toBeCloseTo(4 + 8 + BRACKET_Y_OFFSET + 0.04, 5)
+    }
+    store.setGeometry(ceilingId, shifted.slice(0, 3), 8)
+    expect(store.getSnapshot().reduce((sum, mesh) => sum + mesh.count, 0)).toBe(9)
+    for (const mesh of store.getSnapshot()) {
+      expect(mesh.raycast).toBe(InstancedMesh.prototype.raycast)
+      expect(mesh.frustumCulled).toBe(false)
+      expect(mesh.layers.mask).toBe(1)
+      expect(mesh.material.depthTest).toBe(true)
+      expect(mesh.material.depthWrite).toBe(false)
+      expect(mesh.material.transparent).toBe(true)
+    }
+    expect(store.getSnapshot().map((mesh) => mesh.renderOrder)).toEqual([1000, 1001])
+    expect(store.getSnapshot().map((mesh) => mesh.material.opacity)).toEqual([0.72, 0.92])
+    store.dispose()
+  })
+
+  test('unchanged geometry and highlights do not rewrite buffers or notify React', () => {
+    const store = new CeilingBracketBatchStore()
+    store.setGeometry(ceilingId, corners, 3)
+    const versions = store.getSnapshot().map((mesh) => mesh.instanceMatrix.version)
+    let notifications = 0
+    store.subscribe(() => notifications++)
+    store.setGeometry(ceilingId, corners, 3)
+    store.setHighlight(ceilingId, null)
+    expect(store.getSnapshot().map((mesh) => mesh.instanceMatrix.version)).toEqual(versions)
+    expect(notifications).toBe(0)
+    store.dispose()
+  })
+})
+
+describe('ceiling bracket pointer identities', () => {
+  test('pointer-out retains the old target after its packed slot is reassigned', () => {
+    const store = new CeilingBracketBatchStore()
+    const pointer = new BracketPointerState()
+    store.setGeometry(ceilingId, corners, 3)
+    store.setGeometry(otherId, corners, 3)
+    const { mesh, instanceId } = store.getLocation(target(0))!
+    const hit = store.getTarget(mesh, instanceId)!
+    pointer.over('old-hit', hit)
+    store.setHighlight(ceilingId, 0)
+    expect(bracketTargetKey(store.getTarget(mesh, instanceId)!)).not.toBe(bracketTargetKey(hit))
+    expect(pointer.out('old-hit')).toBe(hit)
+    expect(pointer.out('old-hit')).toBeUndefined()
+    store.dispose()
+  })
+
+  test('reused hover IDs and click targets retain ceiling, corner, and part identity', () => {
+    const pointer = new BracketPointerState()
+    const first = target(0)
+    const next = target(1)
+    expect(pointer.over('same-slot', first)).toBeUndefined()
+    expect(pointer.over('same-slot', next)).toBe(first)
+    expect(pointer.out('same-slot')).toBe(next)
+    pointer.pointerDown([first, target(0, 'incoming')])
+    expect(pointer.canClick({ ...first })).toBe(true)
+    expect(pointer.canClick(target(0, 'incoming'))).toBe(true)
+    expect(pointer.canClick(next)).toBe(false)
+    expect(pointer.canClick(target(0, 'outgoing'))).toBe(false)
+    expect(pointer.canClick(target(0, 'cube', otherId))).toBe(false)
+    pointer.over('old-mesh/undefined/2', first)
+    pointer.replaceObject('old-mesh', 'new-mesh')
+    expect(pointer.out('old-mesh/undefined/2')).toBeUndefined()
+    expect(pointer.out('new-mesh/undefined/2')).toBe(first)
+    pointer.pointerDown([])
+    expect(pointer.canClick(first)).toBe(false)
+  })
+})

--- a/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.ts
+++ b/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.ts
@@ -2,14 +2,15 @@ import type { CeilingNode } from '@pascal-app/core'
 import {
   BoxGeometry,
   Color,
-  DynamicDrawUsage,
   Euler,
   InstancedMesh,
+  type Intersection,
   Matrix4,
   MeshBasicMaterial,
   type Object3D,
   Quaternion,
   Sphere,
+  StaticDrawUsage,
   Vector3,
 } from 'three'
 
@@ -95,13 +96,19 @@ function createBatch(highlighted: boolean, capacity: number): BracketBatch {
     depthTest: true,
     depthWrite: false,
   })
-  const mesh = new InstancedMesh(SHARED_HANDLE_BOX_GEOMETRY, material, capacity)
+  // WebGPU releases instance attributes through the geometry's dispose listener.
+  const mesh = new InstancedMesh(SHARED_HANDLE_BOX_GEOMETRY.clone(), material, capacity)
   mesh.name = highlighted ? 'ceiling-brackets-highlighted' : 'ceiling-brackets-normal'
   mesh.renderOrder = highlighted ? 1001 : 1000
   mesh.frustumCulled = false
-  mesh.instanceMatrix.setUsage(DynamicDrawUsage)
+  mesh.instanceMatrix.setUsage(StaticDrawUsage)
   mesh.setColorAt(0, highlighted ? HIGHLIGHT_COLOR : NORMAL_COLOR)
-  mesh.instanceColor!.setUsage(DynamicDrawUsage)
+  mesh.instanceColor!.setUsage(StaticDrawUsage)
+  mesh.onAfterRender = () => {
+    // TSL uploads internal wrappers; clear the source ranges after they have been consumed.
+    mesh.instanceMatrix.clearUpdateRanges()
+    mesh.instanceColor!.clearUpdateRanges()
+  }
   mesh.count = 0
   mesh.boundingSphere = new Sphere()
   return { mesh, instances: [] }
@@ -123,6 +130,21 @@ export class CeilingBracketBatchStore {
   getTarget(object: Object3D, instanceId: number | undefined): BracketTarget | undefined {
     if (instanceId === undefined) return undefined
     return this.batches.find((batch) => batch.mesh === object)?.instances[instanceId]
+  }
+
+  resolveHitTarget(
+    event: Pick<Intersection, 'object' | 'instanceId' | 'distance'>,
+    hits: Array<Pick<Intersection, 'object' | 'instanceId' | 'distance'>>,
+  ) {
+    let target = this.getTarget(event.object, event.instanceId)
+    if (!target) return undefined
+    // Equal-distance ownership must not depend on which opacity batch is raycast first.
+    for (const hit of hits) {
+      if (hit.distance !== event.distance) continue
+      const candidate = this.getTarget(hit.object, hit.instanceId)
+      if (candidate && bracketTargetKey(candidate) < bracketTargetKey(target)) target = candidate
+    }
+    return target
   }
 
   getLocation(target: BracketTarget) {
@@ -201,6 +223,7 @@ export class CeilingBracketBatchStore {
 
   dispose() {
     for (const batch of this.batches) {
+      batch.mesh.geometry.dispose()
       batch.mesh.dispose()
       batch.mesh.material.dispose()
     }
@@ -216,6 +239,7 @@ export class CeilingBracketBatchStore {
     this.batches[index] = replacement
     for (const instance of replacement.instances) this.write(instance)
     replacement.mesh.count = replacement.instances.length
+    batch.mesh.geometry.dispose()
     batch.mesh.dispose()
     batch.mesh.material.dispose()
     this.meshes = this.batches.map((item) => item.mesh)
@@ -249,6 +273,8 @@ export class CeilingBracketBatchStore {
     const mesh = this.batches[Number(instance.highlighted)]!.mesh
     mesh.setMatrixAt(instance.instanceId, instance.matrix)
     mesh.setColorAt(instance.instanceId, instance.highlighted ? HIGHLIGHT_COLOR : NORMAL_COLOR)
+    mesh.instanceMatrix.addUpdateRange(instance.instanceId * 16, 16)
+    mesh.instanceColor!.addUpdateRange(instance.instanceId * 3, 3)
     mesh.instanceMatrix.needsUpdate = true
     mesh.instanceColor!.needsUpdate = true
     // Native InstancedMesh.raycast still tests its sphere even with frustum culling off.
@@ -287,6 +313,12 @@ export class BracketPointerState {
       this.hovered.delete(key)
       this.hovered.set(nextUuid + key.slice(previousUuid.length), target)
     }
+  }
+
+  clearHover() {
+    const targets = [...this.hovered.values()]
+    this.hovered.clear()
+    return targets
   }
 
   pointerDown(targets: BracketTarget[]) {

--- a/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.ts
+++ b/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.ts
@@ -101,6 +101,9 @@ function createBatch(highlighted: boolean, capacity: number): BracketBatch {
   mesh.name = highlighted ? 'ceiling-brackets-highlighted' : 'ceiling-brackets-normal'
   mesh.renderOrder = highlighted ? 1001 : 1000
   mesh.frustumCulled = false
+  // Three 0.185.1 re-uploads the whole matrix array every render when it fits the device's
+  // uniform-buffer limit (roughly 1024 matrices), ignoring versions/ranges; accepted for
+  // small batches. Above that limit, the attribute path honors versions and ranges.
   mesh.instanceMatrix.setUsage(StaticDrawUsage)
   mesh.setColorAt(0, highlighted ? HIGHLIGHT_COLOR : NORMAL_COLOR)
   mesh.instanceColor!.setUsage(StaticDrawUsage)

--- a/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.ts
+++ b/packages/editor/src/components/systems/ceiling/ceiling-bracket-batch.ts
@@ -1,0 +1,336 @@
+import type { CeilingNode } from '@pascal-app/core'
+import {
+  BoxGeometry,
+  Color,
+  DynamicDrawUsage,
+  Euler,
+  InstancedMesh,
+  Matrix4,
+  MeshBasicMaterial,
+  type Object3D,
+  Quaternion,
+  Sphere,
+  Vector3,
+} from 'three'
+
+export const BRACKET_Y_OFFSET = 0.035
+const SHARED_HANDLE_BOX_GEOMETRY = new BoxGeometry(1, 1, 1)
+SHARED_HANDLE_BOX_GEOMETRY.computeBoundingSphere()
+const NORMAL_COLOR = new Color('#d4d4d4')
+const HIGHLIGHT_COLOR = new Color('#818cf8')
+
+export type CornerBracketData = {
+  corner: [number, number]
+  index: number
+  incomingEdgeIndex: number
+  incomingDirection: [number, number]
+  outgoingEdgeIndex: number
+  outgoingDirection: [number, number]
+  incomingLength: number
+  outgoingLength: number
+}
+
+export type BracketPart = 'incoming' | 'outgoing' | 'cube'
+export type BracketTarget = {
+  ceilingId: CeilingNode['id']
+  cornerIndex: number
+  part: BracketPart
+}
+
+type BracketInstance = BracketTarget & {
+  matrix: Matrix4
+  highlighted: boolean
+  instanceId: number
+}
+
+type CeilingInstances = {
+  corners: CornerBracketData[]
+  height: number
+  activeCornerIndex: number | null
+  instances: BracketInstance[]
+}
+
+type BracketBatch = {
+  mesh: InstancedMesh<BoxGeometry, MeshBasicMaterial>
+  instances: BracketInstance[]
+}
+
+export function growBracketCapacity(current: number, required: number): number {
+  return required <= current ? current : Math.max(32, required * 2)
+}
+
+export function getBracketHighlights(cornerCount: number, activeCornerIndex: number | null) {
+  const edges = new Set<number>()
+  const corners = new Set<number>()
+  if (activeCornerIndex !== null && cornerCount >= 2) {
+    const previous = (activeCornerIndex - 1 + cornerCount) % cornerCount
+    edges.add(activeCornerIndex)
+    edges.add(previous)
+    corners.add(activeCornerIndex)
+    corners.add(previous)
+    corners.add((activeCornerIndex + 1) % cornerCount)
+  }
+  return { edges, corners }
+}
+
+export function getBracketMatrix(corner: CornerBracketData, part: BracketPart, height: number) {
+  const position = new Vector3(corner.corner[0], height + BRACKET_Y_OFFSET, corner.corner[1])
+  const rotation = new Quaternion()
+  const scale = new Vector3(0.28, 0.08, 0.28)
+  if (part !== 'cube') {
+    const direction = part === 'incoming' ? corner.incomingDirection : corner.outgoingDirection
+    const length = part === 'incoming' ? corner.incomingLength : corner.outgoingLength
+    position.x += direction[0] * (length / 2)
+    position.z += direction[1] * (length / 2)
+    rotation.setFromEuler(new Euler(0, -Math.atan2(direction[1], direction[0]), 0))
+    scale.set(length, 0.04, 0.04)
+  }
+  return new Matrix4().compose(position, rotation, scale)
+}
+
+function createBatch(highlighted: boolean, capacity: number): BracketBatch {
+  const material = new MeshBasicMaterial({
+    transparent: true,
+    opacity: highlighted ? 0.92 : 0.72,
+    depthTest: true,
+    depthWrite: false,
+  })
+  const mesh = new InstancedMesh(SHARED_HANDLE_BOX_GEOMETRY, material, capacity)
+  mesh.name = highlighted ? 'ceiling-brackets-highlighted' : 'ceiling-brackets-normal'
+  mesh.renderOrder = highlighted ? 1001 : 1000
+  mesh.frustumCulled = false
+  mesh.instanceMatrix.setUsage(DynamicDrawUsage)
+  mesh.setColorAt(0, highlighted ? HIGHLIGHT_COLOR : NORMAL_COLOR)
+  mesh.instanceColor!.setUsage(DynamicDrawUsage)
+  mesh.count = 0
+  mesh.boundingSphere = new Sphere()
+  return { mesh, instances: [] }
+}
+
+export class CeilingBracketBatchStore {
+  private readonly ceilings = new Map<CeilingNode['id'], CeilingInstances>()
+  private readonly batches = [createBatch(false, 32), createBatch(true, 32)]
+  private readonly listeners = new Set<() => void>()
+  private meshes = this.batches.map((batch) => batch.mesh)
+  private readonly instanceSphere = new Sphere()
+
+  readonly getSnapshot = () => this.meshes
+  readonly subscribe = (listener: () => void) => {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  getTarget(object: Object3D, instanceId: number | undefined): BracketTarget | undefined {
+    if (instanceId === undefined) return undefined
+    return this.batches.find((batch) => batch.mesh === object)?.instances[instanceId]
+  }
+
+  getLocation(target: BracketTarget) {
+    const instance = this.ceilings
+      .get(target.ceilingId)
+      ?.instances.find(
+        (item) => item.cornerIndex === target.cornerIndex && item.part === target.part,
+      )
+    if (!instance) return undefined
+    return {
+      mesh: this.batches[Number(instance.highlighted)]!.mesh,
+      instanceId: instance.instanceId,
+    }
+  }
+
+  setGeometry(ceilingId: CeilingNode['id'], corners: CornerBracketData[], height: number) {
+    let ceiling = this.ceilings.get(ceilingId)
+    if (ceiling?.corners === corners && ceiling.height === height) return
+    if (!ceiling || ceiling.corners.length !== corners.length) {
+      const activeCornerIndex = ceiling?.activeCornerIndex ?? null
+      this.removeCeiling(ceilingId)
+      ceiling = { corners, height, activeCornerIndex: null, instances: [] }
+      this.ceilings.set(ceilingId, ceiling)
+      this.ensureCapacity(false, this.batches[0]!.instances.length + corners.length * 3)
+      for (const corner of corners) {
+        for (const part of ['incoming', 'outgoing', 'cube'] as const) {
+          const instance: BracketInstance = {
+            ceilingId,
+            cornerIndex: corner.index,
+            part,
+            matrix: getBracketMatrix(corner, part, height),
+            highlighted: false,
+            instanceId: -1,
+          }
+          ceiling.instances.push(instance)
+          this.append(instance)
+        }
+      }
+      this.setHighlight(ceilingId, activeCornerIndex)
+      return
+    }
+    ceiling.corners = corners
+    ceiling.height = height
+    for (const instance of ceiling.instances) {
+      instance.matrix = getBracketMatrix(corners[instance.cornerIndex]!, instance.part, height)
+      this.write(instance)
+    }
+  }
+
+  setHighlight(ceilingId: CeilingNode['id'], activeCornerIndex: number | null) {
+    const ceiling = this.ceilings.get(ceilingId)
+    if (!ceiling || ceiling.activeCornerIndex === activeCornerIndex) return
+    ceiling.activeCornerIndex = activeCornerIndex
+    const { edges, corners } = getBracketHighlights(ceiling.corners.length, activeCornerIndex)
+    for (const instance of ceiling.instances) {
+      const corner = ceiling.corners[instance.cornerIndex]!
+      const highlighted =
+        instance.part === 'cube'
+          ? corners.has(instance.cornerIndex)
+          : edges.has(
+              instance.part === 'incoming' ? corner.incomingEdgeIndex : corner.outgoingEdgeIndex,
+            )
+      if (highlighted === instance.highlighted) continue
+      this.remove(instance)
+      instance.highlighted = highlighted
+      this.append(instance)
+    }
+  }
+
+  removeCeiling(ceilingId: CeilingNode['id']) {
+    const ceiling = this.ceilings.get(ceilingId)
+    if (!ceiling) return
+    for (const instance of ceiling.instances) this.remove(instance)
+    this.ceilings.delete(ceilingId)
+  }
+
+  dispose() {
+    for (const batch of this.batches) {
+      batch.mesh.dispose()
+      batch.mesh.material.dispose()
+    }
+  }
+
+  private ensureCapacity(highlighted: boolean, required: number) {
+    const index = Number(highlighted)
+    const batch = this.batches[index]!
+    const capacity = growBracketCapacity(batch.mesh.instanceMatrix.count, required)
+    if (capacity === batch.mesh.instanceMatrix.count) return
+    const replacement = createBatch(highlighted, capacity)
+    replacement.instances = batch.instances
+    this.batches[index] = replacement
+    for (const instance of replacement.instances) this.write(instance)
+    replacement.mesh.count = replacement.instances.length
+    batch.mesh.dispose()
+    batch.mesh.material.dispose()
+    this.meshes = this.batches.map((item) => item.mesh)
+    for (const listener of this.listeners) listener()
+  }
+
+  private append(instance: BracketInstance) {
+    this.ensureCapacity(
+      instance.highlighted,
+      this.batches[Number(instance.highlighted)]!.instances.length + 1,
+    )
+    const batch = this.batches[Number(instance.highlighted)]!
+    instance.instanceId = batch.instances.length
+    batch.instances.push(instance)
+    batch.mesh.count = batch.instances.length
+    this.write(instance)
+  }
+
+  private remove(instance: BracketInstance) {
+    const batch = this.batches[Number(instance.highlighted)]!
+    const last = batch.instances.pop()!
+    if (last !== instance) {
+      last.instanceId = instance.instanceId
+      batch.instances[last.instanceId] = last
+      this.write(last)
+    }
+    batch.mesh.count = batch.instances.length
+  }
+
+  private write(instance: BracketInstance) {
+    const mesh = this.batches[Number(instance.highlighted)]!.mesh
+    mesh.setMatrixAt(instance.instanceId, instance.matrix)
+    mesh.setColorAt(instance.instanceId, instance.highlighted ? HIGHLIGHT_COLOR : NORMAL_COLOR)
+    mesh.instanceMatrix.needsUpdate = true
+    mesh.instanceColor!.needsUpdate = true
+    // Native InstancedMesh.raycast still tests its sphere even with frustum culling off.
+    // Expand it on writes; retaining removed instances' bounds avoids a full scan on hover.
+    this.instanceSphere
+      .copy(SHARED_HANDLE_BOX_GEOMETRY.boundingSphere!)
+      .applyMatrix4(instance.matrix)
+    mesh.boundingSphere!.union(this.instanceSphere)
+  }
+}
+
+export function bracketTargetKey(target: BracketTarget) {
+  return `${target.ceilingId}/${target.cornerIndex}/${target.part}`
+}
+
+export class BracketPointerState {
+  private readonly hovered = new Map<string, BracketTarget>()
+  private initialTargets = new Set<string>()
+
+  over(key: string, target: BracketTarget) {
+    const previous = this.hovered.get(key)
+    this.hovered.set(key, target)
+    return previous
+  }
+
+  out(key: string) {
+    // R3F's pointer-out contains the old instanceId, which may now belong to another corner.
+    const target = this.hovered.get(key)
+    this.hovered.delete(key)
+    return target
+  }
+
+  replaceObject(previousUuid: string, nextUuid: string) {
+    for (const [key, target] of this.hovered) {
+      if (!key.startsWith(`${previousUuid}/`)) continue
+      this.hovered.delete(key)
+      this.hovered.set(nextUuid + key.slice(previousUuid.length), target)
+    }
+  }
+
+  pointerDown(targets: BracketTarget[]) {
+    this.initialTargets = new Set(targets.map(bracketTargetKey))
+  }
+
+  canClick(target: BracketTarget) {
+    return this.initialTargets.has(bracketTargetKey(target))
+  }
+}
+
+export function buildCornerBrackets(polygon: Array<[number, number]>): CornerBracketData[] {
+  if (polygon.length < 3) return []
+
+  return polygon.map((corner, index) => {
+    const previous = polygon[(index - 1 + polygon.length) % polygon.length]!
+    const next = polygon[(index + 1) % polygon.length]!
+    const incomingVector = [previous[0] - corner[0], previous[1] - corner[1]] as [number, number]
+    const outgoingVector = [next[0] - corner[0], next[1] - corner[1]] as [number, number]
+    const incomingDirection = normalize2D(incomingVector)
+    const outgoingDirection = normalize2D(outgoingVector)
+
+    const incomingLength = Math.hypot(incomingVector[0], incomingVector[1])
+    const outgoingLength = Math.hypot(outgoingVector[0], outgoingVector[1])
+
+    return {
+      corner,
+      index,
+      incomingEdgeIndex: (index - 1 + polygon.length) % polygon.length,
+      incomingDirection,
+      outgoingEdgeIndex: index,
+      outgoingDirection,
+      incomingLength: getBracketLength(incomingLength),
+      outgoingLength: getBracketLength(outgoingLength),
+    }
+  })
+}
+
+function normalize2D(vector: [number, number]): [number, number] {
+  const length = Math.hypot(vector[0], vector[1])
+  if (length < 1e-6) return [1, 0]
+  return [vector[0] / length, vector[1] / length]
+}
+
+function getBracketLength(edgeLength: number): number {
+  return Math.max(0.14, Math.min(0.38, edgeLength * 0.22))
+}

--- a/packages/editor/src/components/systems/ceiling/ceiling-selection-affordance-system.test.ts
+++ b/packages/editor/src/components/systems/ceiling/ceiling-selection-affordance-system.test.ts
@@ -9,7 +9,7 @@ import {
   useScene,
 } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
-import { _roots, act, createRoot, events, extend } from '@react-three/fiber'
+import { _roots, act, createRoot, events, extend, type RootState } from '@react-three/fiber'
 import { createElement } from 'react'
 import { Group, InstancedMesh, OrthographicCamera, Vector3, type WebGLRenderer } from 'three'
 import { sfxEmitter } from '../../../lib/sfx-bus'
@@ -20,7 +20,20 @@ import { CeilingSelectionAffordanceSystem } from './ceiling-selection-affordance
 
 extend({ Group })
 
-test('mounted brackets preserve hover, clicks, drags, capture visibility, overrides, and unmounting', async () => {
+type PointerHandler = 'onPointerMove' | 'onPointerDown' | 'onClick' | 'onPointerLeave'
+type BracketHarness = {
+  ceiling: CeilingNode
+  level: LevelNode
+  levelObject: Group
+  state: () => RootState
+  dispatch: (name: PointerHandler, x: number, z: number) => Promise<void>
+  dispatchWindow: (type: string, x: number, z: number) => Promise<void>
+  meshes: () => InstancedMesh[]
+  clicks: any[]
+  sounds: string[]
+}
+
+async function withMountedBrackets(run: (harness: BracketHarness) => Promise<void>) {
   const previousScene = useScene.getState()
   const previousViewer = useViewer.getState()
   const previousEditor = useEditor.getState()
@@ -104,12 +117,8 @@ test('mounted brackets preserve hover, clicks, drags, capture visibility, overri
         preventDefault() {},
       } as unknown as PointerEvent
     }
-    const dispatch = async (
-      name: 'onPointerMove' | 'onPointerDown' | 'onClick' | 'onPointerLeave',
-      x: number,
-      z: number,
-    ) => {
-      levelObject.updateMatrixWorld(true)
+    const dispatch = async (name: PointerHandler, x: number, z: number) => {
+      sceneRegistry.nodes.get(level.id)?.updateMatrixWorld(true)
       await act(async () => state().events.handlers![name](eventAt(x, z)))
     }
     const dispatchWindow = async (type: string, x: number, z: number) => {
@@ -124,113 +133,17 @@ test('mounted brackets preserve hover, clicks, drags, capture visibility, overri
       })
     }
     const meshes = () => state().internal.interaction as InstancedMesh[]
-    expect(meshes()).toHaveLength(2)
-    expect(meshes().every((mesh) => mesh instanceof InstancedMesh)).toBe(true)
-    expect(meshes().reduce((sum, mesh) => sum + mesh.count, 0)).toBe(12)
-    expect(meshes()[0]!.parent!.parent).toBe(levelObject)
-    await dispatch('onPointerDown', 0, 0)
-    await dispatch('onPointerMove', 0, 0)
-    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
-    expect(meshes().find((mesh) => mesh.renderOrder === 1001)!.count).toBe(7)
-    await dispatch('onPointerMove', 0, 0)
-    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
-    await dispatch('onClick', 0, 0)
-    expect(clicks).toHaveLength(1)
-    expect(clicks[0]).toMatchObject({ viaHandle: true, node: ceiling, position: [0, 3, 0] })
-    await dispatch('onClick', 4, 0)
-    expect(clicks).toHaveLength(1)
-    await dispatch('onPointerMove', 4, 0)
-    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
-    await dispatch('onPointerDown', 4, 0)
-
-    const oldNormal = meshes().find((mesh) => mesh.renderOrder === 1000)
-    await act(async () => {
-      const additions = Array.from({ length: 8 }, (_, index) =>
-        CeilingNode.parse({
-          ...ceiling,
-          id: undefined,
-          polygon: [
-            [10 + index * 5, 0],
-            [14 + index * 5, 0],
-            [14 + index * 5, 4],
-            [10 + index * 5, 4],
-          ],
-        }),
-      )
-      useScene.setState({
-        nodes: {
-          ...useScene.getState().nodes,
-          ...Object.fromEntries(additions.map((node) => [node.id, node])),
-        },
-      })
+    await run({
+      ceiling,
+      level,
+      levelObject,
+      state,
+      dispatch,
+      dispatchWindow,
+      meshes,
+      clicks,
+      sounds,
     })
-    expect(meshes()).toHaveLength(2)
-    expect(meshes().find((mesh) => mesh.renderOrder === 1000)).not.toBe(oldNormal)
-    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
-    await dispatch('onClick', 4, 0)
-    expect(clicks).toHaveLength(2)
-    expect(clicks[1].position).toEqual([4, 3, 0])
-    await dispatch('onPointerLeave', 4, 0)
-    expect(useViewer.getState().hoveredId).toBeNull()
-
-    const bracketRoot = meshes()[0]!.parent!
-    emitter.emit('thumbnail:before-capture')
-    expect(bracketRoot.visible).toBe(false)
-    emitter.emit('thumbnail:after-capture')
-    expect(bracketRoot.visible).toBe(true)
-    await act(async () =>
-      useLiveNodeOverrides.getState().set(ceiling.id, {
-        height: 5,
-        polygon: [
-          [1, 1],
-          [4, 0],
-          [4, 4],
-          [0, 4],
-        ],
-      }),
-    )
-    await dispatch('onPointerMove', 1, 1)
-    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
-    await dispatch('onPointerDown', 1, 1)
-    await dispatch('onClick', 1, 1)
-    expect(clicks[2].position).toEqual([1, 5, 1])
-    await dispatchWindow('pointerup', 1, 1)
-    await act(async () => useLiveNodeOverrides.getState().clear(ceiling.id))
-    await dispatch('onPointerDown', 0, 0)
-    const initialInputDragging = useViewer.getState().inputDragging
-    await dispatchWindow('pointermove', 3 / (1000 / 6), 0)
-    expect(sounds).not.toContain('sfx:item-pick')
-    await dispatchWindow('pointermove', 0.5, 0.5)
-    expect(useViewer.getState().inputDragging).toBe(true)
-    expect(sounds).toContain('sfx:item-pick')
-    expect(useLiveNodeOverrides.getState().overrides.get(ceiling.id)?.polygon).not.toEqual(
-      ceiling.polygon,
-    )
-    expect(useScene.getState().nodes[ceiling.id]).toEqual(ceiling)
-    await dispatchWindow('pointercancel', 0.5, 0.5)
-    expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
-    expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
-    expect(useScene.getState().nodes[ceiling.id]).toEqual(ceiling)
-    await dispatch('onPointerDown', 0, 0)
-    await dispatchWindow('pointermove', 0.5, 0.5)
-    const preview = useLiveNodeOverrides.getState().overrides.get(ceiling.id)
-      ?.polygon as CeilingNode['polygon']
-    expect(preview).toBeDefined()
-    await dispatchWindow('pointerup', 0.5, 0.5)
-    expect((useScene.getState().nodes[ceiling.id] as CeilingNode).polygon).toEqual(preview)
-    expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
-    expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
-    expect(sounds).toContain('sfx:item-place')
-    const corner = preview[0]!
-    await dispatch('onPointerDown', corner[0], corner[1])
-    await dispatchWindow('pointermove', corner[0] + 0.5, corner[1] + 0.5)
-    expect(useViewer.getState().inputDragging).toBe(true)
-    await act(async () => useEditor.setState({ mode: 'build' }))
-    expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
-    expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
-    expect(state().internal.interaction).toHaveLength(0)
-    expect(levelObject.children).toHaveLength(0)
-    expect(useViewer.getState().hoveredId).toBeNull()
   } finally {
     await act(async () => root.render(null))
     clearBoxSelectHandled()
@@ -248,4 +161,187 @@ test('mounted brackets preserve hover, clicks, drags, capture visibility, overri
     globalThis.window = previousWindow
     actGlobal.IS_REACT_ACT_ENVIRONMENT = previousAct
   }
+}
+
+test('mounted brackets preserve hover, clicks, drags, capture visibility, overrides, and unmounting', async () => {
+  await withMountedBrackets(
+    async ({ ceiling, levelObject, state, dispatch, dispatchWindow, meshes, clicks, sounds }) => {
+      expect(meshes()).toHaveLength(2)
+      expect(meshes().every((mesh) => mesh instanceof InstancedMesh)).toBe(true)
+      expect(meshes().reduce((sum, mesh) => sum + mesh.count, 0)).toBe(12)
+      expect(meshes()[0]!.parent!.parent).toBe(levelObject)
+      await dispatch('onPointerDown', 0, 0)
+      await dispatch('onPointerMove', 0, 0)
+      expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+      expect(meshes().find((mesh) => mesh.renderOrder === 1001)!.count).toBe(7)
+      await dispatch('onPointerMove', 0, 0)
+      expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+      await dispatch('onClick', 0, 0)
+      expect(clicks).toHaveLength(1)
+      expect(clicks[0]).toMatchObject({ viaHandle: true, node: ceiling, position: [0, 3, 0] })
+      await dispatch('onClick', 4, 0)
+      expect(clicks).toHaveLength(1)
+      await dispatch('onPointerMove', 4, 0)
+      expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+      await dispatch('onPointerDown', 4, 0)
+
+      const oldNormal = meshes().find((mesh) => mesh.renderOrder === 1000)
+      await act(async () => {
+        const additions = Array.from({ length: 8 }, (_, index) =>
+          CeilingNode.parse({
+            ...ceiling,
+            id: undefined,
+            polygon: [
+              [10 + index * 5, 0],
+              [14 + index * 5, 0],
+              [14 + index * 5, 4],
+              [10 + index * 5, 4],
+            ],
+          }),
+        )
+        useScene.setState({
+          nodes: {
+            ...useScene.getState().nodes,
+            ...Object.fromEntries(additions.map((node) => [node.id, node])),
+          },
+        })
+      })
+      expect(meshes()).toHaveLength(2)
+      expect(meshes().find((mesh) => mesh.renderOrder === 1000)).not.toBe(oldNormal)
+      expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+      await dispatch('onClick', 4, 0)
+      expect(clicks).toHaveLength(2)
+      expect(clicks[1].position).toEqual([4, 3, 0])
+      await dispatch('onPointerLeave', 4, 0)
+      expect(useViewer.getState().hoveredId).toBeNull()
+
+      const bracketRoot = meshes()[0]!.parent!
+      emitter.emit('thumbnail:before-capture')
+      expect(bracketRoot.visible).toBe(false)
+      emitter.emit('thumbnail:after-capture')
+      expect(bracketRoot.visible).toBe(true)
+      await act(async () =>
+        useLiveNodeOverrides.getState().set(ceiling.id, {
+          height: 5,
+          polygon: [
+            [1, 1],
+            [4, 0],
+            [4, 4],
+            [0, 4],
+          ],
+        }),
+      )
+      await dispatch('onPointerMove', 1, 1)
+      expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+      await dispatch('onPointerDown', 1, 1)
+      await dispatch('onClick', 1, 1)
+      expect(clicks[2].position).toEqual([1, 5, 1])
+      await dispatchWindow('pointerup', 1, 1)
+      await act(async () => useLiveNodeOverrides.getState().clear(ceiling.id))
+      await dispatch('onPointerDown', 0, 0)
+      const initialInputDragging = useViewer.getState().inputDragging
+      await dispatchWindow('pointermove', 3 / (1000 / 6), 0)
+      expect(sounds).not.toContain('sfx:item-pick')
+      await dispatchWindow('pointermove', 0.5, 0.5)
+      expect(useViewer.getState().inputDragging).toBe(true)
+      expect(sounds).toContain('sfx:item-pick')
+      expect(useLiveNodeOverrides.getState().overrides.get(ceiling.id)?.polygon).not.toEqual(
+        ceiling.polygon,
+      )
+      expect(useScene.getState().nodes[ceiling.id]).toEqual(ceiling)
+      await dispatchWindow('pointercancel', 0.5, 0.5)
+      expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
+      expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
+      expect(useScene.getState().nodes[ceiling.id]).toEqual(ceiling)
+      await dispatch('onPointerDown', 0, 0)
+      await dispatchWindow('pointermove', 0.5, 0.5)
+      const preview = useLiveNodeOverrides.getState().overrides.get(ceiling.id)
+        ?.polygon as CeilingNode['polygon']
+      expect(preview).toBeDefined()
+      await dispatchWindow('pointerup', 0.5, 0.5)
+      expect((useScene.getState().nodes[ceiling.id] as CeilingNode).polygon).toEqual(preview)
+      expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
+      expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
+      expect(sounds).toContain('sfx:item-place')
+      const corner = preview[0]!
+      await dispatch('onPointerDown', corner[0], corner[1])
+      await dispatchWindow('pointermove', corner[0] + 0.5, corner[1] + 0.5)
+      expect(useViewer.getState().inputDragging).toBe(true)
+      await act(async () => useEditor.setState({ mode: 'build' }))
+      expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
+      expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
+      expect(state().internal.interaction).toHaveLength(0)
+      expect(levelObject.children).toHaveLength(0)
+      expect(useViewer.getState().hoveredId).toBeNull()
+    },
+  )
+})
+
+test('coincident ceiling corners keep the same hover, click, and drag owner across batch transfers', async () => {
+  await withMountedBrackets(async ({ ceiling, dispatch, dispatchWindow, meshes, clicks }) => {
+    const adjacent = CeilingNode.parse({
+      ...ceiling,
+      id: undefined,
+      polygon: [
+        [0, 0],
+        [-4, 0],
+        [-4, -4],
+        [0, -4],
+      ],
+    })
+    await act(async () =>
+      useScene.setState({
+        nodes: { ...useScene.getState().nodes, [adjacent.id]: adjacent },
+      }),
+    )
+    const owner = ceiling.id < adjacent.id ? ceiling : adjacent
+    const other = owner === ceiling ? adjacent : ceiling
+    for (let move = 0; move < 20; move++) {
+      await dispatch('onPointerMove', 0, 0)
+      expect(useViewer.getState().hoveredId).toBe(owner.id)
+      expect(meshes().find((mesh) => mesh.renderOrder === 1001)!.count).toBe(7)
+    }
+    await dispatch('onPointerDown', 0, 0)
+    await dispatch('onClick', 0, 0)
+    expect(clicks[0].node.id).toBe(owner.id)
+    await dispatchWindow('pointermove', 0.5, 0.5)
+    expect(useLiveNodeOverrides.getState().overrides.has(owner.id)).toBe(true)
+    expect(useLiveNodeOverrides.getState().overrides.has(other.id)).toBe(false)
+    await dispatchWindow('pointercancel', 0.5, 0.5)
+    await dispatch('onPointerLeave', 0, 0)
+    expect(useViewer.getState().hoveredId).toBeNull()
+  })
+})
+
+test('same-id registry replacement rebinds the portal and drag plane without rewriting instance data', async () => {
+  await withMountedBrackets(
+    async ({ ceiling, level, levelObject, state, dispatch, dispatchWindow, meshes, clicks }) => {
+      const initialMeshes = [...meshes()]
+      const geometries = initialMeshes.map((mesh) => mesh.geometry)
+      const versions = initialMeshes.map((mesh) => mesh.instanceMatrix.version)
+      const replacement = new Group()
+      replacement.position.set(10, 0, 20)
+      replacement.rotation.y = Math.PI / 2
+      sceneRegistry.nodes.set(level.id, replacement)
+      await act(async () => state().advance(1))
+      expect(levelObject.children).toHaveLength(0)
+      expect(replacement.children).toHaveLength(1)
+      expect(meshes()).toEqual(initialMeshes)
+      expect(meshes().map((mesh) => mesh.geometry)).toEqual(geometries)
+      expect(meshes().map((mesh) => mesh.instanceMatrix.version)).toEqual(versions)
+      for (let frame = 2; frame < 6; frame++) {
+        await act(async () => state().advance(frame))
+      }
+      expect(meshes().map((mesh) => mesh.instanceMatrix.version)).toEqual(versions)
+      await dispatch('onPointerDown', 10, 20)
+      await dispatch('onClick', 10, 20)
+      expect(clicks[0].position).toEqual([0, 3, 0])
+      await dispatchWindow('pointermove', 10.5, 20)
+      const preview = useLiveNodeOverrides.getState().overrides.get(ceiling.id)
+        ?.polygon as CeilingNode['polygon']
+      expect(preview[0]![0]).toBeCloseTo(0, 6)
+      expect(preview[0]![1]).toBeCloseTo(0.5, 6)
+      await dispatchWindow('pointercancel', 10.5, 20)
+    },
+  )
 })

--- a/packages/editor/src/components/systems/ceiling/ceiling-selection-affordance-system.test.ts
+++ b/packages/editor/src/components/systems/ceiling/ceiling-selection-affordance-system.test.ts
@@ -1,0 +1,251 @@
+import { expect, test } from 'bun:test'
+import {
+  BuildingNode,
+  CeilingNode,
+  emitter,
+  LevelNode,
+  sceneRegistry,
+  useLiveNodeOverrides,
+  useScene,
+} from '@pascal-app/core'
+import { useViewer } from '@pascal-app/viewer'
+import { _roots, act, createRoot, events, extend } from '@react-three/fiber'
+import { createElement } from 'react'
+import { Group, InstancedMesh, OrthographicCamera, Vector3, type WebGLRenderer } from 'three'
+import { sfxEmitter } from '../../../lib/sfx-bus'
+import useEditor from '../../../store/use-editor'
+import useInteractionScope from '../../../store/use-interaction-scope'
+import { clearBoxSelectHandled } from '../../tools/select/box-select-state'
+import { CeilingSelectionAffordanceSystem } from './ceiling-selection-affordance-system'
+
+extend({ Group })
+
+test('mounted brackets preserve hover, clicks, drags, capture visibility, overrides, and unmounting', async () => {
+  const previousScene = useScene.getState()
+  const previousViewer = useViewer.getState()
+  const previousEditor = useEditor.getState()
+  const previousScope = useInteractionScope.getState()
+  const previousOverrides = useLiveNodeOverrides.getState()
+  const previousWindow = globalThis.window
+  const previousRaf = globalThis.requestAnimationFrame
+  const frames: FrameRequestCallback[] = []
+  globalThis.requestAnimationFrame = (callback) => frames.push(callback)
+  const actGlobal = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  const previousAct = actGlobal.IS_REACT_ACT_ENVIRONMENT
+  actGlobal.IS_REACT_ACT_ENVIRONMENT = true
+  globalThis.window = new EventTarget() as Window & typeof globalThis
+  const canvas = Object.assign(new EventTarget(), {
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 1000, height: 1000 }),
+  }) as unknown as HTMLCanvasElement
+  const root = createRoot(canvas)
+  const building = BuildingNode.parse({})
+  const level = LevelNode.parse({ parentId: building.id, height: 3 })
+  const ceiling = CeilingNode.parse({
+    parentId: level.id,
+    height: 3,
+    polygon: [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+      [0, 4],
+    ],
+  })
+  const levelObject = new Group()
+  sceneRegistry.nodes.set(level.id, levelObject)
+  const clicks: any[] = []
+  const onClick = (event: unknown) => clicks.push(event)
+  emitter.on('ceiling:click', onClick)
+  const sounds: string[] = []
+  const onSound = (type: string) => {
+    sounds.push(type)
+  }
+  sfxEmitter.on('*', onSound)
+  try {
+    useScene.setState({
+      nodes: { [building.id]: building, [level.id]: level, [ceiling.id]: ceiling },
+    })
+    useViewer.setState({
+      hoveredId: null,
+      selection: { buildingId: building.id, levelId: level.id, zoneId: null, selectedIds: [] },
+    })
+    useEditor.setState({ phase: 'structure', mode: 'select', structureLayer: 'elements' })
+    useInteractionScope.setState({ scope: { kind: 'idle' } })
+    const camera = Object.assign(new OrthographicCamera(-1, 5, 5, -1, 0.1, 100), { manual: true })
+    camera.position.set(0, 10, 0)
+    camera.up.set(0, 0, -1)
+    camera.lookAt(0, 0, 0)
+    camera.updateMatrixWorld(true)
+    await root.configure({
+      gl: {
+        domElement: canvas,
+        render() {},
+        setSize() {},
+        setPixelRatio() {},
+      } as unknown as WebGLRenderer,
+      camera,
+      events,
+      frameloop: 'never',
+      dpr: 1,
+      size: { width: 1000, height: 1000, top: 0, left: 0 },
+    })
+    await act(async () => root.render(createElement(CeilingSelectionAffordanceSystem)))
+    const state = () => _roots.get(canvas)!.store.getState()
+    const eventAt = (x: number, z: number) => {
+      const point = new Vector3(x, 3, z).project(camera)
+      return {
+        target: canvas,
+        pointerId: 1,
+        button: 0,
+        offsetX: (point.x + 1) * 500,
+        offsetY: (1 - point.y) * 500,
+        clientX: (point.x + 1) * 500,
+        clientY: (1 - point.y) * 500,
+        stopPropagation() {},
+        preventDefault() {},
+      } as unknown as PointerEvent
+    }
+    const dispatch = async (
+      name: 'onPointerMove' | 'onPointerDown' | 'onClick' | 'onPointerLeave',
+      x: number,
+      z: number,
+    ) => {
+      levelObject.updateMatrixWorld(true)
+      await act(async () => state().events.handlers![name](eventAt(x, z)))
+    }
+    const dispatchWindow = async (type: string, x: number, z: number) => {
+      const point = eventAt(x, z)
+      const event = Object.assign(new Event(type, { cancelable: true }), {
+        pointerId: 1,
+        clientX: point.clientX,
+        clientY: point.clientY,
+      })
+      await act(async () => {
+        window.dispatchEvent(event)
+      })
+    }
+    const meshes = () => state().internal.interaction as InstancedMesh[]
+    expect(meshes()).toHaveLength(2)
+    expect(meshes().every((mesh) => mesh instanceof InstancedMesh)).toBe(true)
+    expect(meshes().reduce((sum, mesh) => sum + mesh.count, 0)).toBe(12)
+    expect(meshes()[0]!.parent!.parent).toBe(levelObject)
+    await dispatch('onPointerDown', 0, 0)
+    await dispatch('onPointerMove', 0, 0)
+    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+    expect(meshes().find((mesh) => mesh.renderOrder === 1001)!.count).toBe(7)
+    await dispatch('onPointerMove', 0, 0)
+    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+    await dispatch('onClick', 0, 0)
+    expect(clicks).toHaveLength(1)
+    expect(clicks[0]).toMatchObject({ viaHandle: true, node: ceiling, position: [0, 3, 0] })
+    await dispatch('onClick', 4, 0)
+    expect(clicks).toHaveLength(1)
+    await dispatch('onPointerMove', 4, 0)
+    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+    await dispatch('onPointerDown', 4, 0)
+
+    const oldNormal = meshes().find((mesh) => mesh.renderOrder === 1000)
+    await act(async () => {
+      const additions = Array.from({ length: 8 }, (_, index) =>
+        CeilingNode.parse({
+          ...ceiling,
+          id: undefined,
+          polygon: [
+            [10 + index * 5, 0],
+            [14 + index * 5, 0],
+            [14 + index * 5, 4],
+            [10 + index * 5, 4],
+          ],
+        }),
+      )
+      useScene.setState({
+        nodes: {
+          ...useScene.getState().nodes,
+          ...Object.fromEntries(additions.map((node) => [node.id, node])),
+        },
+      })
+    })
+    expect(meshes()).toHaveLength(2)
+    expect(meshes().find((mesh) => mesh.renderOrder === 1000)).not.toBe(oldNormal)
+    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+    await dispatch('onClick', 4, 0)
+    expect(clicks).toHaveLength(2)
+    expect(clicks[1].position).toEqual([4, 3, 0])
+    await dispatch('onPointerLeave', 4, 0)
+    expect(useViewer.getState().hoveredId).toBeNull()
+
+    const bracketRoot = meshes()[0]!.parent!
+    emitter.emit('thumbnail:before-capture')
+    expect(bracketRoot.visible).toBe(false)
+    emitter.emit('thumbnail:after-capture')
+    expect(bracketRoot.visible).toBe(true)
+    await act(async () =>
+      useLiveNodeOverrides.getState().set(ceiling.id, {
+        height: 5,
+        polygon: [
+          [1, 1],
+          [4, 0],
+          [4, 4],
+          [0, 4],
+        ],
+      }),
+    )
+    await dispatch('onPointerMove', 1, 1)
+    expect(useViewer.getState().hoveredId).toBe(ceiling.id)
+    await dispatch('onPointerDown', 1, 1)
+    await dispatch('onClick', 1, 1)
+    expect(clicks[2].position).toEqual([1, 5, 1])
+    await dispatchWindow('pointerup', 1, 1)
+    await act(async () => useLiveNodeOverrides.getState().clear(ceiling.id))
+    await dispatch('onPointerDown', 0, 0)
+    const initialInputDragging = useViewer.getState().inputDragging
+    await dispatchWindow('pointermove', 3 / (1000 / 6), 0)
+    expect(sounds).not.toContain('sfx:item-pick')
+    await dispatchWindow('pointermove', 0.5, 0.5)
+    expect(useViewer.getState().inputDragging).toBe(true)
+    expect(sounds).toContain('sfx:item-pick')
+    expect(useLiveNodeOverrides.getState().overrides.get(ceiling.id)?.polygon).not.toEqual(
+      ceiling.polygon,
+    )
+    expect(useScene.getState().nodes[ceiling.id]).toEqual(ceiling)
+    await dispatchWindow('pointercancel', 0.5, 0.5)
+    expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
+    expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
+    expect(useScene.getState().nodes[ceiling.id]).toEqual(ceiling)
+    await dispatch('onPointerDown', 0, 0)
+    await dispatchWindow('pointermove', 0.5, 0.5)
+    const preview = useLiveNodeOverrides.getState().overrides.get(ceiling.id)
+      ?.polygon as CeilingNode['polygon']
+    expect(preview).toBeDefined()
+    await dispatchWindow('pointerup', 0.5, 0.5)
+    expect((useScene.getState().nodes[ceiling.id] as CeilingNode).polygon).toEqual(preview)
+    expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
+    expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
+    expect(sounds).toContain('sfx:item-place')
+    const corner = preview[0]!
+    await dispatch('onPointerDown', corner[0], corner[1])
+    await dispatchWindow('pointermove', corner[0] + 0.5, corner[1] + 0.5)
+    expect(useViewer.getState().inputDragging).toBe(true)
+    await act(async () => useEditor.setState({ mode: 'build' }))
+    expect(useLiveNodeOverrides.getState().overrides.has(ceiling.id)).toBe(false)
+    expect(useViewer.getState().inputDragging).toBe(initialInputDragging)
+    expect(state().internal.interaction).toHaveLength(0)
+    expect(levelObject.children).toHaveLength(0)
+    expect(useViewer.getState().hoveredId).toBeNull()
+  } finally {
+    await act(async () => root.render(null))
+    clearBoxSelectHandled()
+    emitter.off('ceiling:click', onClick)
+    sfxEmitter.off('*', onSound)
+    for (const frame of frames) frame(0)
+    globalThis.requestAnimationFrame = previousRaf
+    sceneRegistry.nodes.delete(level.id)
+    _roots.delete(canvas)
+    useScene.setState(previousScene)
+    useViewer.setState(previousViewer)
+    useEditor.setState(previousEditor)
+    useInteractionScope.setState(previousScope)
+    useLiveNodeOverrides.setState(previousOverrides)
+    globalThis.window = previousWindow
+    actGlobal.IS_REACT_ACT_ENVIRONMENT = previousAct
+  }
+})

--- a/packages/editor/src/components/systems/ceiling/ceiling-selection-affordance-system.tsx
+++ b/packages/editor/src/components/systems/ceiling/ceiling-selection-affordance-system.tsx
@@ -11,7 +11,7 @@ import {
   useScene,
 } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
-import { createPortal, type ThreeEvent, useThree } from '@react-three/fiber'
+import { createPortal, type ThreeEvent, useFrame, useThree } from '@react-three/fiber'
 import {
   memo,
   useCallback,
@@ -22,7 +22,7 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react'
-import { type Group, type Object3D, Plane, Raycaster, Vector2, Vector3 } from 'three'
+import { Group, type Object3D, Plane, Raycaster, Vector2, Vector3 } from 'three'
 import { useShallow } from 'zustand/react/shallow'
 import {
   clearCeilingSnapFeedback,
@@ -143,7 +143,23 @@ const LevelCeilingBrackets = ({
   const [levelObject, setLevelObject] = useState<Object3D | null>(
     () => sceneRegistry.nodes.get(levelId) ?? null,
   )
-  const bracketsRootRef = useRef<Group>(null)
+  // A stable portal container preserves instance event records when the level object changes.
+  const [bracketsRoot] = useState(() => new Group())
+  const registryRevision = useRef(sceneRegistry.revision)
+
+  useFrame(() => {
+    if (registryRevision.current === sceneRegistry.revision) return
+    registryRevision.current = sceneRegistry.revision
+    setLevelObject(sceneRegistry.nodes.get(levelId) ?? null)
+  })
+
+  useLayoutEffect(() => {
+    if (!levelObject) return
+    levelObject.add(bracketsRoot)
+    return () => {
+      bracketsRoot.removeFromParent()
+    }
+  }, [bracketsRoot, levelObject])
 
   // The brackets render on SCENE_LAYER (scene-depth occlusion), so unlike
   // EDITOR_LAYER affordances the thumbnail camera can't filter them — hide
@@ -151,10 +167,10 @@ const LevelCeilingBrackets = ({
   // capture renders right after the emit), same as `site-boundary-editor.tsx`.
   useEffect(() => {
     const hideForCapture = () => {
-      if (bracketsRootRef.current) bracketsRootRef.current.visible = false
+      bracketsRoot.visible = false
     }
     const restoreAfterCapture = () => {
-      if (bracketsRootRef.current) bracketsRootRef.current.visible = true
+      bracketsRoot.visible = true
     }
     emitter.on('thumbnail:before-capture', hideForCapture)
     emitter.on('thumbnail:after-capture', restoreAfterCapture)
@@ -162,7 +178,7 @@ const LevelCeilingBrackets = ({
       emitter.off('thumbnail:before-capture', hideForCapture)
       emitter.off('thumbnail:after-capture', restoreAfterCapture)
     }
-  }, [])
+  }, [bracketsRoot])
 
   useEffect(() => {
     let frameId = 0
@@ -200,16 +216,13 @@ const LevelCeilingBrackets = ({
           controllers={controllers}
           key={ceiling.id}
           levelId={levelId}
-          levelObject={levelObject}
           store={store}
         />
       ))}
       {levelObject &&
         createPortal(
-          <group ref={bracketsRootRef}>
-            <CeilingBracketMeshes controllers={controllers} store={store} />
-          </group>,
-          levelObject,
+          <CeilingBracketMeshes controllers={controllers} store={store} />,
+          bracketsRoot,
         )}
     </>
   )
@@ -236,6 +249,15 @@ const CeilingBracketMeshes = memo(
       previousMeshes.current = meshes
     }, [meshes, pointer])
 
+    useLayoutEffect(
+      () => () => {
+        for (const target of pointer.clearHover()) {
+          controllers.get(target.ceilingId)?.onHoverChange(target.cornerIndex, false)
+        }
+      },
+      [controllers, pointer],
+    )
+
     const hover = (target: BracketTarget, hovered: boolean) => {
       controllers.get(target.ceilingId)?.onHoverChange(target.cornerIndex, hovered)
     }
@@ -243,7 +265,7 @@ const CeilingBracketMeshes = memo(
       `${event.object.uuid}/${event.index}/${event.instanceId}`
     const handleOver = (event: ThreeEvent<PointerEvent>) => {
       event.stopPropagation()
-      const target = store.getTarget(event.object, event.instanceId)
+      const target = store.resolveHitTarget(event, event.intersections)
       if (!target) return
       const previous = pointer.over(eventKey(event), target)
       if (previous && bracketTargetKey(previous) === bracketTargetKey(target)) return
@@ -256,7 +278,7 @@ const CeilingBracketMeshes = memo(
       if (target) hover(target, false)
     }
     const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
-      const target = store.getTarget(event.object, event.instanceId)
+      const target = store.resolveHitTarget(event, event.intersections)
       if (!target) return
       pointer.pointerDown(
         event.intersections.flatMap((hit) => {
@@ -275,7 +297,7 @@ const CeilingBracketMeshes = memo(
       controllers.get(target.ceilingId)?.onPointerDown(target.cornerIndex, event)
     }
     const handleClick = (event: ThreeEvent<MouseEvent>) => {
-      const target = store.getTarget(event.object, event.instanceId)
+      const target = store.resolveHitTarget(event, event.intersections)
       if (!target || !pointer.canClick(target)) return
       controllers.get(target.ceilingId)?.onClick(target.cornerIndex, event)
     }
@@ -302,13 +324,11 @@ const CeilingBracketMeshes = memo(
 const CeilingSelectionAffordance = memo(function CeilingSelectionAffordance({
   ceiling,
   levelId,
-  levelObject,
   store,
   controllers,
 }: {
   ceiling: CeilingNode
   levelId: string
-  levelObject: Object3D | null
   store: CeilingBracketBatchStore
   controllers: Map<CeilingNode['id'], CeilingBracketController>
 }) {
@@ -364,6 +384,7 @@ const CeilingSelectionAffordance = memo(function CeilingSelectionAffordance({
 
   const getHandlePlanePoint = useCallback(
     (event: MouseEvent | PointerEvent): [number, number] | null => {
+      const levelObject = sceneRegistry.nodes.get(levelId)
       if (!levelObject) return null
 
       const rect = gl.domElement.getBoundingClientRect()
@@ -390,7 +411,7 @@ const CeilingSelectionAffordance = memo(function CeilingSelectionAffordance({
       levelObject.worldToLocal(localIntersectionRef.current)
       return [localIntersectionRef.current.x, localIntersectionRef.current.z]
     },
-    [camera, resolvedHeight, gl.domElement, levelObject],
+    [camera, resolvedHeight, gl.domElement, levelId],
   )
 
   const handleCornerPointerDown = useCallback(
@@ -592,6 +613,7 @@ const CeilingSelectionAffordance = memo(function CeilingSelectionAffordance({
           node: effectiveCeiling,
           nativeEvent: event.nativeEvent,
           localPosition: [0, 0, 0],
+          // Position is level-local, matching the original ceiling handle payload.
           position: [
             corner.corner[0],
             resolveCeilingHeight(effectiveCeiling, useScene.getState().nodes),

--- a/packages/editor/src/components/systems/ceiling/ceiling-selection-affordance-system.tsx
+++ b/packages/editor/src/components/systems/ceiling/ceiling-selection-affordance-system.tsx
@@ -12,8 +12,17 @@ import {
 } from '@pascal-app/core'
 import { useViewer } from '@pascal-app/viewer'
 import { createPortal, type ThreeEvent, useThree } from '@react-three/fiber'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { BoxGeometry, type Group, type Object3D, Plane, Raycaster, Vector2, Vector3 } from 'three'
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
+import { type Group, type Object3D, Plane, Raycaster, Vector2, Vector3 } from 'three'
 import { useShallow } from 'zustand/react/shallow'
 import {
   clearCeilingSnapFeedback,
@@ -23,31 +32,22 @@ import { sfxEmitter } from '../../../lib/sfx-bus'
 import useEditor, { isGridSnapActive } from '../../../store/use-editor'
 import useInteractionScope from '../../../store/use-interaction-scope'
 import { suppressBoxSelectForPointer } from '../../tools/select/box-select-state'
+import {
+  BRACKET_Y_OFFSET,
+  BracketPointerState,
+  type BracketTarget,
+  bracketTargetKey,
+  buildCornerBrackets,
+  CeilingBracketBatchStore,
+  type CornerBracketData,
+} from './ceiling-bracket-batch'
 
-const BRACKET_THICKNESS = 0.04
-const BRACKET_HEIGHT = 0.04
-const BRACKET_Y_OFFSET = 0.035
-const HIT_BOX_SIZE: [number, number, number] = [0.28, 0.08, 0.28]
-const HANDLE_COLOR = '#d4d4d4'
-const HANDLE_HOVER_COLOR = '#818cf8'
-const HANDLE_OPACITY = 0.72
-const HANDLE_HOVER_OPACITY = 0.92
 const HANDLE_DRAG_THRESHOLD_PX = 4
-const SHARED_HANDLE_BOX_GEOMETRY = new BoxGeometry(1, 1, 1)
-// Draw the corner handles after the ceiling surface so they read cleanly
-// when unobstructed, while material depth testing still lets other scene
-// geometry hide them.
-const CORNER_RENDER_ORDER = 1000
 
-type CornerBracketData = {
-  corner: [number, number]
-  index: number
-  incomingEdgeIndex: number
-  incomingDirection: [number, number]
-  outgoingEdgeIndex: number
-  outgoingDirection: [number, number]
-  incomingLength: number
-  outgoingLength: number
+type CeilingBracketController = {
+  onHoverChange: (cornerIndex: number, hovered: boolean) => void
+  onPointerDown: (cornerIndex: number, event: ThreeEvent<PointerEvent>) => void
+  onClick: (cornerIndex: number, event: ThreeEvent<MouseEvent>) => void
 }
 
 type CornerDragState = {
@@ -128,23 +128,191 @@ export const CeilingSelectionAffordanceSystem = () => {
 
   if (!shouldRender) return null
 
+  return <LevelCeilingBrackets ceilings={ceilings} key={currentLevelId} levelId={currentLevelId} />
+}
+
+const LevelCeilingBrackets = ({
+  ceilings,
+  levelId,
+}: {
+  ceilings: CeilingNode[]
+  levelId: string
+}) => {
+  const [store] = useState(() => new CeilingBracketBatchStore())
+  const [controllers] = useState(() => new Map<CeilingNode['id'], CeilingBracketController>())
+  const [levelObject, setLevelObject] = useState<Object3D | null>(
+    () => sceneRegistry.nodes.get(levelId) ?? null,
+  )
+  const bracketsRootRef = useRef<Group>(null)
+
+  // The brackets render on SCENE_LAYER (scene-depth occlusion), so unlike
+  // EDITOR_LAYER affordances the thumbnail camera can't filter them — hide
+  // them around captures via synchronous Object3D.visible mutation (the
+  // capture renders right after the emit), same as `site-boundary-editor.tsx`.
+  useEffect(() => {
+    const hideForCapture = () => {
+      if (bracketsRootRef.current) bracketsRootRef.current.visible = false
+    }
+    const restoreAfterCapture = () => {
+      if (bracketsRootRef.current) bracketsRootRef.current.visible = true
+    }
+    emitter.on('thumbnail:before-capture', hideForCapture)
+    emitter.on('thumbnail:after-capture', restoreAfterCapture)
+    return () => {
+      emitter.off('thumbnail:before-capture', hideForCapture)
+      emitter.off('thumbnail:after-capture', restoreAfterCapture)
+    }
+  }, [])
+
+  useEffect(() => {
+    let frameId = 0
+
+    const resolveLevelObject = () => {
+      const nextLevelObject = sceneRegistry.nodes.get(levelId) ?? null
+      setLevelObject((currentLevelObject) => {
+        if (currentLevelObject === nextLevelObject) {
+          return currentLevelObject
+        }
+        return nextLevelObject
+      })
+
+      if (!nextLevelObject) {
+        frameId = window.requestAnimationFrame(resolveLevelObject)
+      }
+    }
+
+    resolveLevelObject()
+
+    return () => {
+      if (frameId) {
+        window.cancelAnimationFrame(frameId)
+      }
+    }
+  }, [levelId])
+
+  useEffect(() => () => store.dispose(), [store])
+
   return (
     <>
       {ceilings.map((ceiling) => (
-        <CeilingSelectionAffordance ceiling={ceiling} key={ceiling.id} levelId={currentLevelId} />
+        <CeilingSelectionAffordance
+          ceiling={ceiling}
+          controllers={controllers}
+          key={ceiling.id}
+          levelId={levelId}
+          levelObject={levelObject}
+          store={store}
+        />
       ))}
+      {levelObject &&
+        createPortal(
+          <group ref={bracketsRootRef}>
+            <CeilingBracketMeshes controllers={controllers} store={store} />
+          </group>,
+          levelObject,
+        )}
     </>
   )
 }
 
-const CeilingSelectionAffordance = ({
+const CeilingBracketMeshes = memo(
+  ({
+    store,
+    controllers,
+  }: {
+    store: CeilingBracketBatchStore
+    controllers: Map<CeilingNode['id'], CeilingBracketController>
+  }) => {
+    const get = useThree((state) => state.get)
+    const [pointer] = useState(() => new BracketPointerState())
+    const previousMeshes = useRef(store.getSnapshot())
+    const meshes = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot)
+
+    useLayoutEffect(() => {
+      for (const [index, previous] of previousMeshes.current.entries()) {
+        const next = meshes[index]!
+        if (previous !== next) pointer.replaceObject(previous.uuid, next.uuid)
+      }
+      previousMeshes.current = meshes
+    }, [meshes, pointer])
+
+    const hover = (target: BracketTarget, hovered: boolean) => {
+      controllers.get(target.ceilingId)?.onHoverChange(target.cornerIndex, hovered)
+    }
+    const eventKey = (event: ThreeEvent<PointerEvent>) =>
+      `${event.object.uuid}/${event.index}/${event.instanceId}`
+    const handleOver = (event: ThreeEvent<PointerEvent>) => {
+      event.stopPropagation()
+      const target = store.getTarget(event.object, event.instanceId)
+      if (!target) return
+      const previous = pointer.over(eventKey(event), target)
+      if (previous && bracketTargetKey(previous) === bracketTargetKey(target)) return
+      if (previous) hover(previous, false)
+      hover(target, true)
+    }
+    const handleOut = (event: ThreeEvent<PointerEvent>) => {
+      event.stopPropagation()
+      const target = pointer.out(eventKey(event))
+      if (target) hover(target, false)
+    }
+    const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
+      const target = store.getTarget(event.object, event.instanceId)
+      if (!target) return
+      pointer.pointerDown(
+        event.intersections.flatMap((hit) => {
+          const hitTarget = store.getTarget(hit.object, hit.instanceId)
+          return hitTarget ? [hitTarget] : []
+        }),
+      )
+      // R3F gates clicks by mesh, not instance. Allow transfers between highlight batches,
+      // then enforce the original per-part pointer-down targets in handleClick.
+      let root = get()
+      while (root.previousRoot) root = root.previousRoot.getState()
+      const initialHits = root.internal.initialHits
+      for (const mesh of meshes) {
+        if (!initialHits.includes(mesh)) initialHits.push(mesh)
+      }
+      controllers.get(target.ceilingId)?.onPointerDown(target.cornerIndex, event)
+    }
+    const handleClick = (event: ThreeEvent<MouseEvent>) => {
+      const target = store.getTarget(event.object, event.instanceId)
+      if (!target || !pointer.canClick(target)) return
+      controllers.get(target.ceilingId)?.onClick(target.cornerIndex, event)
+    }
+
+    return (
+      <>
+        {meshes.map((mesh) => (
+          <primitive
+            // Stable keys let R3F transfer hover and initial-hit records on capacity growth.
+            key={mesh.name}
+            object={mesh}
+            onClick={handleClick}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handleOver}
+            onPointerOut={handleOut}
+            onPointerOver={handleOver}
+          />
+        ))}
+      </>
+    )
+  },
+)
+
+const CeilingSelectionAffordance = memo(function CeilingSelectionAffordance({
   ceiling,
   levelId,
+  levelObject,
+  store,
+  controllers,
 }: {
   ceiling: CeilingNode
   levelId: string
-}) => {
-  const { camera, gl } = useThree()
+  levelObject: Object3D | null
+  store: CeilingBracketBatchStore
+  controllers: Map<CeilingNode['id'], CeilingBracketController>
+}) {
+  const { camera, gl, invalidate } = useThree()
   const liveOverride = useLiveNodeOverrides(
     (state) => state.overrides.get(ceiling.id) as Partial<CeilingNode> | undefined,
   )
@@ -155,14 +323,10 @@ const CeilingSelectionAffordance = ({
   // Explicit height when stored, else the live level-top bound the ceiling
   // follows (primitive selector — re-render-safe).
   const resolvedHeight = useScene((s) => resolveCeilingHeight(effectiveCeiling, s.nodes))
-  const [levelObject, setLevelObject] = useState<Object3D | null>(
-    () => sceneRegistry.nodes.get(levelId) ?? null,
-  )
   const [hoveredCornerIndex, setHoveredCornerIndex] = useState<number | null>(null)
   const [draggedCornerIndex, setDraggedCornerIndex] = useState<number | null>(null)
   const [previewPolygon, setPreviewPolygon] = useState<Array<[number, number]> | null>(null)
   const dragRef = useRef<CornerDragState | null>(null)
-  const bracketsRootRef = useRef<Group>(null)
   const raycasterRef = useRef(new Raycaster())
   const ndcRef = useRef(new Vector2())
   const planeRef = useRef(new Plane())
@@ -175,22 +339,6 @@ const CeilingSelectionAffordance = ({
   const displayPolygon = previewPolygon ?? effectiveCeiling.polygon
   const activeCornerIndex = draggedCornerIndex ?? hoveredCornerIndex
   const corners = useMemo(() => buildCornerBrackets(displayPolygon), [displayPolygon])
-  const highlightedEdgeIndices = useMemo(() => {
-    const next = new Set<number>()
-    if (activeCornerIndex === null || displayPolygon.length < 2) return next
-    next.add(activeCornerIndex)
-    next.add((activeCornerIndex - 1 + displayPolygon.length) % displayPolygon.length)
-    return next
-  }, [activeCornerIndex, displayPolygon.length])
-  const highlightedCornerIndices = useMemo(() => {
-    const next = new Set<number>()
-    if (activeCornerIndex === null || displayPolygon.length < 2) return next
-    next.add(activeCornerIndex)
-    next.add((activeCornerIndex - 1 + displayPolygon.length) % displayPolygon.length)
-    next.add((activeCornerIndex + 1) % displayPolygon.length)
-    return next
-  }, [activeCornerIndex, displayPolygon.length])
-
   useEffect(() => {
     if (activeCornerIndex === null) return
 
@@ -394,264 +542,70 @@ const CeilingSelectionAffordance = ({
     }
   }, [effectiveCeiling.id, getHandlePlanePoint, levelId, selectCeilingForEdit])
 
-  // The brackets render on SCENE_LAYER (scene-depth occlusion), so unlike
-  // EDITOR_LAYER affordances the thumbnail camera can't filter them — hide
-  // them around captures via synchronous Object3D.visible mutation (the
-  // capture renders right after the emit), same as `site-boundary-editor.tsx`.
-  useEffect(() => {
-    const hideForCapture = () => {
-      if (bracketsRootRef.current) bracketsRootRef.current.visible = false
-    }
-    const restoreAfterCapture = () => {
-      if (bracketsRootRef.current) bracketsRootRef.current.visible = true
-    }
-    emitter.on('thumbnail:before-capture', hideForCapture)
-    emitter.on('thumbnail:after-capture', restoreAfterCapture)
-    return () => {
-      emitter.off('thumbnail:before-capture', hideForCapture)
-      emitter.off('thumbnail:after-capture', restoreAfterCapture)
-    }
-  }, [])
+  useLayoutEffect(() => {
+    store.setGeometry(ceiling.id, corners, resolvedHeight)
+    invalidate()
+  }, [ceiling.id, corners, resolvedHeight, store, invalidate])
 
-  useEffect(() => {
-    let frameId = 0
+  useLayoutEffect(() => {
+    store.setHighlight(ceiling.id, activeCornerIndex)
+    invalidate()
+  }, [ceiling.id, activeCornerIndex, store, invalidate])
 
-    const resolveLevelObject = () => {
-      const nextLevelObject = sceneRegistry.nodes.get(levelId) ?? null
-      setLevelObject((currentLevelObject) => {
-        if (currentLevelObject === nextLevelObject) {
-          return currentLevelObject
-        }
-        return nextLevelObject
-      })
-
-      if (!nextLevelObject) {
-        frameId = window.requestAnimationFrame(resolveLevelObject)
-      }
-    }
-
-    resolveLevelObject()
-
-    return () => {
-      if (frameId) {
-        window.cancelAnimationFrame(frameId)
-      }
-    }
-  }, [levelId])
-
-  if (!levelObject || corners.length === 0) return null
-
-  return createPortal(
-    <group position={[0, resolvedHeight + BRACKET_Y_OFFSET, 0]} ref={bracketsRootRef}>
-      {corners.map((corner, index) => (
-        <CornerBracket
-          ceiling={effectiveCeiling}
-          corner={corner}
-          highlightIncoming={highlightedEdgeIndices.has(corner.incomingEdgeIndex)}
-          highlightOutgoing={highlightedEdgeIndices.has(corner.outgoingEdgeIndex)}
-          isHovered={activeCornerIndex === corner.index}
-          isLinkedHovered={
-            activeCornerIndex !== null &&
-            activeCornerIndex !== corner.index &&
-            highlightedCornerIndices.has(corner.index)
-          }
-          key={`${ceiling.id}-corner-${index}`}
-          onHoverChange={(hovered) => {
-            setHoveredCornerIndex((current) => {
-              if (hovered) return corner.index
-              return current === corner.index ? null : current
-            })
-          }}
-          onPointerDown={(event) => handleCornerPointerDown(corner, event)}
-        />
-      ))}
-    </group>,
-    levelObject,
+  useLayoutEffect(
+    () => () => {
+      store.removeCeiling(ceiling.id)
+      invalidate()
+    },
+    [ceiling.id, store, invalidate],
   )
-}
 
-const CornerBracket = ({
-  ceiling,
-  corner,
-  highlightIncoming,
-  highlightOutgoing,
-  isHovered,
-  isLinkedHovered,
-  onHoverChange,
-  onPointerDown,
-}: {
-  ceiling: CeilingNode
-  corner: CornerBracketData
-  highlightIncoming: boolean
-  highlightOutgoing: boolean
-  isHovered: boolean
-  isLinkedHovered: boolean
-  onHoverChange: (hovered: boolean) => void
-  onPointerDown: (event: ThreeEvent<PointerEvent>) => void
-}) => {
-  const cubeHighlighted = isHovered || isLinkedHovered
-  const cubeColor = cubeHighlighted ? HANDLE_HOVER_COLOR : HANDLE_COLOR
-  const cubeOpacity = cubeHighlighted ? HANDLE_HOVER_OPACITY : HANDLE_OPACITY
+  useLayoutEffect(() => {
+    controllers.set(ceiling.id, {
+      onHoverChange: (cornerIndex, hovered) => {
+        setHoveredCornerIndex((current) => {
+          if (hovered) return cornerIndex
+          return current === cornerIndex ? null : current
+        })
+      },
+      onPointerDown: (cornerIndex, event) => {
+        const corner = corners[cornerIndex]
+        if (corner) handleCornerPointerDown(corner, event)
+      },
+      onClick: (cornerIndex, event) => {
+        const corner = corners[cornerIndex]
+        if (!corner) return
+        event.stopPropagation()
+        useEditor.getState().setMovingNode(null)
+        useInteractionScope
+          .getState()
+          .endIf((sc) => sc.kind === 'reshaping' && sc.reshape === 'endpoint')
+        useInteractionScope
+          .getState()
+          .endIf((sc) => sc.kind === 'reshaping' && sc.reshape === 'curve')
+        useInteractionScope
+          .getState()
+          .endIf((sc) => sc.kind === 'reshaping' && sc.reshape === 'hole')
+        useEditor.getState().setMode('select')
 
-  const handleClick = (e: ThreeEvent<MouseEvent>) => {
-    e.stopPropagation()
-
-    useEditor.getState().setMovingNode(null)
-    useInteractionScope
-      .getState()
-      .endIf((sc) => sc.kind === 'reshaping' && sc.reshape === 'endpoint')
-    useInteractionScope.getState().endIf((sc) => sc.kind === 'reshaping' && sc.reshape === 'curve')
-    useInteractionScope.getState().endIf((sc) => sc.kind === 'reshaping' && sc.reshape === 'hole')
-    useEditor.getState().setMode('select')
-
-    emitter.emit('ceiling:click' as any, {
-      node: ceiling,
-      nativeEvent: e.nativeEvent,
-      localPosition: [0, 0, 0],
-      position: [
-        corner.corner[0],
-        resolveCeilingHeight(ceiling, useScene.getState().nodes),
-        corner.corner[1],
-      ],
-      stopPropagation: () => e.stopPropagation(),
-      viaHandle: true,
+        emitter.emit('ceiling:click' as any, {
+          node: effectiveCeiling,
+          nativeEvent: event.nativeEvent,
+          localPosition: [0, 0, 0],
+          position: [
+            corner.corner[0],
+            resolveCeilingHeight(effectiveCeiling, useScene.getState().nodes),
+            corner.corner[1],
+          ],
+          stopPropagation: () => event.stopPropagation(),
+          viaHandle: true,
+        })
+      },
     })
-  }
-
-  return (
-    <group position={[corner.corner[0], 0, corner.corner[1]]}>
-      <BracketLeg
-        color={highlightIncoming ? HANDLE_HOVER_COLOR : HANDLE_COLOR}
-        direction={corner.incomingDirection}
-        highlighted={highlightIncoming}
-        length={corner.incomingLength}
-        onClick={handleClick}
-        onHoverChange={onHoverChange}
-        onPointerDown={onPointerDown}
-      />
-      <BracketLeg
-        color={highlightOutgoing ? HANDLE_HOVER_COLOR : HANDLE_COLOR}
-        direction={corner.outgoingDirection}
-        highlighted={highlightOutgoing}
-        length={corner.outgoingLength}
-        onClick={handleClick}
-        onHoverChange={onHoverChange}
-        onPointerDown={onPointerDown}
-      />
-
-      <mesh
-        geometry={SHARED_HANDLE_BOX_GEOMETRY}
-        onClick={handleClick}
-        onPointerDown={onPointerDown}
-        onPointerEnter={(e) => {
-          e.stopPropagation()
-          onHoverChange(true)
-        }}
-        onPointerLeave={(e) => {
-          e.stopPropagation()
-          onHoverChange(false)
-        }}
-        renderOrder={CORNER_RENDER_ORDER}
-        scale={HIT_BOX_SIZE}
-      >
-        <meshBasicMaterial
-          color={cubeColor}
-          depthTest
-          depthWrite={false}
-          opacity={cubeOpacity}
-          transparent
-        />
-      </mesh>
-    </group>
-  )
-}
-
-const BracketLeg = ({
-  direction,
-  length,
-  color,
-  highlighted,
-  onClick,
-  onHoverChange,
-  onPointerDown,
-}: {
-  direction: [number, number]
-  length: number
-  color: string
-  highlighted: boolean
-  onClick: (e: ThreeEvent<MouseEvent>) => void
-  onHoverChange: (hovered: boolean) => void
-  onPointerDown: (event: ThreeEvent<PointerEvent>) => void
-}) => {
-  const angle = -Math.atan2(direction[1], direction[0])
-  const position: [number, number, number] = [
-    direction[0] * (length / 2),
-    0,
-    direction[1] * (length / 2),
-  ]
-
-  return (
-    <mesh
-      geometry={SHARED_HANDLE_BOX_GEOMETRY}
-      onClick={onClick}
-      onPointerDown={onPointerDown}
-      onPointerEnter={(e) => {
-        e.stopPropagation()
-        onHoverChange(true)
-      }}
-      onPointerLeave={(e) => {
-        e.stopPropagation()
-        onHoverChange(false)
-      }}
-      position={position}
-      renderOrder={CORNER_RENDER_ORDER}
-      rotation={[0, angle, 0]}
-      scale={[length, BRACKET_HEIGHT, BRACKET_THICKNESS]}
-    >
-      <meshBasicMaterial
-        color={color}
-        depthTest
-        depthWrite={false}
-        opacity={highlighted ? HANDLE_HOVER_OPACITY : HANDLE_OPACITY}
-        transparent
-      />
-    </mesh>
-  )
-}
-
-function buildCornerBrackets(polygon: Array<[number, number]>): CornerBracketData[] {
-  if (polygon.length < 3) return []
-
-  return polygon.map((corner, index) => {
-    const previous = polygon[(index - 1 + polygon.length) % polygon.length]!
-    const next = polygon[(index + 1) % polygon.length]!
-    const incomingVector = [previous[0] - corner[0], previous[1] - corner[1]] as [number, number]
-    const outgoingVector = [next[0] - corner[0], next[1] - corner[1]] as [number, number]
-    const incomingDirection = normalize2D(incomingVector)
-    const outgoingDirection = normalize2D(outgoingVector)
-
-    const incomingLength = Math.hypot(incomingVector[0], incomingVector[1])
-    const outgoingLength = Math.hypot(outgoingVector[0], outgoingVector[1])
-
-    return {
-      corner,
-      index,
-      incomingEdgeIndex: (index - 1 + polygon.length) % polygon.length,
-      incomingDirection,
-      outgoingEdgeIndex: index,
-      outgoingDirection,
-      incomingLength: getBracketLength(incomingLength),
-      outgoingLength: getBracketLength(outgoingLength),
+    return () => {
+      controllers.delete(ceiling.id)
     }
-  })
-}
+  }, [ceiling.id, controllers, corners, effectiveCeiling, handleCornerPointerDown])
 
-function normalize2D(vector: [number, number]): [number, number] {
-  const length = Math.hypot(vector[0], vector[1])
-  if (length < 1e-6) return [1, 0]
-  return [vector[0] / length, vector[1] / length]
-}
-
-function getBracketLength(edgeLength: number): number {
-  return Math.max(0.14, Math.min(0.38, edgeLength * 0.22))
-}
+  return null
+})


### PR DESCRIPTION
## perf(editor): instance the ceiling corner brackets per level (perf row 11)

Select mode mounted three transparent meshes per ceiling corner for every ceiling on the level (1 236 meshes on
the rich 4× fixture, each with its own material and R3F handlers). The brackets are a deliberate
discoverability affordance, so they stay on every ceiling — but they now render as **two `InstancedMesh`
per level** (normal + highlighted opacity) sharing the unit box, with `instanceColor` for the gray/indigo
tints and per-instance R3F over/out events. Drag/snap/SFX/live-override/`ceiling:click` lifecycle is
unchanged.

**Measured** (rich 4×, load pose, pointer parked, headless Chromium, rebuilt dist):

| idle | build tool | select mode |
| --- | ---: | ---: |
| main | 9.1 ms / 1 646 objects | 10.6 ms / 1 738 objects |
| this PR (+ #mixer PR) | 8.9 ms / 1 646 | **8.4 ms / 1 614** |

Select mode no longer costs more than build mode. Pixel gate (`outline-parity.ts`, poses H/S/SH/SI, rich 4×
and Maxi): ≤ 0.009 % pixels differ, outline colour census identical. E2E: perf-regression-pack,
click-hidden-wall, click-batched-wall, placement + paint + hover specs 14/15 (the one failure,
`placement-preview-follows-cursor`, fails on main too).

**Accepted behaviour changes** (architect ruling, documented in the commits):
- highlighted brackets always composite on top of normal ones (renderOrder 1001 vs 1000) — same-colour
  overlaps are order-independent, mixed overlaps only exist while hovering;
- the two batches sort against other transparent objects as units, not per bracket;
- three 0.185's small-buffer path serves instance matrices through a uniform that is re-uploaded every
  render when the batch fits the uniform-buffer limit (a few KB on levels with few ceilings); above the limit
  the attribute path honours versions/update ranges. Accepted, commented in code.

**Review rounds** (independent Codex review, all fixed): coincident corners of adjacent ceilings could
alternate hover ownership (now a semantic tie-break among equal-distance bracket hits only);
`DynamicDrawUsage` re-uploaded the instance arrays every resting frame (now static usage + per-slot update
ranges); per-batch geometry is now owned and disposed so WebGPU releases the instance attributes; same-id
level replacement rebinds the portal/drag plane (registry revision poll). `ceiling:click.position` stays
level-local as before (commented). Uncertain and unmeasured: overlapping bracket faces with different
normals write different `normalView` into the AO/ink MRT, so batch order could change AO/ink output by a
few pixels — the parity gate with AO on showed ≤ 0.009 %.

Evidence, probes and the charter row live in the private repo (`plans/performance/editor-scalable-scene-runtime.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large editor interaction refactor with accepted rendering differences (highlight batch render order, transparent sort); mitigated by extensive tests but still affects pointer ownership and corner editing UX.
> 
> **Overview**
> Replaces **three transparent meshes per ceiling corner** in select mode with **two level-wide `InstancedMesh` batches** (normal vs highlighted opacity), driven by a new `CeilingBracketBatchStore` that packs matrices/colors, grows capacity, and moves instances between batches on hover.
> 
> `ceiling-selection-affordance-system` no longer renders `CornerBracket` / `BracketLeg` trees; it feeds polygon/height into the store, portals the batch meshes onto the level, and routes instance pointer events through `BracketPointerState` and semantic hit tie-breaking (coincident corners). Corner drag, snap, SFX, live overrides, thumbnail hide, and `ceiling:click` are intended to stay the same.
> 
> Adds focused unit tests for layout parity, batch lifecycle, WebGPU-friendly static draw + update ranges, and R3F integration tests for hover/click/drag and registry rebinding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99876f1137caa90eca44095427e461e6a04724d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->