### PR TITLE
Improve agent skill discovery and MCP safety metadata

### DIFF
--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: open-pr
 description: Open a pull request on pascalorg/editor using the repo's PR template. Use when the user asks to open/create a PR, push and PR, or ship a branch in the editor repo.
+metadata:
+  internal: true
 allowed-tools: Bash(git *) Bash(gh *) Read
 ---
 

--- a/.agents/skills/open-pr2/SKILL.md
+++ b/.agents/skills/open-pr2/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: open-pr2
 description: Open or update a pull request on pascalorg/editor with a plain-language issue-and-fix description based on the full branch diff. Use only when the user explicitly asks for OpenPR2 or /open-pr2.
+metadata:
+  internal: true
 disable-model-invocation: true
 allowed-tools: Bash(git *) Bash(gh *) Bash(bun *) Read
 ---

--- a/.agents/skills/review-architecture/SKILL.md
+++ b/.agents/skills/review-architecture/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: review-architecture
 description: Review a PR against the Pascal architectural rules — package boundaries (core/viewer/editor/nodes), the registry-driven composition model (def.geometry / def.renderer / def.system), legacy-dispatch regressions, the slots + world-scale-UV convention for new nodes/geometry, hook hygiene (useEditor/useScene/useViewer), and selector performance. Use when the user asks to review a PR, audit a branch, or check that changes respect the codebase's architecture.
+metadata:
+  internal: true
 allowed-tools: Bash(git *) Bash(gh *) Read Grep Glob
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Validate agent skills and plugin packages
         run: |
-          bun test scripts/clawhub-ignore-policy.test.ts
+          bun test scripts/clawhub-ignore-policy.test.ts scripts/claude-mcp-config-policy.test.ts scripts/public-skill-discovery-policy.test.ts
           bun scripts/validate-skills.ts
 
       - name: Type check

--- a/packages/mcp/src/tools/annotations.ts
+++ b/packages/mcp/src/tools/annotations.ts
@@ -4,3 +4,28 @@ export const READ_ONLY_TOOL_ANNOTATIONS = {
   idempotentHint: true,
   openWorldHint: false,
 } as const
+
+export const READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+} as const
+
+export const ADDITIVE_TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  openWorldHint: false,
+} as const
+
+export const DESTRUCTIVE_TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  openWorldHint: false,
+} as const
+
+export const DESTRUCTIVE_OPEN_WORLD_TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  openWorldHint: true,
+} as const

--- a/packages/mcp/src/tools/apply-patch.ts
+++ b/packages/mcp/src/tools/apply-patch.ts
@@ -3,6 +3,7 @@ import type { AnyNode, AnyNodeId } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { Patch as BridgePatch } from '../bridge/scene-bridge'
 import type { SceneOperations } from '../operations'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from './annotations'
 import { ErrorCode, throwMcpError } from './errors'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { PatchSchema } from './schemas'
