### PR TITLE
Split canopy regression matrix into independent tests

### DIFF
--- a/packages/nodes/src/lean-to-extension/canopy-rendering-regression.test.ts
+++ b/packages/nodes/src/lean-to-extension/canopy-rendering-regression.test.ts
@@ -183,19 +183,18 @@ describe('freestanding canopy rendered-joint regressions', () => {
     for (const geometry of result.geometries) geometry.dispose()
   })
 
-  test('all canopy forms keep finite, non-overlapping roofs across turns and orientations', () => {
-    const failures: string[] = []
-    for (const form of ['mono', 'gable', 'butterfly'] as const) {
-      for (const angle of [1, 2, 5, 15, 30, 45, 60, 75, 89, 90]) {
-        for (const turn of [-1, 1]) {
-          const radians = (turn * angle * Math.PI) / 180
-          const forward: Point[] = [
-            [0, 0],
-            [8, 0],
-            [8 + 8 * Math.cos(radians), 8 * Math.sin(radians)],
-          ]
-          for (const reverse of [false, true]) {
-            for (const flipProjection of [false, true]) {
+  for (const form of ['mono', 'gable', 'butterfly'] as const) {
+    for (const angle of [1, 2, 5, 15, 30, 45, 60, 75, 89, 90]) {
+      for (const turn of [-1, 1]) {
+        for (const reverse of [false, true]) {
+          for (const flipProjection of [false, true]) {
+            test(`${form} angle=${angle} turn=${turn} reverse=${reverse} flip=${flipProjection} has no separated roof overlap`, () => {
+              const radians = (turn * angle * Math.PI) / 180
+              const forward: Point[] = [
+                [0, 0],
+                [8, 0],
+                [8 + 8 * Math.cos(radians), 8 * Math.sin(radians)],
+              ]
               const points = reverse ? [...forward].reverse() : forward
               const result = buildRuns(
                 `${form}_${angle}_${turn}_${reverse}_${flipProjection}`,
@@ -205,19 +204,14 @@ describe('freestanding canopy rendered-joint regressions', () => {
                 flipProjection,
               )
               const overlaps = separatedTopOverlapCount(result.geometries)
-              if (overlaps > 0) {
-                failures.push(
-                  `${form} angle=${angle} turn=${turn} reverse=${reverse} flip=${flipProjection} has ${overlaps} separated overlaps`,
-                )
-              }
               for (const geometry of result.geometries) geometry.dispose()
-            }
+              expect(overlaps).toBe(0)
+            })
           }
         }
       }
     }
-    expect(failures).toEqual([])
-  }, 15000)
+  }
 
   test('maximum canopy overhangs keep connected, non-overlapping corner roofs', () => {
     const patch = {


### PR DESCRIPTION
The exhaustive canopy rendering regression covered 240 geometry combinations inside one test with a shared 15-second deadline. Two consecutive private-editor main CI attempts timed out at 15,141.06 ms and 15,387.96 ms, even though the same test passed required PR CI at 13,029.10 ms.

This registers each existing form/angle/turn/reverse/projection-flip combination as an independently named test. Every case keeps the same scene construction, overlap calculation, geometry disposal, and zero-overlap requirement. The change does not raise a timeout, remove cases, weaken assertions, or claim faster runtime.

Validation:

- CI-matching Bun 1.3.14: three focused runs, 250/250 passing each
- Exact matrix check: 240 expected unique cases, zero missing/extra/duplicate
- Full `@pascal-app/nodes` suite: 2,336 passed, 1 existing skip
- Repository Biome check: 2,086 files passed
- `git diff --check`: passed

Local timing cannot reproduce GitHub runner load; the fix addresses reliability by removing the shared matrix deadline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with identical assertions and coverage; no production code paths change.
> 
> **Overview**
> **Replaces one 240-case canopy roof overlap regression** with **240 individually named `test()` entries** in `canopy-rendering-regression.test.ts`, so each form/angle/turn/reverse/projection-flip combination runs under its own test instead of a single nested loop.
> 
> Behavior is unchanged: same `buildRuns` setup, `separatedTopOverlapCount`, geometry disposal, and `expect(overlaps).toBe(0)`. The aggregate `failures` array and the **15s timeout** on the monolithic test are removed in favor of per-case failures and default per-test timeouts, addressing CI flakiness from the shared deadline on a heavy matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458ae29cbeb923b6b1f04679ea66ee13f55297e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->