### PR TITLE
fix(viewer): clamp GLB floor animation on slow frames

### DIFF
--- a/packages/viewer/src/components/viewer/glb-scene.tsx
+++ b/packages/viewer/src/components/viewer/glb-scene.tsx
@@ -599,7 +599,9 @@ export function GlbScene({
       const targetY = baseY + (exploded ? index * EXPLODED_GAP : 0)
       // Snap (not lerp) in walkthrough so the first-person collider, built from
       // these world positions, matches the stacked building immediately.
-      node.position.y = walkthroughMode ? targetY : lerp(node.position.y, targetY, delta * 12)
+      node.position.y = walkthroughMode
+        ? targetY
+        : lerp(node.position.y, targetY, Math.min(1, delta * 12))
       // Solo: hidden levels above the soloed one keep casting shadows
       // (shadow-caster-only); below-levels can't block the sun, so plain-hide.
       const hidden =


### PR DESCRIPTION
## What does this PR do?

Fixes #616 by clamping the remaining GLB floor-animation interpolation factor to 1. A slow frame or resumed background tab can otherwise move baked floors past their target and make their positions diverge. This matches the already-clamped parametric LevelSystem; walkthrough mode still snaps to the baked elevation.

## How to test

1. Load a multi-floor baked GLB and switch between stacked and exploded modes.
2. Exercise slow frames or resume a suspended tab; floors should stay between their previous and target elevations.
3. Enter walkthrough mode and confirm floors immediately use their baked elevations.

Focused validation executed the actual priority-5 `useFrame` callback extracted from the source with the TypeScript AST, using structural level objects. All 14 stacked/exploded cases passed for frame deltas of 0, 1/60, 1/12, 0.1, 0.2, 0.5, and 30 seconds; ordinary-frame behavior and walkthrough snapping were preserved. At 0.5-second frames, the original callback diverged to approximately -4.5e28 while the fix settled at the expected 7.7 m elevation. This is deterministic frame-callback validation, not a full browser render.

Pinned Biome 2.4.16 and `git diff --check` passed. [Complete fork CI](https://github.com/FenjuFu/editor/actions/runs/34441214692) also passed: lint/format, agent-skill validation, type checking, the full test suite, application/package builds, and the macOS packed CLI/runtime smoke test. The validation branch contains the same fix plus isolated CI-trigger configuration; those workflow changes are not part of this PR.

## Screenshots / screen recording

No UI layout change; the regression concerns slow-frame level transforms.

## Checklist

- [ ] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (file-scoped pinned Biome passed)
- [x] I've updated relevant documentation (not applicable)
- [x] This PR targets the `main` branch
