### PR TITLE
Prepare Pascal skills for ClawHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ codex plugin marketplace add pascalorg/editor
 codex plugin add pascal-agent-skills@pascal
 ```
 
+OpenClaw installation becomes available after the skills are published under Pascal's ClawHub publisher. See [skills/README.md](skills/README.md) for the owner-qualified install and verification commands.
+
 [`pascal-3d`](skills/pascal-3d/SKILL.md) covers safe local or hosted MCP setup and verified scene work. [`furniture-fit`](skills/furniture-fit/SKILL.md) produces a bounded, evidence-based footprint assessment without claiming unsupported height, swing, or delivery checks. See [skills/README.md](skills/README.md) for package details and validation.
 
 The skills inspect the connected MCP tool schemas before using optional fields. A capability present in this repository may be absent from an older installed or hosted release; the agent should report the narrower supported result instead of assuming source-only inputs are available.

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -110,6 +110,20 @@ for (const skillName of skillNames) {
   if (!/^ {2}native-host-validation: "[a-z0-9-]+"$/m.test(content)) {
     fail(`${skillName}: native host validation state must be explicit`)
   }
+  if (/^license:/m.test(content)) {
+    fail(`${skillName}: per-skill license metadata conflicts with ClawHub's MIT-0 release contract`)
+  }
+  for (const requiredOpenClawMetadata of [
+    '  openclaw:',
+    '    homepage: https://editor.pascal.app/docs/developers/mcp',
+    '    primaryEnv: PASCAL_API_KEY',
+    '      - name: PASCAL_API_KEY',
+    '        required: false',
+  ]) {
+    if (!content.includes(requiredOpenClawMetadata)) {
+      fail(`${skillName}: missing OpenClaw metadata: ${requiredOpenClawMetadata.trim()}`)
+    }
+  }
   if (content.includes('last-verified:'))
     fail(`${skillName}: last-verified overstates the current validation state`)
   if (content.split('\n').length > 500) fail(`${skillName}: SKILL.md exceeds 500 lines`)
@@ -615,6 +629,7 @@ for (const expected of [
   '/plugin marketplace add pascalorg/editor',
   'codex plugin marketplace add pascalorg/editor',
   'codex plugin add pascal-agent-skills@pascal',
+  'OpenClaw installation becomes available after the skills are published',
 ]) {
   if (!readme.includes(expected)) fail(`README is missing install instruction: ${expected}`)
 }

--- a/skills/README.md
+++ b/skills/README.md
@@ -26,6 +26,19 @@ npx skills add https://github.com/pascalorg/editor/tree/main/skills/furniture-fi
 
 Use `-g` for a user-wide installation or `-a claude-code -a codex` to choose hosts explicitly.
 
+## Install with OpenClaw
+
+After publication under Pascal's ClawHub publisher, use the owner-qualified registry references and verify their trust envelopes:
+
+```bash
+openclaw skills install @pascalorg/pascal-3d
+openclaw skills install @pascalorg/furniture-fit
+openclaw skills verify @pascalorg/pascal-3d
+openclaw skills verify @pascalorg/furniture-fit
+```
+
+The references above remain unavailable until an authorized Pascal publisher accepts ClawHub's MIT-0 publication terms and creates the releases. OpenClaw's `skills-sh:` resolver also requires the skill to be indexed by ClawHub, so the existing skills.sh listing is not a pre-publication workaround. Installing either skill provides instructions only; follow its setup reference to connect Pascal MCP.
+
 ## Install as a Claude Code or Codex plugin
 
 This repository is also a shared plugin marketplace containing one plugin backed by the same `skills/` folders. For Claude Code:

--- a/skills/VALIDATION.md
+++ b/skills/VALIDATION.md
@@ -2,11 +2,15 @@
 
 Candidate package source: **0.1.5**. Latest released package source: **0.1.4**. `pascal-3d` skill metadata version: **0.1.0**. `furniture-fit` skill metadata version: **0.1.3**. Recorded September 9, 2026.
 
-## Bundle 0.1.5 OpenAI submission readiness candidate
+## Bundle 0.1.5 OpenAI and ClawHub submission readiness candidate
 
 This candidate adds the portable root Agent Plugins manifest while retaining the Codex compatibility manifest and Claude marketplace package. Its OpenAI listing metadata fits the final public-directory limits: display and short-description copy are at most 30 characters, starter prompts are at most 128 characters, and the package supplies a square bundled logo asset plus public website, support, privacy, and terms URLs. The repository validator keeps the portable and compatibility OpenAI interfaces identical and rejects screenshots for this skills-only package. Shared publishing fixtures moved out of `skills/`, leaving only valid immediate skill directories for OpenAI archive ingestion.
 
 These source checks do not submit or publish the plugin. OpenAI Platform access, a verified matching developer or business identity, portal review, country selection, policy attestations, and the developer's separate publish action remain external requirements. The publishing suite provides more than the required five positive and three negative reviewer cases, including reproducible positive fixtures, expected result shapes, and explicit negative-case reasons; the release-note draft is stored beside it. The submitter must enter those materials in the portal and resolve any automated skill-scan findings.
