### PR TITLE
Verify MCP manifest against live API catalog

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -60,3 +60,46 @@ jobs:
             --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"registry-check","version":"1"}}}' \
             https://editor.pascal.app/api/mcp)
           test "$status" = "401"
+
+      - name: Verify live API catalog matches manifest
+        run: |
+          endpoint=$(jq --raw-output '.remotes[0].url' server.json)
+          version=$(jq --raw-output '.version' server.json)
+          transport=$(jq --raw-output '.remotes[0].type' server.json)
+          registry_name=$(jq --raw-output '.name' server.json)
+
+          curl --fail \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 3 \
+            --retry-connrefused \
+            --retry-delay 2 \
+            --header 'accept: application/linkset+json' \
+            --dump-header "$RUNNER_TEMP/api-catalog.headers" \
+            --output "$RUNNER_TEMP/api-catalog.json" \
+            https://editor.pascal.app/.well-known/api-catalog
+          grep --ignore-case --extended-regexp \
+            '^content-type: application/linkset\+json([;[:space:]]|$)' \
+            "$RUNNER_TEMP/api-catalog.headers"
+          jq --exit-status \
+            --arg endpoint "$endpoint" \
+            --arg version "$version" \
+            --arg transport "$transport" \
+            --arg registry_name "$registry_name" '
+              [.linkset[] | .item[]? | select(.href == $endpoint)] as $matches
+              | ($matches | length) == 1
+                and $matches[0].version == [$version]
+                and $matches[0].transport == [$transport]
+                and $matches[0]["registry-name"] == [$registry_name]
+            ' "$RUNNER_TEMP/api-catalog.json"
+
+          curl --fail --head \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 3 \
+            --retry-connrefused \
+            --retry-delay 2 \
+            https://editor.pascal.app/.well-known/api-catalog \
+            | tr -d '\r' \
+            | grep --fixed-strings --ignore-case \
+              'link: <https://editor.pascal.app/.well-known/api-catalog>; rel="api-catalog"'


### PR DESCRIPTION
The MCP Registry manifest could drift from the hosted discovery contract without CI noticing. This adds a live check that fetches Pascal's RFC 9727 API catalog and verifies the MCP endpoint, version, transport, and registry name against `server.json`, plus the required HEAD discovery relation.

Validation:
- Ran the exact workflow shell against production successfully
- Production returned `application/linkset+json` with version `0.6.1`, transport `streamable-http`, registry name `io.github.pascalorg/editor`, and the expected HEAD `api-catalog` link
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI shell checks against production; no application or auth logic is modified.
> 
> **Overview**
> Adds a **MCP Registry** workflow step that hits production's `/.well-known/api-catalog` and fails CI if discovery drifts from **`server.json`**.
> 
> The step reads endpoint URL, version, transport type, and registry name from the manifest, GETs the catalog with **`application/linkset+json`**, asserts the response content type, and uses **`jq`** to require exactly one linkset item whose **`href`**, **`version`**, **`transport`**, and **`registry-name`** match. It also sends a **HEAD** request and checks for the required **`rel="api-catalog"`** discovery link header.
> 
> This complements the existing manifest validation and hosted MCP contract checks so registry metadata cannot diverge from the live RFC 9727 catalog without a failing build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cfaba9cf0583470fc46128066f47279741ecfad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->