### PR TITLE
perf(core): guard bulk slab changes in the spatial-grid subscriber

### DIFF
--- a/packages/core/src/hooks/spatial-grid/spatial-grid-sync.test.ts
+++ b/packages/core/src/hooks/spatial-grid/spatial-grid-sync.test.ts
@@ -9,6 +9,8 @@ import useLiveTerrain from '../../store/use-live-terrain'
 import useScene, { clearSceneHistory } from '../../store/use-scene'
 import { spatialGridManager } from './spatial-grid-manager'
 import {
+  BULK_SLAB_CHANGE_THRESHOLD,
+  countBulkSlabChanges,
   initSpatialGridSync,
   markCoveringDependentsBelow,
   markLevelHeightDependents,
@@ -781,5 +783,107 @@ describe('temporal writes update slab support dependencies', () => {
         .elevation,
     ).toBe(1)
     await Promise.resolve()
+  })
+})
+
+describe('bulk slab-change guard', () => {
+  let stopSync = () => {}
+
+  // One level: a perimeter wall along y = 1 and a floor slab that contains it.
+  // Plates are small interior squares kept away from the wall, so the per-slab
+  // overlap scan would never dirty the wall — only the bulk superset does.
+  const wall = makeChild('wall_bulk', 'wall', 'level_bulk')
+  const floor = makeSlab('slab_floor', 'level_bulk', { polygon: SQUARE })
+  function plates(count: number): AnyNode[] {
+    return Array.from({ length: count }, (_, index) => {
+      const x = 0.2 + (index % 16) * 0.22
+      const y = 2.5 + Math.floor(index / 16) * 0.0002
+      return makeSlab(`slab_plate_${index}`, 'level_bulk', {
+        polygon: [
+          [x, y],
+          [x + 0.2, y],
+          [x + 0.2, y + 0.2],
+          [x, y + 0.2],
+        ],
+        elevation: 0.5,
+      })
+    })
+  }
+  function sceneWith(extra: AnyNode[]): Record<AnyNodeId, AnyNode> {
+    const level = makeLevel('level_bulk', 0, 2.5, [
+      wall.id,
+      floor.id,
+      ...extra.map((node) => node.id),
+    ])
+    return nodesFor(level, wall, floor, ...extra)
+  }
+  function write(nodes: Record<AnyNodeId, AnyNode>) {
+    useScene.setState({ dirtyNodes: new Set<AnyNodeId>() })
+    const started = performance.now()
+    useScene.setState({ nodes })
+    return performance.now() - started
+  }
+
+  beforeEach(() => {
+    spatialGridManager.clear()
+    useScene.setState({
+      collections: {},
+      dirtyNodes: new Set<AnyNodeId>(),
+      nodes: sceneWith([]),
+      readOnly: false,
+      rootNodeIds: ['level_bulk'] as AnyNodeId[],
+    } as never)
+    clearSceneHistory()
+    stopSync = initSpatialGridSync()
+    useScene.setState({ dirtyNodes: new Set<AnyNodeId>() })
+  })
+
+  afterEach(() => {
+    stopSync()
+    spatialGridManager.clear()
+  })
+
+  test('counts added, removed and reshaped slabs only', () => {
+    const before = sceneWith([])
+    const added = sceneWith(plates(3))
+    expect(countBulkSlabChanges(added, before)).toBe(3)
+    expect(countBulkSlabChanges(before, added)).toBe(3)
+    const moved = { ...added, slab_plate_0: { ...added.slab_plate_0, elevation: 0.9 } }
+    expect(countBulkSlabChanges(moved as never, added)).toBe(1)
+    const renamedWall = { ...added, wall_bulk: { ...added.wall_bulk, thickness: 0.2 } }
+    expect(countBulkSlabChanges(renamedWall as never, added)).toBe(0)
+  })
+
+  test('below the threshold the per-slab scan runs and leaves a non-overlapping wall clean', () => {
+    write(sceneWith(plates(BULK_SLAB_CHANGE_THRESHOLD - 1)))
+    expect(useScene.getState().dirtyNodes.has(wall.id as AnyNodeId)).toBe(false)
+  })
+
+  test('at the threshold the superset sweep marks the wall once and skips the scans', () => {
+    write(sceneWith(plates(BULK_SLAB_CHANGE_THRESHOLD)))
+    expect(useScene.getState().dirtyNodes.has(wall.id as AnyNodeId)).toBe(true)
+  })
+
+  test('a 3,000-slab write stays linear and later single-slab edits stay targeted', () => {
+    const many = plates(3000)
+    // Unguarded: 3,000 slabs × 2 scans × ~3,000 nodes with a parent walk each.
+    const elapsed = write(sceneWith(many))
+    expect(elapsed).toBeLessThan(1500)
+    expect(useScene.getState().dirtyNodes.has(wall.id as AnyNodeId)).toBe(true)
+
+    // One interior plate moves: nothing it overlaps, so the wall stays clean.
+    const nodes = useScene.getState().nodes
+    write({
+      ...nodes,
+      slab_plate_7: { ...nodes.slab_plate_7, elevation: 0.9 },
+    } as Record<AnyNodeId, AnyNode>)
+    expect(useScene.getState().dirtyNodes.has(wall.id as AnyNodeId)).toBe(false)
+
+    // The floor slab under the wall moves: the targeted overlap rule still fires.
+    write({
+      ...useScene.getState().nodes,
+      slab_floor: { ...floor, elevation: 0.3 },
+    } as Record<AnyNodeId, AnyNode>)
+    expect(useScene.getState().dirtyNodes.has(wall.id as AnyNodeId)).toBe(true)
   })
 })

