### PR TITLE
perf(nodes): skip animation mixers for items without clips

### DIFF
--- a/packages/nodes/src/item/renderer.tsx
+++ b/packages/nodes/src/item/renderer.tsx
@@ -38,8 +38,17 @@ import {
 import { useAnimations } from '@react-three/drei'
 import { Clone } from '@react-three/drei/core/Clone'
 import { useFrame, useLoader, useThree } from '@react-three/fiber'
-import { Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import type { AnimationAction, Group, Material, Mesh, Object3D } from 'three'
+import {
+  type RefObject,
+  Suspense,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import type { AnimationAction, AnimationClip, Group, Material, Mesh, Object3D } from 'three'
 import { MathUtils, Texture } from 'three'
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js'
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js'
@@ -580,7 +589,6 @@ const LoadedModelRenderer = ({
   markSettled: () => void
 }) => {
   const ref = useRef<Group>(null!)
-  const { actions } = useAnimations(animations, ref)
 
   // Mounting past the suspense gate means the GLB resolved — the item's build
   // work is done (`ItemSystem` may clear its dirty mark, scene-ready may fire).
@@ -711,11 +719,11 @@ const LoadedModelRenderer = ({
       </group>
       {animations.length > 0 && (
         <ItemAnimation
-          actions={actions}
           animations={animations}
           animEffect={animEffect}
           interactive={interactive ?? null}
           nodeId={node.id}
+          rootRef={ref}
         />
       )}
       {lightEffects.map((effect, i) => (
@@ -735,15 +743,16 @@ const ItemAnimation = ({
   nodeId,
   animEffect,
   interactive,
-  actions,
   animations,
+  rootRef,
 }: {
   nodeId: AnyNodeId
   animEffect: AnimationEffect | null
   interactive: Interactive | null
-  actions: Record<string, AnimationAction | null>
-  animations: { name: string }[]
+  animations: AnimationClip[]
+  rootRef: RefObject<Group>
 }) => {
+  const { actions } = useAnimations(animations, rootRef)
   const activeClipRef = useRef<string | null>(null)
   const fadingOutRef = useRef<AnimationAction | null>(null)
 


### PR DESCRIPTION
## perf(nodes): skip animation mixers for items without clips

drei's `useAnimations` registers a `useFrame(() => mixer.update(delta))` per hook instance; every loaded item
called it, so rich 4× ran 540 mixers per frame (135 000 calls / 7.9 ms per 5 s parked) although ~95 % of
items have no clips. `useAnimations` now lives inside the clip-only `ItemAnimation` branch (mounted only when
`animations.length > 0`); animated items keep autoplay-first-clip, the `itemHasAnimations` stamp, the clip
registry and `markSettled` timing. After: 6 024 calls / 0.7 ms per 5 s (the 24 items with clips).

`bun test` in packages/nodes: 1 910 pass, also with `--randomize --seed=1`; tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized render-path refactor with unchanged animation semantics for items that have clips; main risk is a subtle regression in clip binding if `rootRef` timing differs from the old parent-level hook.
> 
> **Overview**
> **Moves `useAnimations` off every loaded item** so static GLBs no longer pay for per-frame mixer updates. Drei’s hook registers a `useFrame` that calls `mixer.update` on each instance; previously that ran for all items even when `animations` was empty.
> 
> `useAnimations` now lives inside `ItemAnimation`, which only mounts when `animations.length > 0`. The clone `ref` is passed as `rootRef` instead of precomputed `actions`. `LoadedModelRenderer` still sets `userData.itemHasAnimations` from clip count and only renders `<ItemAnimation>` when there are clips, so autoplay-first-clip behavior, interactive clip switching, and static-batch exclusion (`itemHasAnimations`) stay the same for animated items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ec006170256ebda4d81df06aa85a382768d557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->