### PR TITLE
fix(mcp): declare 2020-12 dialect for tools/list schemas

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `@pascal-app/mcp` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Tool schemas in `tools/list` now declare the JSON Schema 2020-12 dialect
+  instead of the SDK default `draft-07`, so clients that enforce 2020-12 no
+  longer reject every tool call.
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,6 +5,7 @@ import { registerPrompts } from './prompts'
 import { registerResources } from './resources'
 import type { SceneStore } from './storage/types'
 import { registerTools } from './tools'
+import { normalizeToolSchemaDialect } from './tools/normalize-schema-dialect'
 import { registerVisionTools } from './tools/vision'
 import { version } from './version'
 
@@ -28,5 +29,6 @@ export function createPascalMcpServer(opts: CreatePascalMcpServerOptions): McpSe
   registerVisionTools(server, operations)
   registerResources(server, operations)
   registerPrompts(server, operations)
+  normalizeToolSchemaDialect(server)
   return server
 }

--- a/packages/mcp/src/tools/normalize-schema-dialect.ts
+++ b/packages/mcp/src/tools/normalize-schema-dialect.ts
@@ -1,0 +1,35 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+
+const DIALECT_2020_12 = 'https://json-schema.org/draft/2020-12/schema'
+
+type RequestHandler = (request: unknown, extra: unknown) => Promise<unknown>
+
+type HandlerRegistry = {
+  _requestHandlers: Map<string, RequestHandler>
+}
+
+function retargetDialect(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) retargetDialect(item)
+    return
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    if (typeof record.$schema === 'string') record.$schema = DIALECT_2020_12
+    for (const key of Object.keys(record)) retargetDialect(record[key])
+  }
+}
+
+export function normalizeToolSchemaDialect(server: McpServer): void {
+  const registry = server.server as unknown as HandlerRegistry
+  const original = registry._requestHandlers.get('tools/list')
+  if (!original) return
+
+  server.server.removeRequestHandler('tools/list')
+  server.server.setRequestHandler(ListToolsRequestSchema, async (request, extra) => {
+    const result = (await original(request, extra)) as { tools?: unknown }
+    retargetDialect(result.tools)
+    return result
+  })
+}

--- a/packages/mcp/src/tools/schema-dialect.test.ts
+++ b/packages/mcp/src/tools/schema-dialect.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { SceneBridge } from '../bridge/scene-bridge'
+import { createPascalMcpServer } from '../server'
+
+const DIALECT_2020_12 = 'https://json-schema.org/draft/2020-12/schema'
+
+async function listRawSchemas() {
+  const bridge = new SceneBridge()
+  bridge.setScene({}, [])
+  bridge.loadDefault()
+
+  const server = createPascalMcpServer({ bridge })
+  const [srvT, cliT] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'schema-dialect', version: '0.0.0' })
+  await Promise.all([server.connect(srvT), client.connect(cliT)])
+  const { tools } = await client.listTools()
+
+  const dialects = new Set<string>()
+  for (const tool of tools) {
+    const input = tool.inputSchema as Record<string, unknown> | undefined
+    const output = tool.outputSchema as Record<string, unknown> | undefined
+    if (typeof input?.$schema === 'string') dialects.add(input.$schema)
+    if (typeof output?.$schema === 'string') dialects.add(output.$schema)
+  }
+  return dialects
+}
+
+describe('tools/list schema dialect', () => {
+  test('every declared $schema is JSON Schema 2020-12', async () => {
+    const dialects = await listRawSchemas()
+
+    expect(dialects.size).toBeGreaterThan(0)
+    expect([...dialects]).toEqual([DIALECT_2020_12])
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes #696 — every tool call against the local `@pascal-app/mcp` server fails on clients that enforce JSON Schema 2020-12, because `tools/list` declares `draft-07`.

The MCP SDK's `McpServer` builds each tool's `inputSchema`/`outputSchema` with `toJsonSchemaCompat` and no `target`, so the compat layer falls back to `draft-07`. There's no version bump or `registerTool` option that changes this. The generated schemas contain no draft-07-only keywords (`definitions`, `dependencies`, `$ref`), so the fix re-registers the `tools/list` handler after tool registration and retargets the declared `$schema` to `https://json-schema.org/draft/2020-12/schema` on the way out — the approach the maintainer outlined in the issue.

## How to test

1. `cd packages/core && bun run build` (mcp tests import built `@pascal-app/core/schema`)
2. `cd ../mcp && bun test`

New regression test `src/tools/schema-dialect.test.ts` asserts the raw `tools/list` payload only declares 2020-12 (validating through the SDK client — as the existing contract test does — would not catch this, since the client uses the SDK's own validator).

## Validation (real results)

- `bun test` (packages/mcp): **357 pass, 0 fail** (52 files)
- New test alone: pass
- RED→GREEN: removing `normalizeToolSchemaDialect(server)` makes the new test fail with the raw dialect showing `http://json-schema.org/draft-07/schema#`; restoring it turns it green.
- `biome check` clean on the changed files; `tsc -p tsconfig.json` clean.

## Screenshots / screen recording

N/A — headless MCP/server change, covered by the test above.

## Checklist

- [x] I've tested this locally (`bun test`)
- [x] My code follows the existing code style (`bun check`)
- [x] I've updated relevant documentation (CHANGELOG)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Response-shaping middleware on `tools/list` only; behavior is covered by a regression test, though it depends on SDK-internal handler registration.
> 
> **Overview**
> Fixes **#696**: MCP clients that require JSON Schema **2020-12** were rejecting all tool calls because `tools/list` advertised the SDK default **draft-07** `$schema`.
> 
> After tools, resources, and prompts are registered, **`normalizeToolSchemaDialect`** wraps the existing `tools/list` handler and recursively rewrites every `$schema` URL in the listed tool **input/output** schemas to `https://json-schema.org/draft/2020-12/schema` before the response is returned—without changing schema structure (no draft-07-only keywords in play).
> 
> A new integration test asserts the raw `listTools()` payload only exposes the 2020-12 dialect; the **Unreleased** changelog entry documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9509c9ba5ecbbb32a48500f5a563bf6f39b0ae2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->