@@ -27,6 +28,7 @@ export function registerApplyPatch(server: McpServer, bridge: SceneOperations): 
         'Apply a batch of create/update/delete operations atomically. All patches are validated before any are applied; the entire batch forms a single undo step.',
       inputSchema: applyPatchInput,
       outputSchema: applyPatchOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ patches }) => {
       const bridgePatches: BridgePatch[] = patches.map((p) => {

--- a/packages/mcp/src/tools/construction-tools.ts
+++ b/packages/mcp/src/tools/construction-tools.ts
@@ -14,6 +14,7 @@ import {
 } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS, DESTRUCTIVE_TOOL_ANNOTATIONS } from './annotations'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { measurement } from './measurement'
 import { NodeIdSchema, Vec2Schema, Vec3Schema } from './schemas'
@@ -259,6 +260,7 @@ export function registerConstructionTools(server: McpServer, bridge: SceneOperat
         'Create one level-owned building shell from a footprint: perimeter walls plus optional slab and ceiling. Use once per story; do not make first-floor walls span multiple stories.',
       inputSchema: createStoryShellInput,
       outputSchema: createStoryShellOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({
       levelId,
@@ -355,6 +357,7 @@ export function registerConstructionTools(server: McpServer, bridge: SceneOperat
         'Create a roof container with one roof segment. By default creates a dedicated roof level above the reference level so exploded/solo level views can isolate the roof.',
       inputSchema: createRoofInput,
       outputSchema: createRoofOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({
       levelId,
@@ -460,6 +463,7 @@ export function registerConstructionTools(server: McpServer, bridge: SceneOperat
         'Create a straight stair and a single rectangular manual opening in the destination slab/source ceiling. This disables stair auto-opening mode to avoid duplicate or irregular holes.',
       inputSchema: createStairBetweenLevelsInput,
       outputSchema: createStairBetweenLevelsOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({
       fromLevelId,

--- a/packages/mcp/src/tools/create-level.ts
+++ b/packages/mcp/src/tools/create-level.ts
@@ -4,6 +4,7 @@ import type { AnyNodeId } from '@pascal-app/core/schema'
 import { LevelNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS } from './annotations'
 import { ErrorCode, throwMcpError } from './errors'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { measurement } from './measurement'
@@ -36,6 +37,7 @@ export function registerCreateLevel(server: McpServer, bridge: SceneOperations):
         "Append a new level above the given building's current top level. height is stored as the level's floor-to-floor storey height.",
       inputSchema: createLevelInput,
       outputSchema: createLevelOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ buildingId, height, label }) => {
       const parent = bridge.getNode(buildingId as AnyNodeId)

--- a/packages/mcp/src/tools/create-wall.ts
+++ b/packages/mcp/src/tools/create-wall.ts
@@ -3,6 +3,7 @@ import type { AnyNodeId } from '@pascal-app/core/schema'
 import { WallNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS } from './annotations'
 import { ErrorCode, throwMcpError } from './errors'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { measurement } from './measurement'
@@ -33,6 +34,7 @@ export function registerCreateWall(server: McpServer, bridge: SceneOperations): 
         'Create a new wall on the given level between two 2D points. Thickness and height default to the core library defaults when omitted.',
       inputSchema: createWallInput,
       outputSchema: createWallOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ levelId, start, end, thickness, height }) => {
       const parent = bridge.getNode(levelId as AnyNodeId)

--- a/packages/mcp/src/tools/cut-opening.ts
+++ b/packages/mcp/src/tools/cut-opening.ts
@@ -3,6 +3,7 @@ import type { AnyNodeId } from '@pascal-app/core/schema'
 import { DoorNode, WindowNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS } from './annotations'
 import { ErrorCode, throwMcpError } from './errors'
 import { wallLength, wallLocalXFromT } from './geometry'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
@@ -31,6 +32,7 @@ export function registerCutOpening(server: McpServer, bridge: SceneOperations): 
         'Cut a door or window opening into an existing wall. position is a parametric 0..1 offset along the wall centreline.',
       inputSchema: cutOpeningInput,
       outputSchema: cutOpeningOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ wallId, type, position, width, height }) => {
       const wall = bridge.getNode(wallId as AnyNodeId)

--- a/packages/mcp/src/tools/delete-node.ts
+++ b/packages/mcp/src/tools/delete-node.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { AnyNodeId } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from './annotations'
 import { ErrorCode, throwMcpError } from './errors'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { NodeIdSchema } from './schemas'
@@ -25,6 +26,7 @@ export function registerDeleteNode(server: McpServer, bridge: SceneOperations): 
         'Delete a node. If it has children, pass `cascade: true` to delete descendants recursively.',
       inputSchema: deleteNodeInput,
       outputSchema: deleteNodeOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ id, cascade }) => {
       const node = bridge.getNode(id as AnyNodeId)

--- a/packages/mcp/src/tools/describe-node.ts
+++ b/packages/mcp/src/tools/describe-node.ts
@@ -3,6 +3,7 @@ import { resolveCeilingHeight } from '@pascal-app/core'
 import type { AnyNode, AnyNodeId } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { READ_ONLY_TOOL_ANNOTATIONS } from './annotations'
 import { ErrorCode, throwMcpError } from './errors'
 import { resolveReportedWallHeight } from './scene-query'
 import { NodeIdSchema } from './schemas'
@@ -70,6 +71,7 @@ export function registerDescribeNode(server: McpServer, bridge: SceneOperations)
         'Return a structured summary of a node including its ancestry, children IDs, key properties, and a short human description.',
       inputSchema: describeNodeInput,
       outputSchema: describeNodeOutput,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ id }) => {
       const node = bridge.getNode(id as AnyNodeId)

--- a/packages/mcp/src/tools/duplicate-level.ts
+++ b/packages/mcp/src/tools/duplicate-level.ts
@@ -4,6 +4,7 @@ import type { AnyNode, AnyNodeId } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { Patch as BridgePatch } from '../bridge/scene-bridge'
 import type { SceneOperations } from '../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS } from './annotations'
 import { ErrorCode, throwMcpError } from './errors'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { NodeIdSchema } from './schemas'
@@ -27,6 +28,7 @@ export function registerDuplicateLevel(server: McpServer, bridge: SceneOperation
         'Clone a level and all its descendants into a new subtree attached to the same building.',
       inputSchema: duplicateLevelInput,
       outputSchema: duplicateLevelOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ levelId }) => {
       const node = bridge.getNode(levelId as AnyNodeId)

--- a/packages/mcp/src/tools/photo-to-scene/photo-to-scene.ts
+++ b/packages/mcp/src/tools/photo-to-scene/photo-to-scene.ts
@@ -12,6 +12,7 @@ import {
 } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
+import { DESTRUCTIVE_OPEN_WORLD_TOOL_ANNOTATIONS } from '../annotations'
 import { appendLiveSceneEvent } from '../live-sync'
 import { measurement } from '../measurement'
 
@@ -358,6 +359,7 @@ export function registerPhotoToScene(server: McpServer, bridge: SceneOperations)
         'Orchestrator: analyse a floor-plan photo via MCP sampling, translate the structured vision result into a Pascal SceneGraph (site → building → level with walls and zones), optionally save it, and swap the bridge to the new scene. Requires host support for sampling.',
       inputSchema: photoToSceneInput,
       outputSchema: photoToSceneOutput,
+      annotations: DESTRUCTIVE_OPEN_WORLD_TOOL_ANNOTATIONS,
     },
     async ({ image, scaleHint, name, save, defaultWallThickness, defaultWallHeight }) => {
       // 1. Vision.

--- a/packages/mcp/src/tools/place-item.ts
+++ b/packages/mcp/src/tools/place-item.ts
@@ -3,6 +3,7 @@ import type { AnyNodeId } from '@pascal-app/core/schema'
 import { ItemNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS } from './annotations'
 import { findCatalogItem } from './asset-catalog'
 import { ErrorCode, throwMcpError } from './errors'
 import { projectWorldPointToWallLocalX, wallLength } from './geometry'
@@ -32,6 +33,7 @@ export function registerPlaceItem(server: McpServer, bridge: SceneOperations): v
         'Place a catalog item into the scene. Target a level/slab/zone for floor items, a wall for wall-attached items, or a ceiling for ceiling-attached items. Do not target the site node directly.',
       inputSchema: placeItemInput,
       outputSchema: placeItemOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ catalogItemId, targetNodeId, position, rotation }) => {
       const target = bridge.getNode(targetNodeId as AnyNodeId)

--- a/packages/mcp/src/tools/read-tool-annotations.test.ts
+++ b/packages/mcp/src/tools/read-tool-annotations.test.ts
@@ -8,25 +8,101 @@ import { SceneBridge } from '../bridge/scene-bridge'
 import { createPascalMcpServer } from '../server'
 import { SqliteSceneStore } from '../storage/sqlite-scene-store'
 
-const FURNITURE_FIT_READ_TOOLS = [
-  'check_collisions',
-  'export_glb',
-  'export_json',
-  'find_nodes',
-  'get_level_summary',
-  'get_node',
-  'get_scene',
-  'get_walls',
-  'get_zones',
-  'list_levels',
-  'list_scenes',
-  'measure',
-  'validate_scene',
-  'verify_scene',
+const TOOL_POLICIES = [
+  {
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    tools: [
+      'check_collisions',
+      'describe_node',
+      'export_glb',
+      'export_json',
+      'find_nodes',
+      'get_level_summary',
+      'get_node',
+      'get_scene',
+      'get_walls',
+      'get_zones',
+      'list_levels',
+      'list_scenes',
+      'list_templates',
+      'measure',
+      'search_assets',
+      'validate_scene',
+      'verify_scene',
+    ],
+  },
+  {
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    tools: ['analyze_floorplan_image', 'analyze_room_photo'],
+  },
+  {
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      openWorldHint: false,
+    },
+    tools: [
+      'add_door',
+      'add_window',
+      'create_level',
+      'create_project',
+      'create_roof',
+      'create_room',
+      'create_story_shell',
+      'create_wall',
+      'cut_opening',
+      'duplicate_level',
+      'furnish_room',
+      'generate_variants',
+      'place_item',
+      'set_zone',
+    ],
+  },
+  {
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: false,
+    },
+    tools: [
+      'apply_patch',
+      'create_from_template',
+      'create_house_from_brief',
+      'create_stair_between_levels',
+      'delete_node',
+      'delete_scene',
+      'get_project_status',
+      'load_scene',
+      'redo',
+      'rename_scene',
+      'save_scene',
+      'undo',
+    ],
+  },
+  {
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+    },
+    tools: ['photo_to_scene'],
+  },
 ] as const
 
-describe('read-only MCP tool annotations', () => {
-  test('marks the furniture-fit inspection path safe for approval-aware clients', async () => {
+const EXPECTED_TOOL_NAMES = TOOL_POLICIES.flatMap(({ tools }) => tools).toSorted()
+
+describe('MCP tool annotations', () => {
+  test('classifies every registered tool for approval-aware clients', async () => {
     const bridge = new SceneBridge()
     bridge.setScene({}, [])
     bridge.loadDefault()
@@ -40,15 +116,13 @@ describe('read-only MCP tool annotations', () => {
     try {
       const listed = await client.listTools()
       const byName = new Map(listed.tools.map((tool) => [tool.name, tool]))
-      for (const name of FURNITURE_FIT_READ_TOOLS) {
-        expect(byName.get(name)?.annotations).toEqual({
-          readOnlyHint: true,
-          destructiveHint: false,
-          idempotentHint: true,
-          openWorldHint: false,
-        })
+      expect([...byName.keys()].toSorted()).toEqual(EXPECTED_TOOL_NAMES)
+
+      for (const policy of TOOL_POLICIES) {
+        for (const name of policy.tools) {
+          expect(byName.get(name)?.annotations).toEqual(policy.annotations)
+        }
       }
-      expect(byName.get('get_project_status')?.annotations?.readOnlyHint).not.toBe(true)
     } finally {
       await client.close()
       await server.close()

--- a/packages/mcp/src/tools/redo.ts
+++ b/packages/mcp/src/tools/redo.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from './annotations'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 
 export const redoInput = {
@@ -21,6 +22,7 @@ export function registerRedo(server: McpServer, bridge: SceneOperations): void {
         'Redo the next N previously-undone steps (default 1). Returns the number of steps actually redone.',
       inputSchema: redoInput,
       outputSchema: redoOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ steps }) => {
       const redone = bridge.redo(steps ?? 1)

--- a/packages/mcp/src/tools/room-tools.ts
+++ b/packages/mcp/src/tools/room-tools.ts
@@ -11,6 +11,7 @@ import {
 } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS, READ_ONLY_TOOL_ANNOTATIONS } from './annotations'
 import { findCatalogItem, searchCatalogItems } from './asset-catalog'
 import { keepoutCoversPlanned, keepoutForPolygonEdge } from './door-clearance'
 import { ErrorCode, throwMcpError } from './errors'
@@ -412,6 +413,7 @@ export function registerSearchAssets(server: McpServer): void {
         'Search the built-in MCP item catalog by keyword. Call before place_item when you need a valid catalogItemId.',
       inputSchema: searchAssetsInput,
       outputSchema: searchAssetsOutput,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ query, category }) => {
       const results = searchCatalogItems({ query, category }).map((item) => ({
@@ -436,6 +438,7 @@ export function registerCreateRoom(server: McpServer, bridge: SceneOperations): 
         'Create a room on a level: zone, slab, ceiling, and one wall per polygon edge. Returns wallIds in polygon edge order.',
       inputSchema: createRoomInput,
       outputSchema: createRoomOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ levelId, name, polygon, color, wallHeight, wallThickness }) => {
       assertLevel(bridge, levelId)
@@ -492,6 +495,7 @@ export function registerAddDoor(server: McpServer, bridge: SceneOperations): voi
         'Add a door to an existing wall. t/position is 0..1 along the wall: 0 = start, 0.5 = center, 1 = end.',
       inputSchema: addDoorInput,
       outputSchema: addDoorOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ wallId, t, position, width = 0.9, height = 2.1, hingesSide, swingDirection }) => {
       const wall = assertWall(bridge, wallId)
@@ -538,6 +542,7 @@ export function registerAddWindow(server: McpServer, bridge: SceneOperations): v
         'Add a window to an existing wall. t/position is 0..1 along the wall; sillHeight is the height from floor to window bottom.',
       inputSchema: addWindowInput,
       outputSchema: addWindowOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ wallId, t, position, width = 1.5, height = 1.5, sillHeight = 0.9 }) => {
       const wall = assertWall(bridge, wallId)
@@ -583,6 +588,7 @@ export function registerFurnishRoom(server: McpServer, bridge: SceneOperations):
         'Place furniture for a room type (levelId+polygon or zoneId). Skips or nudges poses that block door clear zones or overlap existing items (rotation-aware). Parent floor items to the level.',
       inputSchema: furnishRoomInput,
       outputSchema: furnishRoomOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ levelId, zoneId, roomType, polygon, doorWallIndex }) => {
       const room = inferRoomGeometry(bridge, levelId, polygon as Vec2[] | undefined, zoneId)

--- a/packages/mcp/src/tools/scene-lifecycle/create-project.ts
+++ b/packages/mcp/src/tools/scene-lifecycle/create-project.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, throwMcpError } from '../errors'
 import { currentLevelContext, projectStatusPayload } from './metadata'
 
@@ -43,6 +44,7 @@ export function registerCreateProject(server: McpServer, operations: SceneOperat
         'Create a browser-visible Pascal project for the authenticated user. Use this before save_scene when the user asks for a new project.',
       inputSchema: createProjectInput,
       outputSchema: createProjectOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ name, id, isPrivate }) => {
       if (!operations.canCreateProject) {

--- a/packages/mcp/src/tools/scene-lifecycle/delete-scene.ts
+++ b/packages/mcp/src/tools/scene-lifecycle/delete-scene.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
 import { SceneNotFoundError, SceneVersionConflictError } from '../../storage/types'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, throwMcpError } from '../errors'
 
 export const deleteSceneInput = {
@@ -22,6 +23,7 @@ export function registerDeleteScene(server: McpServer, operations: SceneOperatio
         'Delete a scene from the SceneStore by id. Optionally pass `expectedVersion` for optimistic concurrency.',
       inputSchema: deleteSceneInput,
       outputSchema: deleteSceneOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ id, expectedVersion }) => {
       try {

--- a/packages/mcp/src/tools/scene-lifecycle/get-project-status.ts
+++ b/packages/mcp/src/tools/scene-lifecycle/get-project-status.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, McpError, throwMcpError } from '../errors'
 import { currentLevelContext, projectStatusPayload } from './metadata'
 
@@ -41,6 +42,7 @@ export function registerGetProjectStatus(server: McpServer, operations: SceneOpe
         'Authoritative status/debug call for a Pascal project: editor URL, browser-visible version, latest saved version, published version, node count, and graph hash.',
       inputSchema: getProjectStatusInput,
       outputSchema: getProjectStatusOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ id }) => {
       try {

--- a/packages/mcp/src/tools/scene-lifecycle/load-scene.ts
+++ b/packages/mcp/src/tools/scene-lifecycle/load-scene.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, throwMcpError } from '../errors'
 import { currentLevelContext, sceneMetaPayload } from './metadata'
 
@@ -38,6 +39,7 @@ export function registerLoadScene(server: McpServer, bridge: SceneOperations): v
         'Load a scene from the SceneStore into the bridge. Returns the scene metadata. Throws `scene_not_found` if the id does not exist.',
       inputSchema: loadSceneInput,
       outputSchema: loadSceneOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ id }) => {
       const result = await bridge.loadStoredScene(id)

--- a/packages/mcp/src/tools/scene-lifecycle/rename-scene.ts
+++ b/packages/mcp/src/tools/scene-lifecycle/rename-scene.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
 import { SceneNotFoundError, SceneVersionConflictError } from '../../storage/types'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, throwMcpError } from '../errors'
 
 export const renameSceneInput = {
@@ -32,6 +33,7 @@ export function registerRenameScene(server: McpServer, operations: SceneOperatio
         'Rename a scene in the SceneStore. Returns the updated SceneMeta. Optionally pass `expectedVersion` for optimistic concurrency.',
       inputSchema: renameSceneInput,
       outputSchema: renameSceneOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ id, newName, expectedVersion }) => {
       try {

--- a/packages/mcp/src/tools/scene-lifecycle/save-scene.ts
+++ b/packages/mcp/src/tools/scene-lifecycle/save-scene.ts
@@ -4,6 +4,7 @@ import { AnyNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
 import { SceneVersionConflictError } from '../../storage/types'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, throwMcpError } from '../errors'
 import { appendLiveSceneEvent } from '../live-sync'
 import { currentLevelContext, sceneMetaPayload } from './metadata'
@@ -66,6 +67,7 @@ export function registerSaveScene(server: McpServer, bridge: SceneOperations): v
         'Save the current scene (or a provided graph) to the SceneStore. Defaults to a browser-visible draft save so agents can iterate without creating many project versions. Use saveMode: "checkpoint" for meaningful version history.',
       inputSchema: saveSceneInput,
       outputSchema: saveSceneOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({
       id,

--- a/packages/mcp/src/tools/set-zone.ts
+++ b/packages/mcp/src/tools/set-zone.ts
@@ -3,6 +3,7 @@ import type { AnyNodeId } from '@pascal-app/core/schema'
 import { ZoneNode } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS } from './annotations'
 import { ErrorCode, throwMcpError } from './errors'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 import { NodeIdSchema, Vec2Schema } from './schemas'
@@ -28,6 +29,7 @@ export function registerSetZone(server: McpServer, bridge: SceneOperations): voi
         'Create a polygonal zone on the given level. label is stored as the zone name and properties are merged into metadata.',
       inputSchema: setZoneInput,
       outputSchema: setZoneOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ levelId, polygon, label, properties }) => {
       const parent = bridge.getNode(levelId as AnyNodeId)

--- a/packages/mcp/src/tools/templates/create-from-template.ts
+++ b/packages/mcp/src/tools/templates/create-from-template.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { rehydrateSiteChildren } from '../../lib/rehydrate-site-children'
 import type { SceneOperations } from '../../operations'
 import { isTemplateId, TEMPLATES, type TemplateId } from '../../templates'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, throwMcpError } from '../errors'
 import { appendLiveSceneEvent } from '../live-sync'
 import { currentLevelContext, sceneMetaPayload } from '../scene-lifecycle/metadata'
@@ -79,6 +80,7 @@ export function registerCreateFromTemplate(server: McpServer, bridge: SceneOpera
         'Instantiate a seed Pascal scene template into the bridge. Regenerates all ids before applying. When `save: true` and a SceneStore is wired, also persists the new scene and returns the SceneMeta.',
       inputSchema: createFromTemplateInput,
       outputSchema: createFromTemplateOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ id, name, save, projectId }) => {
       if (!isTemplateId(id)) {

--- a/packages/mcp/src/tools/templates/create-house-from-brief.ts
+++ b/packages/mcp/src/tools/templates/create-house-from-brief.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { rehydrateSiteChildren } from '../../lib/rehydrate-site-children'
 import type { SceneOperations } from '../../operations'
 import { isTemplateId, TEMPLATES, type TemplateId } from '../../templates'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, throwMcpError } from '../errors'
 import { appendLiveSceneEvent } from '../live-sync'
 import { currentLevelContext, sceneMetaPayload } from '../scene-lifecycle/metadata'
@@ -83,6 +84,7 @@ export function registerCreateHouseFromBrief(server: McpServer, bridge: SceneOpe
         'High-level hosted workflow for external agents: choose a starter house from a brief, create/save/publish it, and return the editor URL. Use semantic tools afterward for exact customization.',
       inputSchema: createHouseFromBriefInput,
       outputSchema: createHouseFromBriefOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({
       brief,

--- a/packages/mcp/src/tools/templates/list-templates.ts
+++ b/packages/mcp/src/tools/templates/list-templates.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { TEMPLATES } from '../../templates'
+import { READ_ONLY_TOOL_ANNOTATIONS } from '../annotations'
 
 export const listTemplatesInput = {} as const
 
@@ -29,6 +30,7 @@ export function registerListTemplates(server: McpServer): void {
         'List the seed Pascal scene templates available to `create_from_template`. Returns the id, display name, one-line description and node count for each.',
       inputSchema: listTemplatesInput,
       outputSchema: listTemplatesOutput,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async () => {
       const templates = Object.values(TEMPLATES).map((entry) => ({

--- a/packages/mcp/src/tools/undo.ts
+++ b/packages/mcp/src/tools/undo.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../operations'
+import { DESTRUCTIVE_TOOL_ANNOTATIONS } from './annotations'
 import { liveSyncOutput, persistencePayload, publishLiveSceneSnapshot } from './live-sync'
 
 export const undoInput = {
@@ -21,6 +22,7 @@ export function registerUndo(server: McpServer, bridge: SceneOperations): void {
         'Undo the most recent N steps in the scene history (default 1). Returns the number of steps actually undone.',
       inputSchema: undoInput,
       outputSchema: undoOutput,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
     },
     async ({ steps }) => {
       const undone = bridge.undo(steps ?? 1)

--- a/packages/mcp/src/tools/variants/generate-variants.ts
+++ b/packages/mcp/src/tools/variants/generate-variants.ts
@@ -3,6 +3,7 @@ import { forkSceneGraph, type SceneGraph } from '@pascal-app/core/clone-scene-gr
 import { AnyNode as AnyNodeSchema } from '@pascal-app/core/schema'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
+import { ADDITIVE_TOOL_ANNOTATIONS } from '../annotations'
 import { ErrorCode, throwMcpError } from '../errors'
 import { applyMutation, describeVariant, type MutationKind, mulberry32 } from './mutations'
 
@@ -64,6 +65,7 @@ export function registerGenerateVariants(server: McpServer, bridge: SceneOperati
         'Generate N variations of a base scene by forking and applying seeded mutations. Example: "give me 5 variations of this kitchen". If `save=true`, each variant is persisted via scene operations and returned with an id + URL; otherwise the graph is returned inline.',
       inputSchema: generateVariantsInput,
       outputSchema: generateVariantsOutput,
+      annotations: ADDITIVE_TOOL_ANNOTATIONS,
     },
     async ({ baseSceneId, count, vary, seed, save }) => {
       // 1. Obtain the base SceneGraph.

--- a/packages/mcp/src/tools/vision/analyze-floorplan-image.ts
+++ b/packages/mcp/src/tools/vision/analyze-floorplan-image.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
+import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from '../annotations'
 
 /**
  * Input shape for `analyze_floorplan_image`.
@@ -127,6 +128,7 @@ export function registerAnalyzeFloorplanImage(server: McpServer, _bridge: SceneO
         'Defer to the MCP host (via sampling) to extract walls, rooms, and approximate dimensions from a floor-plan image. Requires host support for sampling.',
       inputSchema: analyzeFloorplanImageInput,
       outputSchema: analyzeFloorplanImageOutput,
+      annotations: READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS,
     },
     async ({ image, scaleHint }) => {
       const caps = server.server.getClientCapabilities()

--- a/packages/mcp/src/tools/vision/analyze-room-photo.ts
+++ b/packages/mcp/src/tools/vision/analyze-room-photo.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import type { SceneOperations } from '../../operations'
+import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from '../annotations'
 
 /**
  * Input shape for `analyze_room_photo`.
@@ -108,6 +109,7 @@ export function registerAnalyzeRoomPhoto(server: McpServer, _bridge: SceneOperat
         'Defer to the MCP host (via sampling) to extract approximate dimensions, fixtures, and windows from a single-room photograph. Requires host support for sampling.',
       inputSchema: analyzeRoomPhotoInput,
       outputSchema: analyzeRoomPhotoOutput,
+      annotations: READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS,
     },
     async ({ image }) => {
       const caps = server.server.getClientCapabilities()

--- a/plugin-evals/publishing-cases.json
+++ b/plugin-evals/publishing-cases.json
@@ -7,6 +7,17 @@
     "OAuth-compatible reviewer access and reusable demo credentials without MFA, SMS, email confirmation, or private-network access are not prepared.",
     "Positive cases do not yet identify provisioned disposable project fixtures and stable reviewer-visible identifiers."
   ],
+  "tool_annotation_validation": {
+    "status": "local_pass",
+    "checked_at": "2026-09-09",
+    "registered_tools": 46,
+    "required_hints": ["readOnlyHint", "destructiveHint", "openWorldHint"],
+    "evidence": [
+      "The live MCP tools/list enumeration test classified all 46 registered tools and failed on any unlisted or unannotated tool.",
+      "The complete @pascal-app/mcp suite passed 361 tests with 1407 assertions, and the package TypeScript build passed."
+    ],
+    "limitations": "Local enumeration and package checks do not establish production hosted-MCP behavior, OpenAI Scan Tools approval, reviewer access, submission, or listing."
+  },
   "cases": [
     {
       "id": "foundation-hosted-create-room-positive",

--- a/scripts/public-skill-discovery-policy.test.ts
+++ b/scripts/public-skill-discovery-policy.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import {
+  collectSkillDiscoveryEntries,
+  intendedPublicSkillNames,
+  publicSkillNames,
+  type SkillDiscoveryEntry,
+  validatePublicSkillDiscoverySurface,
+} from './public-skill-discovery-policy'
+
+const repositoryRoot = resolve(import.meta.dir, '..')
+const canonicalEntries = collectSkillDiscoveryEntries(repositoryRoot)
+
+function replaceEntry(path: string, replace: (content: string) => string): SkillDiscoveryEntry[] {
+  return canonicalEntries.map((entry) =>
+    entry.path === path ? { ...entry, content: replace(entry.content) } : entry,
+  )
+}
+
+describe('public skill discovery policy', () => {
+  test('exposes exactly the two product skills', () => {
+    expect(validatePublicSkillDiscoverySurface(canonicalEntries)).toEqual([])
+    expect(publicSkillNames(canonicalEntries)).toEqual(intendedPublicSkillNames)
+  })
+
+  test.each([
+    '.agents/skills/open-pr/SKILL.md',
+    '.agents/skills/open-pr2/SKILL.md',
+    '.agents/skills/review-architecture/SKILL.md',
+  ])('requires %s to remain internal', (path) => {
+    const entries = replaceEntry(path, (content) => content.replace('  internal: true\n', ''))
+    expect(validatePublicSkillDiscoverySurface(entries)).toContain(
+      `${path} must declare metadata.internal: true`,
+    )
+  })
+
+  test('rejects an explicit false value on a maintainer skill', () => {
+    const path = '.agents/skills/open-pr/SKILL.md'
+    const entries = replaceEntry(path, (content) =>
+      content.replace('  internal: true', '  internal: false'),
+    )
+    expect(validatePublicSkillDiscoverySurface(entries)).toContain(
+      `${path} must declare metadata.internal: true`,
+    )
+  })
+
+  test('rejects hiding a product skill', () => {
+    const path = 'skills/pascal-3d/SKILL.md'
+    const entries = replaceEntry(path, (content) =>
+      content.replace('metadata:\n', 'metadata:\n  internal: true\n'),
+    )
+    const failures = validatePublicSkillDiscoverySurface(entries)
+    expect(failures).toContain(`${path} must remain publicly discoverable`)
+    expect(
+      failures.some((failure) => failure.startsWith('Public skill discovery must expose')),
+    ).toBe(true)
+  })
+
+  test('rejects an unexpected discoverable skill', () => {
+    const entries = [
+      ...canonicalEntries,
+      {
+        path: 'skills/unreviewed/SKILL.md',
+        content: '---\nname: unreviewed\ndescription: fixture\n---\n',
+      },
+    ]
+    const failures = validatePublicSkillDiscoverySurface(entries)
+    expect(failures).toContain(
+      'Unexpected skill in the repository discovery roots: skills/unreviewed/SKILL.md',
+    )
+    expect(failures).toContain(
+      `Public skill discovery must expose exactly ${intendedPublicSkillNames.join(', ')}; found ${[...intendedPublicSkillNames, 'unreviewed'].sort().join(', ')}`,
+    )
+  })
+
+  test('collects nested skills so discovery cannot bypass the policy', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'pascal-skill-discovery-'))
+    try {
+      const nestedSkillRoot = join(fixtureRoot, 'skills', 'nested', 'unreviewed')
+      mkdirSync(nestedSkillRoot, { recursive: true })
+      writeFileSync(
+        join(nestedSkillRoot, 'SKILL.md'),
+        '---\nname: nested-unreviewed\ndescription: fixture\n---\n',
+      )
+      expect(collectSkillDiscoveryEntries(fixtureRoot).map((entry) => entry.path)).toEqual([
+        'skills/nested/unreviewed/SKILL.md',
+      ])
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects a frontmatter name that differs from its intended skill', () => {
+    const path = 'skills/furniture-fit/SKILL.md'
+    const entries = replaceEntry(path, (content) =>
+      content.replace('name: furniture-fit', 'name: furniture-placement'),
+    )
+    expect(validatePublicSkillDiscoverySurface(entries)).toContain(
+      `${path} must declare frontmatter name furniture-fit`,
+    )
+  })
+})

--- a/scripts/public-skill-discovery-policy.ts
+++ b/scripts/public-skill-discovery-policy.ts
@@ -1,0 +1,129 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+export type SkillDiscoveryEntry = {
+  path: string
+  content: string
+}
+
+type IntendedSkill = {
+  name: string
+  internal: boolean
+}
+
+export const intendedSkillDiscovery = new Map<string, IntendedSkill>([
+  ['skills/pascal-3d/SKILL.md', { name: 'pascal-3d', internal: false }],
+  ['skills/furniture-fit/SKILL.md', { name: 'furniture-fit', internal: false }],
+  ['.agents/skills/open-pr/SKILL.md', { name: 'open-pr', internal: true }],
+  ['.agents/skills/open-pr2/SKILL.md', { name: 'open-pr2', internal: true }],
+  ['.agents/skills/review-architecture/SKILL.md', { name: 'review-architecture', internal: true }],
+])
+
+export const intendedPublicSkillNames = [...intendedSkillDiscovery.values()]
+  .filter((skill) => !skill.internal)
+  .map((skill) => skill.name)
+  .sort()
+
+function parseFrontmatter(content: string): string[] | undefined {
+  const match = content.match(/^---\n([\s\S]*?)\n---/u)
+  return match?.[1]?.split('\n')
+}
+
+export function parseSkillDiscoveryMetadata(content: string): {
+  name?: string
+  internal?: boolean
+} {
+  const lines = parseFrontmatter(content)
+  if (!lines) return {}
+
+  let name: string | undefined
+  let internal: boolean | undefined
+  let inMetadata = false
+
+  for (const line of lines) {
+    const topLevel = line.match(/^([A-Za-z][A-Za-z0-9-]*):(?:\s*(.*))?$/u)
+    if (topLevel) {
+      inMetadata = topLevel[1] === 'metadata'
+      if (topLevel[1] === 'name') name = topLevel[2]?.replace(/^['"]|['"]$/gu, '')
+      continue
+    }
+
+    if (!inMetadata) continue
+    const internalField = line.match(/^ {2}internal:\s*(true|false)\s*$/u)
+    if (internalField) internal = internalField[1] === 'true'
+  }
+
+  return { name, internal }
+}
+
+export function collectSkillDiscoveryEntries(repositoryRoot: string): SkillDiscoveryEntry[] {
+  const entries: SkillDiscoveryEntry[] = []
+
+  function collectFrom(directory: string) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name)
+      if (entry.isDirectory()) {
+        collectFrom(path)
+      } else if (entry.isFile() && entry.name === 'SKILL.md') {
+        entries.push({
+          path: relative(repositoryRoot, path).replaceAll('\\', '/'),
+          content: readFileSync(path, 'utf8'),
+        })
+      }
+    }
+  }
+
+  for (const skillsRoot of ['skills', '.agents/skills']) {
+    const absoluteRoot = join(repositoryRoot, skillsRoot)
+    if (existsSync(absoluteRoot)) collectFrom(absoluteRoot)
+  }
+
+  return entries.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+export function publicSkillNames(entries: SkillDiscoveryEntry[]): string[] {
+  return entries
+    .map((entry) => parseSkillDiscoveryMetadata(entry.content))
+    .filter((metadata) => metadata.internal !== true && metadata.name)
+    .map((metadata) => metadata.name!)
+    .sort()
+}
+
+export function validatePublicSkillDiscoverySurface(entries: SkillDiscoveryEntry[]): string[] {
+  const failures: string[] = []
+  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]))
+
+  for (const entry of entries) {
+    if (!intendedSkillDiscovery.has(entry.path)) {
+      failures.push(`Unexpected skill in the repository discovery roots: ${entry.path}`)
+    }
+  }
+
+  for (const [path, intended] of intendedSkillDiscovery) {
+    const entry = entriesByPath.get(path)
+    if (!entry) {
+      failures.push(`Missing intended skill: ${path}`)
+      continue
+    }
+
+    const metadata = parseSkillDiscoveryMetadata(entry.content)
+    if (metadata.name !== intended.name) {
+      failures.push(`${path} must declare frontmatter name ${intended.name}`)
+    }
+    if (intended.internal && metadata.internal !== true) {
+      failures.push(`${path} must declare metadata.internal: true`)
+    }
+    if (!intended.internal && metadata.internal === true) {
+      failures.push(`${path} must remain publicly discoverable`)
+    }
+  }
+
+  const actualPublicSkillNames = publicSkillNames(entries)
+  if (actualPublicSkillNames.join('\n') !== intendedPublicSkillNames.join('\n')) {
+    failures.push(
+      `Public skill discovery must expose exactly ${intendedPublicSkillNames.join(', ')}; found ${actualPublicSkillNames.join(', ') || 'none'}`,
+    )
+  }
+
+  return failures
+}

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -4,6 +4,10 @@ import { fileURLToPath } from 'node:url'
 import { XMLParser, XMLValidator } from 'fast-xml-parser'
 import { validateClaudeMcpPolicy } from './claude-mcp-config-policy'
 import { validateClawHubIgnorePolicy } from './clawhub-ignore-policy'
+import {
+  collectSkillDiscoveryEntries,
+  validatePublicSkillDiscoverySurface,
+} from './public-skill-discovery-policy'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const skillNames = ['pascal-3d', 'furniture-fit'] as const
@@ -195,6 +199,12 @@ function walk(path: string): string[] {
     }
   }
   return files
+}
+
+for (const discoveryFailure of validatePublicSkillDiscoverySurface(
+  collectSkillDiscoveryEntries(root),
+)) {
+  fail(discoveryFailure)
 }
 
 for (const entry of readdirSync(join(root, 'skills'), { withFileTypes: true })) {

--- a/skills/README.md
+++ b/skills/README.md
@@ -7,13 +7,13 @@ These public skills teach MCP-capable agents to use Pascal for editable building
 List the available skills:
 
 ```bash
-npx skills add pascalorg/editor --list
+npx skills add https://github.com/pascalorg/editor/tree/main/skills --list
 ```
 
 Install both skills:
 
 ```bash
-npx skills add pascalorg/editor \
+npx skills add https://github.com/pascalorg/editor/tree/main/skills \
   --skill pascal-3d \
   --skill furniture-fit
 ```
@@ -81,10 +81,9 @@ The `source-reviewed` date records a code and public-documentation review. The `
 ## Validate the source package
 
 ```bash
-bun test scripts/clawhub-ignore-policy.test.ts
-bun test scripts/claude-mcp-config-policy.test.ts
+bun test scripts/clawhub-ignore-policy.test.ts scripts/claude-mcp-config-policy.test.ts scripts/public-skill-discovery-policy.test.ts
 bun scripts/validate-skills.ts
 claude plugin validate . --strict
 ```
 
-The repository validator checks frontmatter, bundled links, task and trigger fixtures, semantic furniture next-action decision cases, scoped ClawHub ignore policies without re-inclusion overrides, the exact credential-free Claude local MCP configuration, the publishing suite, portable and compatibility manifest consistency, OpenAI public-directory metadata limits, bundled branding assets, and accidental private-path or credential leakage.
+The repository validator checks the exact two-skill public discovery surface, keeps contributor-only workflows internal, and checks frontmatter, bundled links, task and trigger fixtures, semantic furniture next-action decision cases, scoped ClawHub ignore policies without re-inclusion overrides, the exact credential-free Claude local MCP configuration, the publishing suite, portable and compatibility manifest consistency, OpenAI public-directory metadata limits, bundled branding assets, and accidental private-path or credential leakage.

--- a/skills/VALIDATION.md
+++ b/skills/VALIDATION.md
@@ -2,6 +2,12 @@
 
 Released package source: **0.1.7**. Latest released package source: **0.1.7**. `pascal-3d` skill metadata version: **0.1.0**. `furniture-fit` skill metadata version: **0.1.3**. Recorded September 9, 2026.
 
+## OpenAI MCP tool-annotation candidate
+
+The unreleased candidate based on public `main` at `ed562c3a09570a2fe02a6c8c0d56142b224a3b7a` explicitly classifies every registered MCP tool with `readOnlyHint`, `destructiveHint`, and `openWorldHint`. The live `tools/list` regression test enumerated all 46 tools, required an exact classified inventory, and passed. The classifications distinguish 17 closed-world reads, two open-world image-analysis reads, 14 additive closed-world mutations, 12 destructive closed-world operations, and one destructive open-world photo-to-scene operation.
+
+`bun test packages/mcp/src/tools/read-tool-annotations.test.ts packages/mcp/src/tools/check-collisions.test.ts` passed 14 tests with 88 assertions. The complete `packages/mcp` suite passed 361 tests with 1,407 assertions, `bun run build` passed, and changed-file Ultracite checks passed. These local checks establish annotation completeness for the tested package source. They do not establish behavior of the production hosted endpoint, an OpenAI Scan Tools result, reviewer access, submission, approval, listing, or release; the publishing suite remains blocked on those prerequisites.
+
 ## Bundle 0.1.7 Claude local MCP release
 
 This release adds one Claude plugin-provided local stdio server whose exact command is `pascal mcp connect`. The package does not contain a remote URL, headers, environment credentials, or another server. It does not install or start the Pascal editor; `pascal` must already be on the `PATH` used to launch Claude Code. Local use requires no Pascal account or API key and does not upload projects automatically.


### PR DESCRIPTION
The public skill surface exposed maintainer-only workflows, and MCP clients lacked reliable side-effect metadata for approval decisions. This change limits marketplace discovery to the two product skills and adds truthful OpenAI-compatible annotations to all 46 registered MCP tools.

Validation:
- 47 combined policy and MCP tests passed
- Full Biome check passed across 2,098 files
- Skill/package validator passed
- MCP TypeScript build passed
- Independent source worktrees also passed the full 361-test MCP suite and real skills.sh discovery

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MCP tool metadata and skill discovery rules affect agent approval behavior and what ships publicly; mistakes could mislabel destructive tools or expose internal skills, but changes are heavily regression-tested.
> 
> **Overview**
> This PR **locks public agent-skill discovery** to `pascal-3d` and `furniture-fit`, and marks maintainer workflows (`open-pr`, `open-pr2`, `review-architecture`) as **`metadata.internal: true`**. A new **`public-skill-discovery-policy`** module plus CI/`validate-skills` checks reject extra `SKILL.md` files, hidden product skills, or internal skills without the flag.
> 
> On the MCP side, it introduces **shared tool annotation presets** (`readOnlyHint`, `destructiveHint`, `openWorldHint`, etc.) and attaches them to **every registered tool**. The **`read-tool-annotations`** test now asserts an exact inventory of **46 tools** and their policy bucket (closed-world reads, open-world vision reads, additive mutations, destructive lifecycle/scene ops, destructive open-world `photo_to_scene`).
> 
> Docs and publishing metadata are updated: **skills.sh** install URLs point at the `skills/` tree, validation commands include the new policy tests, and **`VALIDATION.md` / `plugin-evals`** record local annotation evidence (not production hosted-MCP approval).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ca1b71a6dcc35d03bc1dbf5be45971def97ce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->