### PR TITLE
Add MCP tool execution middleware

### DIFF
--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { SceneBridge } from './bridge/scene-bridge'
+import { createPascalMcpServer } from './server'
+
+describe('Pascal MCP tool execution', () => {
+  test('runs registered tools through the configured executor', async () => {
+    const bridge = new SceneBridge()
+    bridge.loadDefault()
+    const events: string[] = []
+    const server = createPascalMcpServer({
+      bridge,
+      executeTool: async ({ name, execute }) => {
+        events.push(`before:${name}`)
+        const result = await execute()
+        events.push(`after:${name}`)
+        return result
+      },
+    })
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair()
+    const client = new Client({ name: 'tool-executor-test', version: '0.0.0' })
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+
+    try {
+      const result = await client.callTool({ name: 'get_scene', arguments: {} })
+      expect(result.isError).toBeFalsy()
+      expect(events).toEqual(['before:get_scene', 'after:get_scene'])
+    } finally {
+      await client.close()
+      await server.close()
+    }
+  })
+})

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -8,6 +8,11 @@ import { registerTools } from './tools'
 import { registerVisionTools } from './tools/vision'
 import { version } from './version'
 
+export type PascalMcpToolExecutor = <Result>(input: {
+  name: string
+  execute: () => Promise<Result>
+}) => Promise<Result>
+
 export type CreatePascalMcpServerOptions = {
   bridge: SceneBridge
   operations?: SceneOperations
@@ -15,6 +20,8 @@ export type CreatePascalMcpServerOptions = {
   store?: SceneStore
   name?: string
   version?: string
+  /** Wrap every tool handler, for example to serialize access to a stateful bridge. */
+  executeTool?: PascalMcpToolExecutor
 }
 
 export function createPascalMcpServer(opts: CreatePascalMcpServerOptions): McpServer {
@@ -22,6 +29,7 @@ export function createPascalMcpServer(opts: CreatePascalMcpServerOptions): McpSe
     name: opts.name ?? 'pascal-mcp-server',
     version: opts.version ?? version,
   })
+  if (opts.executeTool) installToolExecutor(server, opts.executeTool)
   const operations =
     opts.operations ?? createSceneOperations({ bridge: opts.bridge, store: opts.store })
   registerTools(server, operations)
@@ -29,4 +37,15 @@ export function createPascalMcpServer(opts: CreatePascalMcpServerOptions): McpSe
   registerResources(server, operations)
   registerPrompts(server, operations)
   return server
+}
+
+function installToolExecutor(server: McpServer, executeTool: PascalMcpToolExecutor): void {
+  const registerTool = server.registerTool.bind(server)
+  const wrappedRegisterTool: McpServer['registerTool'] = (name, config, callback) =>
+    registerTool(name, config, ((...args: Parameters<typeof callback>) =>
+      executeTool({
+        name,
+        execute: () => Promise.resolve(Reflect.apply(callback, undefined, args)),
+      })) as typeof callback)
+  server.registerTool = wrappedRegisterTool
 }


### PR DESCRIPTION
## Description

Expose a server-level `executeTool` hook so stateful MCP hosts can wrap every registered tool for session-local ordering or other execution controls. The callback receives the registered tool name and an `execute` function, while resources, prompts, and protocol notifications remain unaffected.

This is the public-package prerequisite for serializing hosted Pascal tool calls without blocking MCP cancellation or SSE traffic.

## Validation

- `bun test packages/mcp/src` — 357 tests passed, 1,356 assertions.
- `bunx biome check packages/mcp/src/server.ts packages/mcp/src/server.test.ts`
- `git diff --check`
- Package TypeScript build has no diagnostics in changed files; the workspace currently reports eight pre-existing implicit-`any` diagnostics in `packages/mcp/src/tools/scene-query.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional, additive server factory API; behavior is unchanged when `executeTool` is omitted, with scope limited to tool registration wrapping.
> 
> **Overview**
> Adds an optional **`executeTool`** hook on **`createPascalMcpServer`** so hosts can wrap every registered tool handler (e.g. to serialize access to a stateful bridge) without touching resources, prompts, or other MCP traffic.
> 
> When provided, **`installToolExecutor`** temporarily wraps **`server.registerTool`** so each tool callback runs through `{ name, execute }` before the real handler runs. A new integration test drives **`get_scene`** over in-memory transport and asserts the wrapper’s before/after ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff953a1f86f992bd7184299574a559dd3002d76e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->