### PR TITLE
perf(viewer): give the initial wall build a 48 ms frame budget

### DIFF
--- a/packages/viewer/src/systems/wall/wall-progressive-budget.test.ts
+++ b/packages/viewer/src/systems/wall/wall-progressive-budget.test.ts
@@ -53,6 +53,15 @@ describe('progressive wall budget', () => {
     expect(shouldDeferWallRebuild(heavy.id, nodes, 0, 100)).toBe(false)
   })
 
+  test('initial build drains under a 48 ms budget without the count cap; interactive tiers unchanged', () => {
+    expect(shouldDeferWallRebuild(cheap.id, nodes, 40, 30, true)).toBe(false)
+    expect(shouldDeferWallRebuild(cheap.id, nodes, 40, 48, true)).toBe(true)
+    expect(shouldDeferWallRebuild(cheap.id, nodes, 8, 0, true)).toBe(false)
+    expect(shouldDeferWallRebuild(heavy.id, nodes, 1, 0, true)).toBe(true)
+    expect(shouldDeferWallRebuild(cheap.id, nodes, 8, 0)).toBe(true)
+    expect(shouldDeferWallRebuild(cheap.id, nodes, 1, 8)).toBe(true)
+  })
+
   test('counts item cutout proxies but skips ordinary items', () => {
     const item = { id: 'item_budget-test', type: 'item' } as AnyNode
     const wall = { ...heavy, children: [...heavy.children.slice(0, 5), item.id] }
@@ -366,7 +375,7 @@ test('reattaching mid-drain preserves the hydration counters and one continuous 
   try {
     hydrate(12)
     const token = useScene.getState().hydrationToken
-    rebuildCost = 4
+    rebuildCost = 24
     runWallBuildFrame()
     expect(stats().firstBuilds).toBe(2)
     unsubscribe()
@@ -379,7 +388,7 @@ test('reattaching mid-drain preserves the hydration counters and one continuous 
     rebuildCost = 0
     runWallBuildFrame()
     expect(stats().firstBuilds).toBe(12)
-    expect(spans).toEqual([28])
+    expect(spans).toEqual([68])
   } finally { stop() }
 })
 
@@ -447,9 +456,9 @@ test('setScene starts initial build; more than eight cheap walls drain in one fr
   expect(stats().drainedExits).toBe(1)
 })
 
-test('checks the eight millisecond budget between walls and skips first-build neighbour invalidation across frames', () => {
+test('checks the initial-build time budget between walls and skips first-build neighbour invalidation across frames', () => {
   hydrate(12)
-  rebuildCost = 4
+  rebuildCost = 24
   runWallBuildFrame()
   expect(stats().wallsConsumedThisFrame).toBe(2)
   expect(stats().budgetExits).toBe(1)
@@ -695,7 +704,7 @@ test('canvas and live-state owner precede the lazy wall consumer; remount retain
   const nodes = Object.fromEntries([level, ...walls].map(node => [node.id, node]))
   const meshes = walls.map(wall => {
     const mesh = new Mesh(new BoxGeometry())
-    mesh.geometry.addEventListener('dispose', () => { now += 4 })
+    mesh.geometry.addEventListener('dispose', () => { now += 24 })
     sceneRegistry.nodes.set(wall.id, mesh)
     sceneRegistry.byType.wall.add(wall.id)
     return mesh

--- a/packages/viewer/src/systems/wall/wall-system.tsx
+++ b/packages/viewer/src/systems/wall/wall-system.tsx
@@ -614,6 +614,12 @@ const DRAG_FLUSH_MS = 80
 const MAX_WALL_REBUILDS_PER_FRAME = 8
 const WALL_PROGRESSIVE_DIRTY_THRESHOLD = MAX_WALL_REBUILDS_PER_FRAME
 const WALL_PROGRESSIVE_TIME_BUDGET_MS = 8
+// Initial build (see wall-build-lifecycle) has no interactive gesture to protect:
+// the frame is dominated by rendering the still-unbatched scene, so every extra
+// frame spent draining walls costs a full scene render. Three display frames of
+// wall work per frame drains a 1,600-wall scene in ~1/6 of the frames while every
+// frame stays two orders of magnitude under a perceptible freeze.
+const WALL_INITIAL_BUILD_TIME_BUDGET_MS = 48
 const HEAVY_WALL_OPENINGS = 6
 let lastWallDirtyAtMs = 0
 let unmountedFrames = 0
@@ -628,7 +634,10 @@ function wallRebuildExitReason(
 ): 'cap' | 'budget' | 'heavy' | null {
   if (!initialBuild && rebuiltThisFrame >= MAX_WALL_REBUILDS_PER_FRAME) return 'cap'
   if (rebuiltThisFrame === 0) return null
-  if (elapsedMs >= WALL_PROGRESSIVE_TIME_BUDGET_MS) return 'budget'
+  const budgetMs = initialBuild
+    ? WALL_INITIAL_BUILD_TIME_BUDGET_MS
+    : WALL_PROGRESSIVE_TIME_BUDGET_MS
+  if (elapsedMs >= budgetMs) return 'budget'
   const wall = nodes[wallId as AnyNodeId]
   if (wall?.type !== 'wall') return null
   let cutouts = 0
@@ -654,8 +663,9 @@ export function shouldDeferWallRebuild(
   nodes: Record<AnyNodeId, AnyNode>,
   rebuiltThisFrame: number,
   elapsedMs: number,
+  initialBuild = false,
 ): boolean {
-  return wallRebuildExitReason(wallId, nodes, rebuiltThisFrame, elapsedMs) !== null
+  return wallRebuildExitReason(wallId, nodes, rebuiltThisFrame, elapsedMs, initialBuild) !== null
 }
 
 /** Rebuilds this system still owes — neighbours deferred during a drag. */

--- a/wiki/architecture/systems.md
+++ b/wiki/architecture/systems.md
@@ -69,8 +69,9 @@ Unavailable walls do not continually postpone the pending-neighbour quiet clock.
 `isWallInitialBuildActive()` and `getPendingWallRebuildCount()` remain readable
 without `?perf`.
 
-Initial build consumes walls under the existing **8 ms budget**, checked between
-walls, without the interactive **8 walls/frame** cap. A wall with at least six
+Initial build consumes walls under a **48 ms budget** (about three display frames; the
+interactive tier keeps **8 ms**), checked between walls, without the interactive
+**8 walls/frame** cap. A wall with at least six
 opening cutouts occupies its own frame. Each wall's first build during active
 initial build skips adjacency scanning and neighbour re-invalidation because the
 hydrated inputs are stable and its neighbours are queued for their own first


### PR DESCRIPTION
## What does this PR do?

#800 lifted the 8-walls-per-frame cap during the initial wall build but kept the 8 ms time budget, which exists to protect a drag. The initial build has no gesture to protect, and each of its frames also pays a full render of the still-unbatched scene (the level wall batch merges only once a level stops changing), so every extra frame spent draining walls costs a whole scene render.

This gives the initial build its own budget, 48 ms (about three display frames, still two orders of magnitude under a perceptible freeze), checked between walls exactly as before. The interactive tiers (8 ms / 8 walls) are unchanged, and a heavy wall (≥ 6 openings) still takes its own frame. `shouldDeferWallRebuild` gains an optional `initialBuild` flag so the test can pin both tiers, and `wiki/architecture/systems.md` records the budget.

**Measurement caveat:** the numbers come from an equivalent change (a 48 ms / 128-wall tier for 64+ pending walls) applied to the published `@pascal-app/viewer@1.0.0-beta.5`, which predates #800 and has no initial-build state; this PR is narrower and applies the wider budget only inside #800's initial build. On a 1,600-wall scene in Chrome (WebGPU on Metal) that change halved time to a ready model in an interleaved A/B (17.6/18.3 s → 8.2/8.8 s) and cut main-thread long-task time roughly 3× (~12 s → 4 s). Not re-taken on this source; happy to re-run on your fixture.

## How to test

1. `bun test --cwd packages/viewer src/systems/wall/` — new case in `wall-progressive-budget.test.ts`; the lifecycle probes now simulate 24 ms per wall (was 4) so the budget exit is still exercised, and the recorded span expectation moves 28 → 68 accordingly. Full viewer suite: 311 pass.
2. Load a scene with 1,000+ walls with `?perf`; `__pascalPerf.batchStats().wallDrain` shows walls consumed per frame rising from ~6 to ~35 during initial build, and first-clean arriving in a fraction of the frames.
3. Drag a wall after load: the 8 ms / 8-wall behaviour is unchanged.

A constant is the smallest change. A frame-time-adaptive budget (spend as long as the last render took) would self-tune but needs a render-time signal in the wall system; glad to follow up either way.

## Screenshots / screen recording

No visual change; timing only.

## Checklist

- [ ] I've tested this locally with `bun dev` — verified through the package test suites, `tsc --build` and `bun check` instead; no editor session was run for this change
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timing-only change scoped to initial-build hydration; interactive 8 ms / 8-wall limits and heavy-wall rules are unchanged.
> 
> **Overview**
> **Initial wall hydration** now drains dirty walls with a **48 ms** per-frame time budget (checked between walls, still no 8-walls/frame cap), while **interactive** progressive rebuilds keep **8 ms** and **8 walls/frame**. The 8 ms limit exists to protect drags; initial load has no gesture and pays a full unbatched render each frame, so spending more wall work per frame reduces total frames to readiness.
> 
> `wallRebuildExitReason` / `shouldDeferWallRebuild` take an optional **`initialBuild`** flag to select the budget; heavy walls (≥6 openings) still defer to their own frame. Tests lock both tiers and bump simulated rebuild cost so budget-exit scenarios still match the wider allowance; architecture docs record the split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61e07cdce8eaeb545c4b1a590e9fdafb0cb5a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->