+
+For ClawHub, both canonical skill folders pass `clawhub` 0.23.3 `skill publish --dry-run --json` with their intended owner, slug, version, categories, topics, and public source metadata. OpenClaw 2026.9.3 installs both folders into an isolated workspace, parses the optional `PASCAL_API_KEY` and homepage metadata, and reports both skills eligible without a hosted credential. The documented local and hosted `openclaw mcp add` command shapes were saved successfully in isolated state without contacting Pascal. The OpenClaw `skills-sh:` resolver did not install the existing skills.sh source before ClawHub indexing, so public instructions do not claim that path as a pre-publication workaround.
+
+These checks do not create a ClawHub publisher or release, accept the mandatory MIT-0 publication terms, run ClawHub's post-upload security scanners, prove a live Pascal MCP connection from OpenClaw, or establish installs, useful tasks, or retention. Those remain separate release and adoption evidence.
 
 ## Bundle 0.1.4 release source
 

--- a/skills/furniture-fit/SKILL.md
+++ b/skills/furniture-fit/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: furniture-fit
 description: Assess whether furniture fits in a measured Pascal room or layout. Use this skill for sofa, table, bed, cabinet, appliance, staging, placement, collision, clearance, or rotated-footprint questions. Produce a tool-backed spatial report that distinguishes footprint fit from unsupported height, door-swing, assembly, and delivery-route claims, and return insufficient evidence when dimensions or scale are missing.
-license: MIT
 compatibility: Requires a Pascal MCP connection for verified scene checks. Can still produce an input-gap report when the scene or measurements are unavailable.
 metadata:
   version: "0.1.3"
   source-reviewed: "2026-09-09"
   native-host-validation: "package-checks-only"
+  openclaw:
+    homepage: https://editor.pascal.app/docs/developers/mcp
+    primaryEnv: PASCAL_API_KEY
+    envVars:
+      - name: PASCAL_API_KEY
+        required: false
+        description: Optional Pascal API key for hosted scene checks; input-gap reports and local Pascal do not require it.
 ---
 
 # Furniture fit

--- a/skills/furniture-fit/references/setup.md
+++ b/skills/furniture-fit/references/setup.md
@@ -43,6 +43,16 @@ The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b
 
 Run the setup command for the active host. The MCP command installed in host configuration is `pascal mcp connect`. Local use needs no hosted account and does not upload projects automatically. If the connected MCP schema lacks `check_collisions.candidate`, report the narrower supported result rather than implying the candidate was tested.
 
+For OpenClaw, register and probe the same local connector:
+
+```bash
+openclaw mcp add pascal \
+  --command pascal \
+  --arg mcp \
+  --arg connect
+openclaw mcp doctor pascal --probe
+```
+
 Use only one active agent client with each local CLI service. The standalone HTTP service shares active scene state across clients; do not run concurrent agents against that process. Separate processes need separate local data stores for independent work. The hosted endpoint below uses a different session-isolated bridge.
 
 ## Existing hosted project
@@ -75,6 +85,19 @@ claude mcp add --scope user --transport http pascal https://editor.pascal.app/ap
 ```
 
 The guard exits before changing Claude Code configuration when the variable is unset or empty. Claude Code expands the variable during registration and stores the static Authorization header, including the key, in its private user configuration. The connection is then available in all Claude Code projects for that user. Keep the configuration private; use `--scope local` instead when the connection should remain local to the current project. Never paste the key into a project file, report, prompt, screenshot, or URL.
+
+OpenClaw:
+
+```bash
+: "${PASCAL_API_KEY:?Set PASCAL_API_KEY to a key from Pascal Settings}" && \
+openclaw mcp add pascal \
+  --url https://editor.pascal.app/api/mcp \
+  --transport streamable-http \
+  --header "Authorization=Bearer $PASCAL_API_KEY"
+openclaw mcp doctor pascal --probe
+```
+
+The current OpenClaw static-header path stores the expanded key in its private MCP configuration and may warn about the literal credential during `doctor`. Do not commit or share that configuration. Remove the server with `openclaw mcp unset pascal` and rotate the Pascal key if the configuration is exposed. Installing this skill does not authorize a save, placement, account, upload, publication, or paid operation.
 
 ## Separate autonomous workspace
 

--- a/skills/pascal-3d/SKILL.md
+++ b/skills/pascal-3d/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: pascal-3d
 description: Connect to Pascal and use its MCP tools to create, inspect, edit, validate, save, or hand off editable 3D building scenes. Use this skill whenever a user asks an agent to work in Pascal, make a room or building model, inspect a Pascal project, perform spatial edits, connect Pascal MCP, or return a verified Pascal editor link. It also governs safe local, existing-account, and explicitly authorized autonomous setup.
-license: MIT
 compatibility: Requires an MCP-capable host and either the local Pascal CLI or access to the hosted Pascal MCP endpoint. Local CLI requires Node.js 22.13 or newer.
 metadata:
   version: "0.1.0"
   source-reviewed: "2026-09-08"
   native-host-validation: "source-hash-recorded-separately"
+  openclaw:
+    homepage: https://editor.pascal.app/docs/developers/mcp
+    primaryEnv: PASCAL_API_KEY
+    envVars:
+      - name: PASCAL_API_KEY
+        required: false
+        description: Optional Pascal API key for the hosted MCP endpoint; local Pascal does not require it.
 ---
 
 # Pascal 3D

--- a/skills/pascal-3d/references/setup.md
+++ b/skills/pascal-3d/references/setup.md
@@ -63,6 +63,16 @@ Run only the setup command for the active host. For a JSON-based MCP client, use
 }
 ```
 
