### PR TITLE
docs(cli): publish verified agent claim preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ for pnpm/Bun commands, project management, MCP setup, updates, storage paths, an
 troubleshooting. The npm release is the older runtime described below; use the verified
 GitHub preview when a task needs the new read-only furniture candidate check.
 
-## Candidate-enabled CLI preview
+## Verified CLI preview
 
-The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, which predates the read-only furniture candidate input in this repository. To use that capability before the next npm release, install the verified GitHub prerelease built from commit `aa653f2f523f81f361ac20cb42b745faf7e46844`:
+The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, which predates the read-only furniture candidate input and hosted `pascal agent claim` command in this repository. To use those capabilities before the next npm release, install the verified GitHub prerelease built from commit `8ca0b79c0b415a04d28a28cae3a1958f2f403c39`:
 
 ```bash
-PASCAL_PREVIEW_VERSION='1.0.0-beta.1.agent-skills.0'
+PASCAL_PREVIEW_VERSION='1.0.0-beta.2.claim.0'
 PASCAL_PREVIEW_PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/pascal-preview"
 PASCAL_PREVIEW_DOWNLOAD="$(mktemp -d)"
 cd "$PASCAL_PREVIEW_DOWNLOAD"
 
 curl --fail --location --remote-name \
-  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.2-claim.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
 curl --fail --location --remote-name \
-  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/SHA256SUMS.txt"
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.2-claim.0/SHA256SUMS.txt"
 
 # macOS
 shasum -a 256 -c SHA256SUMS.txt
@@ -53,9 +53,11 @@ export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
 pascal --version
 pascal update --version "$PASCAL_PREVIEW_VERSION"
 pascal editor --no-open
+# For an existing hosted autonomous-agent key:
+PASCAL_API_KEY='sk_live_...' pascal agent claim
 ```
 
-The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. Keep an existing `PASCAL_HOME` unchanged so stored projects remain in the same data directory; `pascal editor` alone reuses any healthy service, including an older one. Keep the preview prefix on the agent host's `PATH` before using the Claude plugin-provided connector, running `pascal mcp setup claude` or `pascal mcp setup codex` for another installation path, or configuring `pascal mcp connect` manually. This GitHub prerelease is not an npm version.
+The expected archive SHA-256 is `8c8204109c619898a34e76cbb33a92cb1a0c9b9ac63bcd7a3b654a2dba9c3c6b`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. Keep an existing `PASCAL_HOME` unchanged so stored projects remain in the same data directory; `pascal editor` alone reuses any healthy service, including an older one. Keep the preview prefix on the agent host's `PATH` before using the Claude plugin-provided connector, running `pascal mcp setup claude` or `pascal mcp setup codex` for another installation path, or configuring `pascal mcp connect` manually. `pascal agent claim` opens a prefilled 15-minute human handoff and does not store or print the hosted key. This GitHub prerelease is not an npm version.
 
 Use one active agent client per local CLI service. The standalone local HTTP runtime shares active scene state between clients; use separate `PASCAL_HOME` directories and service processes when independent concurrent work is required.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,24 +37,24 @@ the runtime, so updating the CLI does not replace your work.
 - npm, including when the CLI itself is launched with pnpm or Bun
 - A browser, unless you pass `--no-open`
 
-The initial supported release is macOS. The GitHub preview below also passed an
-installed managed-service smoke in a Linux arm64 container. This is not an x86_64 or
-Windows result.
+The initial supported release is macOS. The GitHub preview below also passed a clean
+claim-command installation in a Linux arm64 container. This is not an x86_64 or Windows
+result.
 
-## Candidate-enabled CLI preview
+## Verified CLI preview
 
-The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, which predates the read-only furniture candidate input in this repository. To use that capability before the next npm release, install the verified GitHub prerelease built from commit `aa653f2f523f81f361ac20cb42b745faf7e46844`:
+The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, which predates the read-only furniture candidate input and hosted `pascal agent claim` command in this repository. To use those capabilities before the next npm release, install the verified GitHub prerelease built from commit `8ca0b79c0b415a04d28a28cae3a1958f2f403c39`:
 
 ```bash
-PASCAL_PREVIEW_VERSION='1.0.0-beta.1.agent-skills.0'
+PASCAL_PREVIEW_VERSION='1.0.0-beta.2.claim.0'
 PASCAL_PREVIEW_PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/pascal-preview"
 PASCAL_PREVIEW_DOWNLOAD="$(mktemp -d)"
 cd "$PASCAL_PREVIEW_DOWNLOAD"
 
 curl --fail --location --remote-name \
-  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.2-claim.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
 curl --fail --location --remote-name \
-  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/SHA256SUMS.txt"
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.2-claim.0/SHA256SUMS.txt"
 
 # macOS
 shasum -a 256 -c SHA256SUMS.txt
@@ -66,9 +66,11 @@ export PATH="$PASCAL_PREVIEW_PREFIX/bin:$PATH"
 pascal --version
 pascal update --version "$PASCAL_PREVIEW_VERSION"
 pascal editor --no-open
+# For an existing hosted autonomous-agent key:
+PASCAL_API_KEY='sk_live_...' pascal agent claim
 ```
 
