### PR TITLE
test(nodes): establish probe mocks before any fiber/react import

### DIFF
--- a/packages/nodes/src/shared/node-batch/source-systems.test.ts
+++ b/packages/nodes/src/shared/node-batch/source-systems.test.ts
@@ -20,9 +20,6 @@ function runSourceTest(body: string) {
       `
     import assert from 'node:assert/strict'
     import { mock } from 'bun:test'
-    import * as core from '@pascal-app/core'
-    import * as viewer from '@pascal-app/viewer'
-    import { Group, Mesh, MeshBasicMaterial } from 'three'
     ${body}
   `,
     )
@@ -41,8 +38,11 @@ function runSourceTest(body: string) {
 
 test('real slab top/side/skirt collection, shared defaults, transparent overrides and cache ownership', () => {
   runSourceTest(`
+    const core = await import('@pascal-app/core')
     const sourceMaterials = await import(${sourcePath('packages/viewer/src/lib/materials.ts')})
+    const viewer = await import('@pascal-app/viewer')
     mock.module('@pascal-app/viewer', () => ({ ...viewer, ...sourceMaterials }))
+    const { Group } = await import('three')
     const { buildSlabGeometry } = await import(${sourcePath('packages/nodes/src/slab/geometry.ts')})
     const { collectBatchCandidate } = await import(${sourcePath('packages/nodes/src/shared/node-batch/candidates.ts')})
     const { disposeObject3DResources } = await import(${sourcePath('packages/viewer/src/lib/dispose-object3d.ts')})
@@ -108,15 +108,21 @@ test('real slab top/side/skirt collection, shared defaults, transparent override
 
 test('priority-1 dirty snapshot sees the priority-2 ceiling rebuild and batches replacement geometry at 5', () => {
   runSourceTest(`
+    // Mock React before Fiber, and Fiber before the package barrels load their systems.
+    const refs = []
+    const react = await import('react')
+    mock.module('react', () => ({ ...react, useEffect: () => {}, useRef: (value) => { const ref = { current: value }; refs.push(ref); return ref } }))
+    const callbacks = []
+    const fiber = await import('@react-three/fiber')
+    mock.module('@react-three/fiber', () => ({ ...fiber, useThree: (selector) => selector({ invalidate: () => {} }), useFrame: (callback, priority = 0) => callbacks.push({ callback, priority }) }))
+    const core = await import('@pascal-app/core')
     const scene = core.useScene
     const selectorHook = Object.assign((selector) => selector(scene.getState()), scene)
     mock.module('@pascal-app/core', () => ({ ...core, useScene: selectorHook }))
-    const fiber = await import('@react-three/fiber')
-    const callbacks = []
-    mock.module('@react-three/fiber', () => ({ ...fiber, useThree: (selector) => selector({ invalidate: () => {} }), useFrame: (callback, priority = 0) => callbacks.push({ callback, priority }) }))
-    const react = await import('react')
-    const refs = []
-    mock.module('react', () => ({ ...react, useEffect: () => {}, useRef: (value) => { const ref = { current: value }; refs.push(ref); return ref } }))
+    const viewer = await import('@pascal-app/viewer')
+    const viewerStore = viewer.useViewer
+    mock.module(${sourcePath('packages/viewer/src/store/use-viewer.ts')}, () => ({ default: Object.assign((selector) => selector(viewerStore.getState()), viewerStore) }))
+    const { Group, Mesh, MeshBasicMaterial } = await import('three')
     const { CeilingSystem, generateCeilingGeometry } = await import(${sourcePath('packages/viewer/src/systems/ceiling/ceiling-system.tsx')})
     const { NodeBatchSystem, runBatchFrame, resetNodeBatchState } = await import(${sourcePath('packages/nodes/src/shared/node-batch/system.tsx')})
     let now = 0
@@ -150,8 +156,6 @@ test('priority-1 dirty snapshot sees the priority-2 ceiling rebuild and batches 
     assert.equal(callbacks[0].priority, 2)
     NodeBatchSystem().type()
     assert.deepEqual(callbacks.map((pass) => pass.priority), [2, 1, 5])
-    const viewerStore = viewer.useViewer
-    mock.module(${sourcePath('packages/viewer/src/store/use-viewer.ts')}, () => ({ default: Object.assign((selector) => selector(viewerStore.getState()), viewerStore) }))
     const { GeometrySystem } = await import(${sourcePath('packages/viewer/src/systems/geometry/geometry-system.tsx')})
     GeometrySystem()
     assert.equal(callbacks[3].priority, 2)
@@ -172,23 +176,26 @@ test('priority-1 dirty snapshot sees the priority-2 ceiling rebuild and batches 
 })
 
 const slabCacheFixture = `
-  const sourceMaterials = await import(${sourcePath('packages/viewer/src/lib/materials.ts')})
-  const scene = core.useScene
-  const viewerStore = viewer.useViewer
-  viewerStore.setState({ bumpGeometryRevision: () => viewerStore.setState({ geometryRevision: viewerStore.getState().geometryRevision + 1 }) })
-  const selectorHook = (store) => Object.assign((selector) => selector(store.getState()), store)
-  mock.module('@pascal-app/core', () => ({ ...core, useScene: selectorHook(scene), useRegistryVersion: () => 0 }))
-  mock.module('@pascal-app/viewer', () => ({ ...viewer, ...sourceMaterials, useViewer: selectorHook(viewerStore) }))
-  mock.module(${sourcePath('packages/viewer/src/store/use-viewer.ts')}, () => ({ default: selectorHook(viewerStore) }))
-  const fiber = await import('@react-three/fiber')
-  const frames = []
-  mock.module('@react-three/fiber', () => ({ ...fiber, useThree: (selector) => selector({ gl: { domElement: {} }, invalidate: () => {} }), useFrame: (callback, priority) => frames.push({ callback, priority }) }))
-  const react = await import('react')
   let effects = []
   let refs = []
   let refIndex = 0
   const hooks = { useEffect: (effect) => effects.push(effect), useCallback: (callback) => callback, useRef: (value) => refs[refIndex++] ??= { current: value }, useSyncExternalStore: (_, snapshot) => snapshot(), useDebugValue: () => {} }
+  const react = await import('react')
   mock.module('react', () => ({ ...react, ...hooks, default: { ...react.default, ...hooks } }))
+  const frames = []
+  const fiber = await import('@react-three/fiber')
+  mock.module('@react-three/fiber', () => ({ ...fiber, useThree: (selector) => selector({ gl: { domElement: {} }, invalidate: () => {} }), useFrame: (callback, priority) => frames.push({ callback, priority }) }))
+  const selectorHook = (store) => Object.assign((selector) => selector(store.getState()), store)
+  const core = await import('@pascal-app/core')
+  const scene = core.useScene
+  mock.module('@pascal-app/core', () => ({ ...core, useScene: selectorHook(scene), useRegistryVersion: () => 0 }))
+  const viewer = await import('@pascal-app/viewer')
+  const viewerStore = viewer.useViewer
+  viewerStore.setState({ bumpGeometryRevision: () => viewerStore.setState({ geometryRevision: viewerStore.getState().geometryRevision + 1 }) })
+  mock.module(${sourcePath('packages/viewer/src/store/use-viewer.ts')}, () => ({ default: selectorHook(viewerStore) }))
+  const sourceMaterials = await import(${sourcePath('packages/viewer/src/lib/materials.ts')})
+  mock.module('@pascal-app/viewer', () => ({ ...viewer, ...sourceMaterials, useViewer: selectorHook(viewerStore) }))
+  const { Group } = await import('three')
   const { buildSlabGeometry } = await import(${sourcePath('packages/nodes/src/slab/geometry.ts')})
   const { GeometrySystem } = await import(${sourcePath('packages/viewer/src/systems/geometry/geometry-system.tsx')})
   const { captureChangedNodes, runBatchFrame, subscribeBatchInteractions, resetNodeBatchState } = await import(${sourcePath('packages/nodes/src/shared/node-batch/system.tsx')})

--- a/packages/nodes/src/shared/node-batch/source-systems.test.ts
+++ b/packages/nodes/src/shared/node-batch/source-systems.test.ts
@@ -11,7 +11,6 @@ function sourcePath(path: string) {
 function runSourceTest(body: string) {
   const cacheDir = join(import.meta.dir, '.turbo')
   mkdirSync(cacheDir, { recursive: true })
-  // A package-local file resolves hoisted dependencies in private-editor's submodule layout.
   const probeDir = mkdtempSync(join(cacheDir, 'source-test-'))
   try {
     const probePath = join(probeDir, 'probe.ts')
@@ -20,6 +19,31 @@ function runSourceTest(body: string) {
       `
     import assert from 'node:assert/strict'
     import { mock } from 'bun:test'
+    import { fileURLToPath, pathToFileURL } from 'node:url'
+
+    // Isolated installs can give each tested package its own peer module instance.
+    // Share the viewer's instance across every resolved path before loading consumers.
+    const consumers = [
+      ${sourcePath('packages/viewer/src/lib/materials.ts')},
+      ${sourcePath('packages/nodes/src/shared/node-batch/system.tsx')},
+      ${sourcePath('packages/editor/src/components/editor/selection-manager.tsx')},
+    ]
+    const sharedPaths = new Map(
+      ['react', 'three', '@react-three/fiber', '@pascal-app/core', '@pascal-app/viewer'].map((specifier) => [
+        specifier,
+        [...new Set(consumers.map((consumer) => fileURLToPath(import.meta.resolve(specifier, pathToFileURL(consumer).href))))],
+      ]),
+    )
+    function mockShared(specifier, factory) {
+      for (const path of sharedPaths.get(specifier)) mock.module(path, factory)
+    }
+    async function importShared(specifier) {
+      const module = await import(sharedPaths.get(specifier)[0])
+      mockShared(specifier, () => module)
+      return module
+    }
+    await importShared('react')
+    await importShared('three')
     ${body}
   `,
     )
@@ -38,11 +62,11 @@ function runSourceTest(body: string) {
 
 test('real slab top/side/skirt collection, shared defaults, transparent overrides and cache ownership', () => {
   runSourceTest(`
-    const core = await import('@pascal-app/core')
+    const core = await importShared('@pascal-app/core')
     const sourceMaterials = await import(${sourcePath('packages/viewer/src/lib/materials.ts')})
-    const viewer = await import('@pascal-app/viewer')
-    mock.module('@pascal-app/viewer', () => ({ ...viewer, ...sourceMaterials }))
-    const { Group } = await import('three')
+    const viewer = await importShared('@pascal-app/viewer')
+    mockShared('@pascal-app/viewer', () => ({ ...viewer, ...sourceMaterials }))
+    const { Group } = await importShared('three')
     const { buildSlabGeometry } = await import(${sourcePath('packages/nodes/src/slab/geometry.ts')})
     const { collectBatchCandidate } = await import(${sourcePath('packages/nodes/src/shared/node-batch/candidates.ts')})
     const { disposeObject3DResources } = await import(${sourcePath('packages/viewer/src/lib/dispose-object3d.ts')})
@@ -91,7 +115,7 @@ test('real slab top/side/skirt collection, shared defaults, transparent override
     disposeObject3DResources(legacyFirst)
     assert.equal(disposed, 0)
     assert.equal(top.transparent, false)
-    const { flushGlobalEffects } = await import('@react-three/fiber')
+    const { flushGlobalEffects } = await importShared('@react-three/fiber')
     sourceMaterials.clearMaterialCache()
     assert.equal(disposed, 0)
     assert(core.useScene.getState().dirtyNodes.has(slab.id))
@@ -110,19 +134,19 @@ test('priority-1 dirty snapshot sees the priority-2 ceiling rebuild and batches 
   runSourceTest(`
     // Mock React before Fiber, and Fiber before the package barrels load their systems.
     const refs = []
-    const react = await import('react')
-    mock.module('react', () => ({ ...react, useEffect: () => {}, useRef: (value) => { const ref = { current: value }; refs.push(ref); return ref } }))
+    const react = await importShared('react')
+    mockShared('react', () => ({ ...react, useEffect: () => {}, useRef: (value) => { const ref = { current: value }; refs.push(ref); return ref } }))
     const callbacks = []
-    const fiber = await import('@react-three/fiber')
-    mock.module('@react-three/fiber', () => ({ ...fiber, useThree: (selector) => selector({ invalidate: () => {} }), useFrame: (callback, priority = 0) => callbacks.push({ callback, priority }) }))
-    const core = await import('@pascal-app/core')
+    const fiber = await importShared('@react-three/fiber')
+    mockShared('@react-three/fiber', () => ({ ...fiber, useThree: (selector) => selector({ invalidate: () => {} }), useFrame: (callback, priority = 0) => callbacks.push({ callback, priority }) }))
+    const core = await importShared('@pascal-app/core')
     const scene = core.useScene
     const selectorHook = Object.assign((selector) => selector(scene.getState()), scene)
-    mock.module('@pascal-app/core', () => ({ ...core, useScene: selectorHook }))
-    const viewer = await import('@pascal-app/viewer')
+    mockShared('@pascal-app/core', () => ({ ...core, useScene: selectorHook }))
+    const viewer = await importShared('@pascal-app/viewer')
     const viewerStore = viewer.useViewer
     mock.module(${sourcePath('packages/viewer/src/store/use-viewer.ts')}, () => ({ default: Object.assign((selector) => selector(viewerStore.getState()), viewerStore) }))
-    const { Group, Mesh, MeshBasicMaterial } = await import('three')
+    const { Group, Mesh, MeshBasicMaterial } = await importShared('three')
     const { CeilingSystem, generateCeilingGeometry } = await import(${sourcePath('packages/viewer/src/systems/ceiling/ceiling-system.tsx')})
     const { NodeBatchSystem, runBatchFrame, resetNodeBatchState } = await import(${sourcePath('packages/nodes/src/shared/node-batch/system.tsx')})
     let now = 0
@@ -180,22 +204,22 @@ const slabCacheFixture = `
   let refs = []
   let refIndex = 0
   const hooks = { useEffect: (effect) => effects.push(effect), useCallback: (callback) => callback, useRef: (value) => refs[refIndex++] ??= { current: value }, useSyncExternalStore: (_, snapshot) => snapshot(), useDebugValue: () => {} }
-  const react = await import('react')
-  mock.module('react', () => ({ ...react, ...hooks, default: { ...react.default, ...hooks } }))
+  const react = await importShared('react')
+  mockShared('react', () => ({ ...react, ...hooks, default: { ...react.default, ...hooks } }))
   const frames = []
-  const fiber = await import('@react-three/fiber')
-  mock.module('@react-three/fiber', () => ({ ...fiber, useThree: (selector) => selector({ gl: { domElement: {} }, invalidate: () => {} }), useFrame: (callback, priority) => frames.push({ callback, priority }) }))
+  const fiber = await importShared('@react-three/fiber')
+  mockShared('@react-three/fiber', () => ({ ...fiber, useThree: (selector) => selector({ gl: { domElement: {} }, invalidate: () => {} }), useFrame: (callback, priority) => frames.push({ callback, priority }) }))
   const selectorHook = (store) => Object.assign((selector) => selector(store.getState()), store)
-  const core = await import('@pascal-app/core')
+  const core = await importShared('@pascal-app/core')
   const scene = core.useScene
-  mock.module('@pascal-app/core', () => ({ ...core, useScene: selectorHook(scene), useRegistryVersion: () => 0 }))
-  const viewer = await import('@pascal-app/viewer')
+  mockShared('@pascal-app/core', () => ({ ...core, useScene: selectorHook(scene), useRegistryVersion: () => 0 }))
+  const viewer = await importShared('@pascal-app/viewer')
   const viewerStore = viewer.useViewer
   viewerStore.setState({ bumpGeometryRevision: () => viewerStore.setState({ geometryRevision: viewerStore.getState().geometryRevision + 1 }) })
   mock.module(${sourcePath('packages/viewer/src/store/use-viewer.ts')}, () => ({ default: selectorHook(viewerStore) }))
   const sourceMaterials = await import(${sourcePath('packages/viewer/src/lib/materials.ts')})
-  mock.module('@pascal-app/viewer', () => ({ ...viewer, ...sourceMaterials, useViewer: selectorHook(viewerStore) }))
-  const { Group } = await import('three')
+  mockShared('@pascal-app/viewer', () => ({ ...viewer, ...sourceMaterials, useViewer: selectorHook(viewerStore) }))
+  const { Group } = await importShared('three')
   const { buildSlabGeometry } = await import(${sourcePath('packages/nodes/src/slab/geometry.ts')})
   const { GeometrySystem } = await import(${sourcePath('packages/viewer/src/systems/geometry/geometry-system.tsx')})
   const { captureChangedNodes, runBatchFrame, subscribeBatchInteractions, resetNodeBatchState } = await import(${sourcePath('packages/nodes/src/shared/node-batch/system.tsx')})


### PR DESCRIPTION
Follow-up to #792. In private-editor's CI (Bun 1.3.0, hoisted node_modules at the private root) the source-system probes crashed with an invalid hook call: `CeilingSystem → useFrame → useStore → useContext` on a null dispatcher — the probe's `mock.module('@react-three/fiber' | 'react')` was established after `@pascal-app/viewer` had already loaded fiber and react statically. The probes now import nothing that pulls react/fiber before the mocks exist: react mocks first, then fiber (captured via dynamic import), then the package barrels and system sources. Cases and assertions unchanged (5 cases, 60 assertions). Verified with Bun 1.3.0 and 1.3.14 from packages/nodes and from the private root; `bun test packages/nodes --randomize --seed=1` 2 370 pass.

Note: the private CI pins Bun 1.3.0 while this repo's CI and local machines run 1.3.14 — worth aligning separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to isolated subprocess probes; no production runtime paths are modified.
> 
> **Overview**
> Fixes **invalid React hook** failures in `source-systems.test.ts` when Bun runs from a hoisted private root: package barrels were loading real `react` / `@react-three/fiber` before probe mocks ran.
> 
> The **`runSourceTest` probe** now resolves `react`, `three`, fiber, core, and viewer from several consumer source paths, **aliases every resolved path to one module instance** via `importShared` / `mockShared`, and preloads shared `react` and `three` before the test body. Individual probes **mock React, then Fiber, then core/viewer** before importing ceiling/geometry/batch systems; fixture strings use the same order. **Behavior under test is unchanged** (same cases and assertions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8afafc6627ece5c840b926d59c81fa06663f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->