--- a/packages/core/src/hooks/spatial-grid/spatial-grid-sync.ts
+++ b/packages/core/src/hooks/spatial-grid/spatial-grid-sync.ts
@@ -113,6 +113,13 @@ export function initSpatialGridSync(): () => void {
   // Subscribe to all changes
   const unsubscribeScene = store.subscribe((state, prevState) => {
     if (state.nodes === prevState.nodes) return
+    // A bulk slab change (scene load/reload, paste, import) used to run
+    // markNodesOverlappingSlab per slab — two full node scans each, O(slabs ×
+    // nodes). Above the threshold, dirty every possible slab dependent once (a
+    // superset of the per-slab result) and skip the per-slab scans below.
+    const bulkSlabs =
+      countBulkSlabChanges(state.nodes, prevState.nodes) >= BULK_SLAB_CHANGE_THRESHOLD
+    if (bulkSlabs) markAllSlabDependents(state.nodes, markDirty)
     const changedSlabContextLevels = new Set<string>()
     const checkSlabContext = (id: string) => {
       const previous = prevState.nodes[id as AnyNodeId]
@@ -151,7 +158,7 @@ export function initSpatialGridSync(): () => void {
         spatialGridManager.handleNodeCreated(node, levelId)
 
         // When a slab is added, mark overlapping items/walls dirty
-        if (node.type === 'slab') {
+        if (node.type === 'slab' && !bulkSlabs) {
           markNodesOverlappingSlab(node as SlabNode, state.nodes, markDirty)
           markCoveringDependentsBelow(levelId, state.nodes, markDirty)
         }
@@ -172,7 +179,7 @@ export function initSpatialGridSync(): () => void {
         spatialGridManager.handleNodeDeleted(id, node.type, levelId)
 
         // When a slab is removed, mark items/walls that were on it dirty (using current state)
-        if (node.type === 'slab') {
+        if (node.type === 'slab' && !bulkSlabs) {
           markNodesOverlappingSlab(node as SlabNode, state.nodes, markDirty, prevState.nodes)
           markCoveringDependentsBelow(levelId, state.nodes, markDirty)
         }
@@ -216,13 +223,15 @@ export function initSpatialGridSync(): () => void {
           const levelId = resolveLevelId(node, state.nodes)
           spatialGridManager.handleNodeUpdated(node, levelId)
         }
-        markSlabChangeDependents(
-          prev as SlabNode,
-          node as SlabNode,
-          state.nodes,
-          markDirty,
-          prevState.nodes,
-        )
+        if (!bulkSlabs) {
+          markSlabChangeDependents(
+            prev as SlabNode,
+            node as SlabNode,
+            state.nodes,
+            markDirty,
+            prevState.nodes,
+          )
+        }
       } else if (node.type === 'level' && prev.type === 'level') {
         if (node.height !== prev.height) {
           markLevelHeightDependents(node as LevelNode, state.nodes, markDirty)
@@ -304,6 +313,67 @@ export function initSpatialGridSync(): () => void {
   return () => {
     unsubscribeScene()
     unsubscribeLiveTerrain()
+  }
+}
+
+/**
+ * Bulk slab-change guard. A scene load, reload, paste or import changes tens to
+ * thousands of slabs in one store write, and scanning every node twice per slab
+ * is O(slabs × nodes): a 4,600-slab scene blocked the main thread for ~5 s on
+ * every load. When at least this many slabs are added, removed or reshaped in
+ * one write, `markAllSlabDependents` dirties every node any slab could affect,
+ * once, and the per-slab scans are skipped. The marks are a superset of the
+ * per-slab result — and `setScene` marks every node dirty right after `set()`
+ * regardless — so load-time behaviour is unchanged; the saving is the scans.
+ */
+export const BULK_SLAB_CHANGE_THRESHOLD = 32
+
+export function countBulkSlabChanges(
+  nodes: Record<string, AnyNode>,
+  prevNodes: Record<string, AnyNode>,
+): number {
+  let count = 0
+  for (const id in nodes) {
+    const node = nodes[id]!
+    if (node.type !== 'slab') continue
+    const prev = prevNodes[id]
+    if (
+      prev?.type !== 'slab' ||
+      (prev as SlabNode).polygon !== (node as SlabNode).polygon ||
+      (prev as SlabNode).elevation !== (node as SlabNode).elevation ||
+      (prev as SlabNode).holes !== (node as SlabNode).holes
+    ) {
+      count++
+    }
+  }
+  for (const id in prevNodes) {
+    if (prevNodes[id]!.type === 'slab' && !nodes[id]) count++
+  }
+  return count
+}
+
+/**
+ * Every node a slab change can dirty, without looking at any slab: walls and
+ * ceilings (overlap and covering-below rules), stairs (deck attachment) and
+ * level-hosted floor-placed kinds (the generic re-elevation sweep).
+ */
+export function markAllSlabDependents(
+  nodes: Record<string, AnyNode>,
+  markDirty: (id: AnyNodeId) => void,
+) {
+  for (const id in nodes) {
+    const node = nodes[id]!
+    if (node.type === 'wall' || node.type === 'ceiling' || node.type === 'stair') {
+      markDirty(node.id)
+      continue
+    }
+    const floorPlaced = nodeRegistry.get(node.type)?.capabilities?.floorPlaced
+    if (!floorPlaced) continue
+    if (floorPlaced.applies && !floorPlaced.applies(node)) continue
+    const parentId = node.parentId as AnyNodeId | null
+    const parent = parentId ? nodes[parentId] : null
+    if (parent && parent.type !== 'level') continue
+    markDirty(node.id)
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

The spatial-grid subscriber runs `markNodesOverlappingSlab` for every slab a store write adds, removes or reshapes: two full node scans per slab, so a scene load, reload, paste or import is O(slabs × nodes). On a 4,645-slab scene (7,143 nodes) that scan alone blocked the main thread for ~5 s on every load — a real-Chrome CPU profile showed 5.9 s inclusive inside this scan out of a 7 s `setScene` block, enough for Chrome's "Page Unresponsive" dialog on a loaded machine.

When one write changes 32 or more slabs, this dirties every node any slab could affect once — walls, ceilings, stairs and level-hosted floor-placed kinds, a superset of the per-slab marks — and skips the per-slab scans. `setScene` marks every node dirty right after `set()` regardless, so load-time behaviour is unchanged; single-slab edits keep the targeted rules (`markSlabChangeDependents`, covering-below, deck stairs).

**Measurement caveat:** the numbers were taken with an equivalent patch applied to the published `@pascal-app/core@1.0.0-beta.5` (before #805), not re-taken on this source. Same mechanism. Max main-thread freeze on that scene went 6.4 s → 0.4–0.9 s; time to a ready model 31.7 s → ~21 s. Happy to re-run on a fixture you prefer.

## How to test

1. `bun test --cwd packages/core src/hooks/spatial-grid/spatial-grid-sync.test.ts` — new `bulk slab-change guard` block: 31 added interior plates leave a non-overlapping wall clean (per-slab path); 32 mark it (superset path); a 3,000-slab write stays linear (well under 1.5 s, versus seconds unguarded); later single-slab edits stay targeted.
2. Load a scene with hundreds of slab nodes with `?perf` and compare the `setScene` span before and after.
3. Full core suite passes (1,490 tests); `tsc --build` and `bun check` clean.

## Screenshots / screen recording

No visual change. Numbers above; a before/after CPU profile of the scan is available on request.

## Checklist

- [ ] I've tested this locally with `bun dev` — verified through the package test suites, `tsc --build` and `bun check` instead; no editor session was run for this change
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and which nodes are marked dirty in the spatial-grid subscriber; bulk mode trades precise overlap scans for a fixed superset sweep, so correctness depends on that superset matching real slab dependents outside full-scene hydration.
> 
> **Overview**
> Fixes main-thread freezes on scene load, paste, and import when thousands of slabs change in one store write. The spatial-grid subscriber used to run **two full node scans per added, removed, or reshaped slab**; this adds a **bulk guard** at **32+ slab changes** that calls **`markAllSlabDependents`** once (walls, ceilings, stairs, level-hosted floor-placed nodes) and **skips** the per-slab overlap and **`markSlabChangeDependents`** paths.
> 
> Exports **`BULK_SLAB_CHANGE_THRESHOLD`**, **`countBulkSlabChanges`**, and **`markAllSlabDependents`**. Dirty marks on bulk writes can be a **superset** of the old per-slab marks (e.g. a non-overlapping wall may be marked at the threshold); **single-slab edits** still use the targeted rules. Tests cover counting, threshold behavior, a 3,000-slab performance bound, and that later one-slab edits stay precise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7997a2f76508d656f95025b7b7b8482075f267b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->