### PR TITLE
fix(editor): type optional ancestor traversal for consumers

### DIFF
--- a/packages/editor/src/components/tools/shared/pointer-support-cap.ts
+++ b/packages/editor/src/components/tools/shared/pointer-support-cap.ts
@@ -1,4 +1,5 @@
 import {
+  type AnyNode,
   type AnyNodeId,
   canHostOnTop,
   GROUND_SUPPORT_ID,
@@ -194,7 +195,7 @@ export function resolvePointerSupportSurface(
     // convention — the election owns the invariant.
     const interactingNodeId = scopeNodeId(useInteractionScope.getState().scope)
     const isEligibleCandidate = (nodeId: AnyNodeId) => {
-      let current = nodes[nodeId]
+      let current: AnyNode | undefined = nodes[nodeId]
       const visited = new Set<AnyNodeId>()
       while (current && !visited.has(current.id)) {
         if (current.id === interactingNodeId) return false


### PR DESCRIPTION
## What does this PR do?

Fixes #617. A consumer compiling the raw editor TypeScript with `strict: true` and `noUncheckedIndexedAccess: false` infers the ancestor traversal variable as `AnyNode`, then rejects the later `undefined` assignment with TS2322. Explicitly typing it as `AnyNode | undefined` makes the traversal compile with either setting. The added import is type-only; runtime behavior is unchanged.

## How to test

1. Compile the affected ancestor traversal with TypeScript 6.0.3, `strict: true`, and `noUncheckedIndexedAccess: false`.
2. Confirm the original source reports TS2322 and this change removes it.
3. Repeat with `noUncheckedIndexedAccess: true`; both revisions should compile.

Local focused validation used the actual loop extracted through the TypeScript AST, structural node declarations, and the existing `Record<AnyNodeId, AnyNode>` scene-map contract. It reproduced the original failure and passed both configurations after the change. This is not a full workspace typecheck. `git diff --check` and a file-scoped Biome 2.4.16 check also passed. TypeScript 6.0.3 transpilation produced byte-identical JavaScript before and after the type-only change (12,731 bytes).

The required `bun run check` and `bun run test` commands were attempted, but the isolated checkout lacks the workspace-installed `biome` and `turbo` executables. Full workspace validation remains for CI/reviewer environment.

## Screenshots / screen recording

Not applicable: this is a type-only change.

## Checklist

- [ ] I've tested this locally with `bun dev` (not run; no runtime change)
- [x] My code follows the existing code style (file-scoped pinned Biome passed; full `bun check` needs workspace dependencies)
- [x] I've updated relevant documentation (not applicable)
- [x] This PR targets the `main` branch