-The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. Keep an existing `PASCAL_HOME` unchanged so stored projects remain in the same data directory; `pascal editor` alone reuses any healthy service, including an older one. Keep the preview prefix on the agent host's `PATH` before running `pascal mcp setup claude`, `pascal mcp setup codex`, or configuring `pascal mcp connect` manually. This GitHub prerelease is not an npm version.
+The expected archive SHA-256 is `8c8204109c619898a34e76cbb33a92cb1a0c9b9ac63bcd7a3b654a2dba9c3c6b`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. Keep an existing `PASCAL_HOME` unchanged so stored projects remain in the same data directory; `pascal editor` alone reuses any healthy service, including an older one. Keep the preview prefix on the agent host's `PATH` before running `pascal mcp setup claude`, `pascal mcp setup codex`, or configuring `pascal mcp connect` manually. `pascal agent claim` opens a prefilled 15-minute human handoff and does not store or print the hosted key. This GitHub prerelease is not an npm version.
 
 Use one active agent client per local CLI service. The standalone local HTTP runtime shares active scene state between clients; use separate `PASCAL_HOME` directories and service processes when independent concurrent work is required.
 

--- a/skills/furniture-fit/references/setup.md
+++ b/skills/furniture-fit/references/setup.md
@@ -1,25 +1,25 @@
 # Connect Pascal for a furniture-fit assessment
 
-Source and public-documentation review date: 2026-09-09. Native task results are recorded separately with the evaluated source hash; source review alone does not prove every host or published runtime works.
+Source and public-documentation review date: 2026-09-10. Native task results are recorded separately with the evaluated source hash; source review alone does not prove every host or published runtime works.
 
 ## Local project
 
 Use the local path when the project should remain on the machine:
 
-### Candidate-enabled GitHub preview
+### Verified GitHub preview
 
-The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, an older runtime that may not expose `check_collisions.candidate`. For the candidate-enabled path verified with this skill, install the GitHub prerelease built from public commit `aa653f2f523f81f361ac20cb42b745faf7e46844`:
+The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, an older runtime that may not expose `check_collisions.candidate` or `pascal agent claim`. For the candidate and hosted-claim paths verified with this skill, install the GitHub prerelease built from public commit `8ca0b79c0b415a04d28a28cae3a1958f2f403c39`:
 
 ```bash
-PASCAL_PREVIEW_VERSION='1.0.0-beta.1.agent-skills.0'
+PASCAL_PREVIEW_VERSION='1.0.0-beta.2.claim.0'
 PASCAL_PREVIEW_PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/pascal-preview"
 PASCAL_PREVIEW_DOWNLOAD="$(mktemp -d)"
 cd "$PASCAL_PREVIEW_DOWNLOAD"
 
 curl --fail --location --remote-name \
-  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.2-claim.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
 curl --fail --location --remote-name \
-  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/SHA256SUMS.txt"
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.2-claim.0/SHA256SUMS.txt"
 
 # macOS
 shasum -a 256 -c SHA256SUMS.txt
@@ -38,7 +38,7 @@ pascal update --version "$PASCAL_PREVIEW_VERSION"
 pascal editor --no-open
 ```
 
-The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. `pascal editor` alone reuses any healthy service, including an older one, so run `pascal update` when activating the preview. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. This preview is not published on npm.
+The expected archive SHA-256 is `8c8204109c619898a34e76cbb33a92cb1a0c9b9ac63bcd7a3b654a2dba9c3c6b`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. `pascal editor` alone reuses any healthy service, including an older one, so run `pascal update` when activating the preview. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. The preview also includes `pascal agent claim`, which opens a prefilled 15-minute accountability handoff for an existing hosted autonomous-agent key. This preview is not published on npm.
 
 The Claude Code plugin supplies `pascal mcp connect` automatically. Keep `pascal` on the `PATH` used to launch Claude Code; the plugin does not install or start the Pascal editor. Claude Code 2.1.258 loads both the user-scoped `pascal` server created by `pascal mcp setup claude` and the plugin-provided server. Remove the manual entry with `claude mcp remove --scope user pascal` before reloading or restarting Claude Code. Use `/mcp` to remove or disable other manual Pascal connections. Leaving both connections active violates the one-active-agent-client-per-local-service requirement. If the intended project is hosted, disable the plugin-provided local server in `/mcp` before configuring the hosted connection below.
 

--- a/skills/pascal-3d/references/setup.md
+++ b/skills/pascal-3d/references/setup.md
@@ -1,6 +1,6 @@
 # Pascal connection and credential setup
 
-Source and public-documentation review date: 2026-09-09. Native task results are recorded separately with the evaluated source hash; source review alone does not prove every host or published runtime works.
+Source and public-documentation review date: 2026-09-10. Native task results are recorded separately with the evaluated source hash; source review alone does not prove every host or published runtime works.
 
 Choose one path. Do not switch storage boundaries without the user's instruction.
 
