### PR TITLE
fix(ci): authenticate CLI npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,8 @@ jobs:
 
       - name: Publish CLI
         if: inputs.package == 'cli' || inputs.package == 'all'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd packages/cli
           if [ "${{ inputs.dry-run }}" = "true" ]; then


### PR DESCRIPTION
## What does this PR do?

Passes the repository `NPM_TOKEN` to the CLI publish step, matching the other package-specific publish steps. The CLI beta release reached `npm publish` but failed with npm 404/permission because this step had no token environment.

## How to test

1. Inspect the release workflow diff.
2. Rerun the CLI beta release after merge; its recovery-safe version check will publish `1.0.0-beta.2` and then commit/tag the version bump.

## Screenshots / screen recording

Not applicable.

## Checklist

- [ ] I've tested this locally with `bun dev`
- [x] My code follows the existing workflow pattern
- [ ] I've updated relevant documentation
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds missing npm auth to an existing publish step; no application or runtime behavior changes.
> 
> **Overview**
> The **Publish CLI** job in `release.yml` now sets `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN`, the same pattern used by the other package publish steps.
> 
> Without this, CLI releases could reach `npm publish` and fail with registry permission/404 errors because npm had no credentials for that step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7957fffd33ed40c52f1e509b52293d52f26da528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->