### PR TITLE
fix(ci): restore OIDC for CLI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,8 +354,7 @@ jobs:
 
       - name: Publish CLI
         if: inputs.package == 'cli' || inputs.package == 'all'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # Keep token auth unset so npm can exchange the GitHub OIDC identity.
         run: |
           cd packages/cli
           if [ "${{ inputs.dry-run }}" = "true" ]; then


### PR DESCRIPTION
The CLI publish step fell back to the repository npm token after trusted publishing was introduced. The current token now requires an OTP, so `@pascal-app/cli@1.0.0-beta.2` could not publish.

This restores the intended tokenless OIDC path for the CLI. npm still needs the package trusted-publisher mapping for `pascalorg/editor`, `.github/workflows/release.yml`, and the `npm` environment before the release can succeed.

Validation: `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to CLI publish authentication; no application runtime impact, though releases depend on npm trusted-publisher configuration being correct.
> 
> **Overview**
> The **Publish CLI** step in `release.yml` no longer sets `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN`, so `npm publish` can use GitHub OIDC trusted publishing (the job already requests `id-token: write` and runs in the `npm` environment).
> 
> A comment documents that token auth must stay unset for that exchange. Other packages in the workflow still publish with the legacy npm token; only the CLI path is aligned with the intended tokenless flow that was broken when the step inherited token auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f668bcd8021a975d448334ea76b9defd309904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->