@@ -15,20 +15,20 @@ npm install --global @pascal-app/cli@beta
 pascal editor --no-open
 ```
 
-### Candidate-enabled GitHub preview
+### Verified GitHub preview
 
-The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, an older runtime that may not expose `check_collisions.candidate`. For the candidate-enabled path verified with this skill, install the GitHub prerelease built from public commit `aa653f2f523f81f361ac20cb42b745faf7e46844`:
+The npm `beta` tag currently resolves to `@pascal-app/cli@1.0.0-beta.1`, an older runtime that may not expose `check_collisions.candidate` or `pascal agent claim`. For the candidate and hosted-claim paths verified with this skill, install the GitHub prerelease built from public commit `8ca0b79c0b415a04d28a28cae3a1958f2f403c39`:
 
 ```bash
-PASCAL_PREVIEW_VERSION='1.0.0-beta.1.agent-skills.0'
+PASCAL_PREVIEW_VERSION='1.0.0-beta.2.claim.0'
 PASCAL_PREVIEW_PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/pascal-preview"
 PASCAL_PREVIEW_DOWNLOAD="$(mktemp -d)"
 cd "$PASCAL_PREVIEW_DOWNLOAD"
 
 curl --fail --location --remote-name \
-  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.2-claim.0/pascal-app-cli-${PASCAL_PREVIEW_VERSION}.tgz"
 curl --fail --location --remote-name \
-  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.1-agent-skills.0/SHA256SUMS.txt"
+  "https://github.com/pascalorg/editor/releases/download/cli-v1.0.0-beta.2-claim.0/SHA256SUMS.txt"
 
 # macOS
 shasum -a 256 -c SHA256SUMS.txt
@@ -47,7 +47,7 @@ pascal update --version "$PASCAL_PREVIEW_VERSION"
 pascal editor --no-open
 ```
 
-The expected archive SHA-256 is `814ffa8c6f6a5fced73bf909c616d9a78feff18fd61fd0b4b7d65e74fad5a33d`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. `pascal editor` alone reuses any healthy service, including an older one, so run `pascal update` when activating the preview. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. This preview is not published on npm.
+The expected archive SHA-256 is `8c8204109c619898a34e76cbb33a92cb1a0c9b9ac63bcd7a3b654a2dba9c3c6b`. The same-version `update` command installs and activates this CLI's bundled runtime, restarting an older running service when necessary. `pascal editor` alone reuses any healthy service, including an older one, so run `pascal update` when activating the preview. Keep the preview prefix on the agent host's `PATH` so its configured `pascal mcp connect` command resolves. The preview also includes `pascal agent claim`, which opens a prefilled 15-minute accountability handoff for an existing hosted autonomous-agent key. This preview is not published on npm.
 
 The Claude Code plugin supplies this local connector automatically. Keep `pascal` on the `PATH` used to launch Claude Code; the plugin does not install or start the Pascal editor. Claude Code 2.1.258 loads both the user-scoped `pascal` server created by `pascal mcp setup claude` and the plugin-provided server. Remove the manual entry with `claude mcp remove --scope user pascal` before reloading or restarting Claude Code. Use `/mcp` to remove or disable other manual Pascal connections. Leaving both connections active violates the one-active-agent-client-per-local-service requirement. If the intended project is hosted, disable the plugin-provided local server in `/mcp` before configuring the hosted connection below.
 


### PR DESCRIPTION
The verified GitHub CLI prerelease now contains both the furniture-candidate runtime and `pascal agent claim`, including the prefilled human handoff from PR #818. This updates public installation instructions to the exact release commit, archive, and checksum while keeping npm availability described as pending.

Validation:
- `bun scripts/validate-skills.ts`
- `git diff --check`
- prerelease `cli-v1.0.0-beta.2-claim.0` anonymously downloaded and checksum-verified
- exact archive clean-installed on macOS and Linux arm64; packed claim JSON contract passed on both

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to installation URLs, checksums, and preview versioning with no runtime or auth logic modified.
> 
> **Overview**
> Updates public install docs to the **verified GitHub CLI prerelease** `1.0.0-beta.2.claim.0` (commit `8ca0b79c…`), replacing the older agent-skills preview. The section title is now **Verified CLI preview**, and instructions cover the new release URLs, tarball version, and archive SHA-256.
> 
> Docs now treat that preview as the path for both **read-only furniture `check_collisions.candidate`** and hosted **`pascal agent claim`**, including an example with `PASCAL_API_KEY` and a note that claim opens a prefilled 15-minute handoff without storing the key. The root and CLI READMEs, plus `pascal-3d` and `furniture-fit` setup references, stay in sync; review dates move to **2026-09-10**, and the CLI README’s Linux note references a clean **claim-command** install instead of a managed-service smoke test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4b59ee0b1cd5ed9ccf62e2827a9bac19cadee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->