### PR TITLE
ci(release): graduate prerelease versions on stable bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
           - cli
           - all
       bump:
-        description: "Version bump (beta publishes a prerelease on the beta dist-tag)"
+        description: "Version bump (beta publishes a prerelease on the beta dist-tag; patch/minor/major on a prerelease graduates it to its base version on latest)"
         required: true
         type: choice
         options:
@@ -120,11 +120,16 @@ jobs:
               fi
               return
             fi
+            if [ "$BUMP" = "none" ]; then echo "$v"; return; fi
+            # A prerelease graduates to its base version on any stable bump
+            # (1.0.0-beta.5 + major|minor|patch -> 1.0.0), matching npm semver.
+            # Splitting "1.0.0-beta.5" on dots would otherwise yield 2.0.0 or
+            # break the patch arithmetic.
+            if [[ "$v" == *-* ]]; then echo "${v%%-*}"; return; fi
             IFS='.' read -r MAJ MIN PAT <<< "$v"
             if [ "$BUMP" = "major" ]; then MAJ=$((MAJ+1)); MIN=0; PAT=0; fi
             if [ "$BUMP" = "minor" ]; then MIN=$((MIN+1)); PAT=0; fi
             if [ "$BUMP" = "patch" ]; then PAT=$((PAT+1)); fi
-            if [ "$BUMP" = "none" ]; then echo "$v"; return; fi
             echo "$MAJ.$MIN.$PAT"
           }
 


### PR DESCRIPTION
## What does this PR do?

`bump_version` in `release.yml` split `1.0.0-beta.5` on dots for stable bumps, so `major` gave `2.0.0`, `minor` gave `1.1.0`, `patch` failed on `0-beta` arithmetic, and `none` would have published a beta version to `latest`. Any stable bump on a prerelease now graduates it to its base version (`1.0.0-beta.N` → `1.0.0`), matching npm semver. Needed to release the current beta line as 1.0.0.

Checked with the function extracted into bash: `1.0.0-beta.5 major → 1.0.0`, `1.0.0-beta.6 patch → 1.0.0`, `1.0.0 major → 2.0.0`, `1.0.0 patch → 1.0.1`, `0.9.2 major → 1.0.0`, `none` unchanged.

## How to test

1. Dispatch `release.yml` from this branch with `package=all`, `bump=major`, `dry-run=true` and read the "Bumped @pascal-app/… → 1.0.0" lines.

## Screenshots / screen recording

N/A

## Checklist

- [ ] I've tested this locally with `bun dev` (not applicable)
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation that sets published npm versions and tags; incorrect logic could ship wrong semver to `latest`, though scope is limited to the workflow bump helper.
> 
> **Overview**
> Fixes **release workflow version bumping** when the current version is a npm prerelease (e.g. `1.0.0-beta.5`).
> 
> `bump_version` in `release.yml` now treats **patch/minor/major** on a prerelease as **graduation** to the stable base (`1.0.0-beta.N` → `1.0.0`), aligned with npm semver, instead of splitting the string on `.` (which produced wrong majors/minors or broken patch math). **`none`** is handled before stable bumps so versions stay unchanged. The manual **`bump`** input description documents this graduation behavior for stable bumps on prereleases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432fb2118a9522f4c37c65bdf5a3691aa4a8de6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->