### PR TITLE
Add Pascal to the official MCP Registry

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,0 +1,62 @@
+name: MCP Registry
+
+on:
+  pull_request:
+    paths:
+      - server.json
+      - .github/workflows/mcp-registry.yml
+  push:
+    branches: [main]
+    paths:
+      - server.json
+      - .github/workflows/mcp-registry.yml
+
+env:
+  MCP_PUBLISHER_VERSION: 1.8.1
+  MCP_PUBLISHER_LINUX_AMD64_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+
+      - name: Install MCP Registry publisher
+        run: |
+          curl --fail --location \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            --output "$RUNNER_TEMP/mcp-publisher.tar.gz"
+          echo "${MCP_PUBLISHER_LINUX_AMD64_SHA256}  $RUNNER_TEMP/mcp-publisher.tar.gz" | sha256sum --check
+          tar -xzf "$RUNNER_TEMP/mcp-publisher.tar.gz" -C "$RUNNER_TEMP" mcp-publisher
+
+      - name: Validate MCP Registry manifest
+        run: "$RUNNER_TEMP/mcp-publisher validate"
+
+      - name: Verify hosted endpoint contract
+        run: |
+          jq --exit-status '
+            .version == "0.6.1"
+            and .remotes == [{
+              "type": "streamable-http",
+              "url": "https://editor.pascal.app/api/mcp",
+              "headers": [{
+                "name": "Authorization",
+                "description": "Bearer API key created in Pascal Settings, formatted as Bearer sk_live_...",
+                "isRequired": true,
+                "isSecret": true
+              }]
+            }]
+          ' server.json
+          curl --fail --location --output /dev/null \
+            https://editor.pascal.app/docs/developers/mcp
+          status=$(curl --silent --show-error --output "$RUNNER_TEMP/mcp-response.json" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header 'content-type: application/json' \
+            --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"registry-check","version":"1"}}}' \
+            https://editor.pascal.app/api/mcp)
+          test "$status" = "401"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pascal Editor
 
-A 3D building editor built with React Three Fiber and WebGPU.
+An open-source, local-first 3D building editor built with React Three Fiber and
+WebGPU. Run it in the browser or from the CLI, and connect AI agents through MCP.
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![npm @pascal-app/core](https://img.shields.io/npm/v/@pascal-app/core?label=%40pascal-app%2Fcore)](https://www.npmjs.com/package/@pascal-app/core)
@@ -89,6 +90,13 @@ OpenClaw installation becomes available after the skills are published under Pas
 The skills inspect the connected MCP tool schemas before using optional fields. A capability present in this repository may be absent from an older installed or hosted release; the agent should report the narrower supported result instead of assuming source-only inputs are available.
 
 These workflows require a connected Pascal MCP server for their tool-backed actions. An OpenAI directory submission must therefore use **With MCP** and submit the production hosted MCP endpoint together with the skills. The repository package does not prove that the endpoint, OAuth flow, reviewer credentials, domain verification, or portal scan is ready for review.
+
+### MCP Registry
+
+[`server.json`](server.json) is Pascal's manifest for the official MCP Registry. Its
+version tracks the hosted MCP implementation independently of the npm package version.
+Pull requests validate the manifest and production endpoint. A Pascal organization
+owner publishes an approved version from `main` with the official registry publisher.
 
 ## Using Published Packages
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.pascalorg/editor",
+  "title": "Pascal 3D Editor",
+  "description": "Create, inspect, validate, and save editable 3D building scenes with Pascal's hosted MCP server.",
+  "version": "0.6.1",
+  "websiteUrl": "https://editor.pascal.app/docs/developers/mcp",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://editor.pascal.app/api/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer API key created in Pascal Settings, formatted as Bearer sk_live_...",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Pascal's hosted MCP server is usable today but absent from the official MCP Registry, so compatible clients cannot discover it through the registry.

This adds a remote-server manifest for `io.github.pascalorg/editor`, aligns its version with the deployed hosted MCP implementation, and adds a dedicated validation workflow. The workflow uses checksum-pinned `mcp-publisher` 1.8.1, validates the manifest, verifies the public setup documentation, and confirms that unauthenticated initialization fails closed. Publication remains an explicit organization-owner action from an approved `main` checkout, avoiding repository-wide OIDC publication authority.

Validation:
- `mcp-publisher 1.8.1 validate` against the production registry
- production MCP documentation returns 200
- unauthenticated production MCP initialization returns 401
- SHA-256 verification of the publisher binary
- `git diff --check`
- YAML parse check