+OpenClaw:
+
+```bash
+openclaw mcp add pascal \
+  --command pascal \
+  --arg mcp \
+  --arg connect
+openclaw mcp doctor pascal --probe
+```
+
 The stable connector discovers the managed loopback service and its private local token. Diagnose without exposing secrets:
 
 ```bash
@@ -106,6 +116,19 @@ claude mcp add --scope user --transport http pascal https://editor.pascal.app/ap
 ```
 
 The guard exits before changing Claude Code configuration when the variable is unset or empty. Claude Code expands the variable during registration and stores the static Authorization header, including the key, in its private user configuration. The connection is then available in all Claude Code projects for that user. Keep the configuration private; use `--scope local` instead when the connection should remain local to the current project.
+
+OpenClaw:
+
+```bash
+: "${PASCAL_API_KEY:?Set PASCAL_API_KEY to a key from Pascal Settings}" && \
+openclaw mcp add pascal \
+  --url https://editor.pascal.app/api/mcp \
+  --transport streamable-http \
+  --header "Authorization=Bearer $PASCAL_API_KEY"
+openclaw mcp doctor pascal --probe
+```
+
+The current OpenClaw static-header path stores the expanded key in its private MCP configuration and may warn about the literal credential during `doctor`. Do not commit or share that configuration. Remove the server with `openclaw mcp unset pascal` and rotate the Pascal key if the configuration is exposed. Skill installation alone does not configure this connection or authorize an account, upload, save, publication, or paid operation.
 
 For other JSON-based clients, prefer their supported environment-variable or secret interpolation rather than a literal key:
 


### PR DESCRIPTION
Pascal's public skills passed ClawHub dry-run packaging, but they lacked OpenClaw runtime metadata and OpenClaw-specific MCP setup. They also declared a per-skill MIT license even though ClawHub publishes skills under MIT-0.

This change:
- declares optional `PASCAL_API_KEY` and the Pascal MCP docs homepage under `metadata.openclaw`
- adds tested OpenClaw local and hosted MCP setup commands with the static-header storage boundary
- documents the future owner-qualified ClawHub install and verification commands without claiming the listings already exist
- removes conflicting per-skill license metadata while leaving the repository's source license unchanged
- extends package validation to preserve those publication constraints
- records the exact validation limits, including the failed prepublication `skills-sh:` resolver path

Validation:
- `bun scripts/validate-skills.ts`
- `claude plugin validate . --strict`
- OpenClaw 2026.9.3 isolated local-directory installs and `skills info` for both skills
- OpenClaw 2026.9.3 isolated `mcp add --no-probe` command-shape checks for local stdio and hosted Streamable HTTP
- ClawHub 0.23.3 `skill publish --dry-run --json` for both skills

No ClawHub login, publisher creation, publication, submission, or external message was performed. A Pascal publisher still needs to choose or create the publisher handle, accept MIT-0 publication, publish both releases, review the resulting scans, and verify the live owner-qualified installs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill-package validation only; no runtime or MCP server code changes.
> 
> **Overview**
> Prepares **pascal-3d** and **furniture-fit** for ClawHub/OpenClaw by aligning skill metadata and docs with publication rules, without claiming live registry listings yet.
> 
> Both skills drop per-skill `license` frontmatter (ClawHub’s MIT-0 contract) and add **`metadata.openclaw`**: MCP docs homepage, optional **`PASCAL_API_KEY`**, and env var hints. Setup references now include **OpenClaw** local stdio (`pascal mcp connect`) and hosted Streamable HTTP registration, including warnings that static headers may store expanded keys in private config.
> 
> **README** and **skills/README.md** document future owner-qualified `openclaw skills install` / `verify` commands and point readers to skills docs; **VALIDATION.md** records ClawHub dry-run and OpenClaw 2026.9.3 checks plus the limit that `skills-sh:` does not work pre-indexing. **`scripts/validate-skills.ts`** enforces the new OpenClaw block, rejects per-skill licenses, and requires the root README OpenClaw install note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed67187136b97ce51c4825f7459a2dcf9498560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->