### PR TITLE
feat(cli): prefill hosted agent claim

### DIFF
--- a/packages/cli/src/agent-account.test.ts
+++ b/packages/cli/src/agent-account.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { startAgentClaim } from './agent-account.js'
+import { agentClaimHandoffUrl, startAgentClaim } from './agent-account.js'
 import { CliError } from './errors.js'
 
 const API_KEY = 'sk_live_private-agent-key'
@@ -10,6 +10,13 @@ const VALID_CLAIM = {
 }
 
 describe('agent account claims', () => {
+  test('builds a prefilled handoff URL without changing the API result', () => {
+    expect(agentClaimHandoffUrl(VALID_CLAIM)).toBe(
+      'https://editor.pascal.app/settings/agents/claim?code=BCDF-GHJK-LMNP',
+    )
+    expect(VALID_CLAIM.claimUrl).toBe('https://editor.pascal.app/settings/agents/claim')
+  })
+
   test('starts a claim with the agent credential and returns the bounded public result', async () => {
     let authorization: string | null = null
     let redirect: RequestRedirect | undefined

--- a/packages/cli/src/agent-account.ts
+++ b/packages/cli/src/agent-account.ts
@@ -13,6 +13,12 @@ export interface AgentClaim {
   expiresAt: string
 }
 
+export function agentClaimHandoffUrl(claim: AgentClaim): string {
+  const url = new URL(claim.claimUrl)
+  url.searchParams.set('code', claim.claimCode)
+  return url.toString()
+}
+
 interface StartAgentClaimOptions {
   fetch?: typeof fetch
   timeoutMs?: number

--- a/packages/cli/src/bin/pascal.ts
+++ b/packages/cli/src/bin/pascal.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process'
 import { parseArgs } from 'node:util'
-import { startAgentClaim } from '../agent-account.js'
+import { agentClaimHandoffUrl, startAgentClaim } from '../agent-account.js'
 import { openBrowser } from '../browser.js'
 import { installGlobalPascalCommand, isNpxInvocation } from '../command-install.js'
 import { collectInfo, runDoctor } from '../diagnostics.js'
@@ -612,13 +612,14 @@ async function runAgent(args: string[], apiKey: string | undefined): Promise<voi
     },
   })
   const claim = await startAgentClaim(apiKey ?? '')
-  if (!values['no-open'] && !values.json) openBrowser(claim.claimUrl)
+  const claimHandoffUrl = agentClaimHandoffUrl(claim)
+  if (!values['no-open'] && !values.json) openBrowser(claimHandoffUrl)
   output(
     values.json,
     claim,
     [
       `Claim code: ${claim.claimCode}`,
-      `Claim page: ${claim.claimUrl}`,
+      `Claim page: ${claimHandoffUrl}`,
       `Expires: ${claim.expiresAt}`,
       '',
       'Claiming links accountability. It does not transfer project ownership or grant access to private projects.',

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -104,6 +104,9 @@ describe('command parsing', () => {
 
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('Claim code: BCDF-GHJK-LMNP')
+    expect(result.stdout).toContain(
+      'Claim page: https://editor.pascal.app/settings/agents/claim?code=BCDF-GHJK-LMNP',
+    )
     expect(result.stdout).toContain('Claiming links accountability.')
     expect(result.stdout).not.toContain('malicious')
     expect(result.stdout).not.toContain('\u001b')


### PR DESCRIPTION
The hosted claim page already accepts `?code=`, but the CLI opened the bare page and made the human copy the code manually. This change opens and prints the prefilled handoff URL while preserving the existing three-field JSON contract and the short claim code as a fallback.

Validation:
- `bun test packages/cli/src/agent-account.test.ts packages/cli/src/cli.test.ts` (27 tests, 90 assertions)
- `bun run --cwd packages/cli check-types`
- `bunx biome check packages/cli/src/agent-account.ts packages/cli/src/agent-account.test.ts packages/cli/src/bin/pascal.ts packages/cli/src/cli.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX-only change; claim API contract and JSON shape are preserved, with no changes to auth or credential handling.
> 
> **Overview**
> The **`pascal agent claim`** flow now opens the browser and prints a **prefilled claim URL** (`?code=<claimCode>`) instead of the bare hosted page, so users do not have to copy the code manually.
> 
> A new **`agentClaimHandoffUrl`** helper builds that URL from the API’s `claimUrl` and `claimCode` without mutating the claim object. **JSON output is unchanged**—still the same three-field `AgentClaim` from `startAgentClaim`; only the human-facing “Claim page” line and `openBrowser` target use the handoff URL. The claim code line remains as a fallback.
> 
> Tests cover the URL builder and assert the CLI stdout includes the prefilled link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de07aab9462795e988c5668c3f7e4ae5b75ce16d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->