### PR TITLE
Propagate MCP tool cancellation to host executors

### DIFF
--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -11,8 +11,9 @@ describe('Pascal MCP tool execution', () => {
     const events: string[] = []
     const server = createPascalMcpServer({
       bridge,
-      executeTool: async ({ name, execute }) => {
+      executeTool: async ({ name, signal, execute }) => {
         events.push(`before:${name}`)
+        expect(signal).toBeInstanceOf(AbortSignal)
         const result = await execute()
         events.push(`after:${name}`)
         return result
@@ -26,6 +27,87 @@ describe('Pascal MCP tool execution', () => {
       const result = await client.callTool({ name: 'get_scene', arguments: {} })
       expect(result.isError).toBeFalsy()
       expect(events).toEqual(['before:get_scene', 'after:get_scene'])
+    } finally {
+      await client.close()
+      await server.close()
+    }
+  })
+
+  test('passes request cancellation through the executor before invoking a tool', async () => {
+    const bridge = new SceneBridge()
+    bridge.loadDefault()
+    let callbackCalls = 0
+    let notifyExecutorStarted: (() => void) | undefined
+    const executorStarted = new Promise<void>((resolve) => {
+      notifyExecutorStarted = resolve
+    })
+    let notifyExecutorStopped: (() => void) | undefined
+    const executorStopped = new Promise<void>((resolve) => {
+      notifyExecutorStopped = resolve
+    })
+    const server = createPascalMcpServer({
+      bridge,
+      executeTool: async ({ name, signal, execute }) => {
+        if (name !== 'cancel_probe') return execute()
+        notifyExecutorStarted?.()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) resolve()
+          else signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        try {
+          signal.throwIfAborted()
+          return await execute()
+        } finally {
+          notifyExecutorStopped?.()
+        }
+      },
+    })
+    server.registerTool('cancel_probe', { inputSchema: {} }, async () => {
+      callbackCalls++
+      return { content: [{ type: 'text', text: 'mutated' }] }
+    })
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair()
+    const client = new Client({ name: 'tool-cancellation-test', version: '0.0.0' })
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+
+    try {
+      const controller = new AbortController()
+      const call = client.callTool({ name: 'cancel_probe', arguments: {} }, undefined, {
+        signal: controller.signal,
+      })
+      await executorStarted
+      controller.abort()
+      await expect(call).rejects.toThrow()
+      await executorStopped
+      expect(callbackCalls).toBe(0)
+    } finally {
+      await client.close()
+      await server.close()
+    }
+  })
+
+  test('wraps tools registered through the deprecated tool surface', async () => {
+    const bridge = new SceneBridge()
+    bridge.loadDefault()
+    const executed: string[] = []
+    const server = createPascalMcpServer({
+      bridge,
+      executeTool: async ({ name, execute }) => {
+        executed.push(name)
+        return execute()
+      },
+    })
+    server.tool('legacy_probe', async () => ({
+      content: [{ type: 'text', text: 'legacy result' }],
+    }))
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair()
+    const client = new Client({ name: 'legacy-tool-executor-test', version: '0.0.0' })
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+
+    try {
+      const result = await client.callTool({ name: 'legacy_probe', arguments: {} })
+      expect(result.isError).toBeFalsy()
+      expect(executed).toEqual(['legacy_probe'])
     } finally {
       await client.close()
       await server.close()

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -10,6 +10,7 @@ import { version } from './version'
 
 export type PascalMcpToolExecutor = <Result>(input: {
   name: string
+  signal: AbortSignal
   execute: () => Promise<Result>
 }) => Promise<Result>
 
@@ -45,7 +46,27 @@ function installToolExecutor(server: McpServer, executeTool: PascalMcpToolExecut
     registerTool(name, config, ((...args: Parameters<typeof callback>) =>
       executeTool({
         name,
+        signal: toolRequestSignal(args),
         execute: () => Promise.resolve(Reflect.apply(callback, undefined, args)),
       })) as typeof callback)
   server.registerTool = wrappedRegisterTool
+
+  const tool = server.tool.bind(server)
+  server.tool = ((name: string, ...args: unknown[]) => {
+    const callback = args.at(-1)
+    if (typeof callback !== 'function') {
+      return Reflect.apply(tool, undefined, [name, ...args])
+    }
+    args[args.length - 1] = (...callbackArgs: unknown[]) =>
+      executeTool({
+        name,
+        signal: toolRequestSignal(callbackArgs),
+        execute: () => Promise.resolve(Reflect.apply(callback, undefined, callbackArgs)),
+      })
+    return Reflect.apply(tool, undefined, [name, ...args])
+  }) as McpServer['tool']
+}
+
+function toolRequestSignal(args: readonly unknown[]): AbortSignal {
+  return (args.at(-1) as { signal: AbortSignal }).signal
 }


### PR DESCRIPTION
## Description

MCP hosts that queue tool handlers need the SDK request cancellation signal before executing queued work. The server wrapper now passes each handler's `AbortSignal` to `executeTool` and applies the wrapper to both `registerTool()` and the deprecated `tool()` registration surface, so tools added after server creation cannot bypass host sequencing or cancellation policy.

## Validation

- `bun test packages/mcp/src` — 359 tests, 1,361 assertions passed.
- `bunx ultracite check packages/mcp/src/server.ts packages/mcp/src/server.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the public `executeTool` contract and changes when queued hosts may run or skip tool callbacks on cancellation.
> 
> **Overview**
> MCP hosts that wrap tool execution (e.g. to queue work) can now observe **request cancellation** before the underlying handler runs.
> 
> `PascalMcpToolExecutor` gains a required **`signal: AbortSignal`**, and `installToolExecutor` forwards the SDK request signal from handler arguments for both **`registerTool`** and the deprecated **`tool()`** path so late-registered tools still go through the host wrapper. Tests cover signal presence, abort-before-callback (tool body never runs), and legacy registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac73dac6a35f1de8cb9725c02be67666a6275e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->