### PR TITLE
cli: cut the packed runtime from 107 MB to 65 MB

### DIFF
--- a/packages/cli/scripts/smoke-packed-runtime.ts
+++ b/packages/cli/scripts/smoke-packed-runtime.ts
@@ -169,9 +169,9 @@ function enforceArtifactBudget(artifact: {
   unpackedSize: number
   entryCount: number
 }): void {
-  const maximumSize = 110 * 1024 * 1024
-  const maximumUnpackedSize = 160 * 1024 * 1024
-  const maximumEntryCount = 4_000
+  const maximumSize = 75 * 1024 * 1024
+  const maximumUnpackedSize = 115 * 1024 * 1024
+  const maximumEntryCount = 3_200
   if (
     artifact.size > maximumSize ||
     artifact.unpackedSize > maximumUnpackedSize ||

--- a/packages/cli/scripts/stage-runtime.ts
+++ b/packages/cli/scripts/stage-runtime.ts
@@ -1,5 +1,15 @@
 import { spawn } from 'node:child_process'
-import { chmod, cp, mkdir, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  cp,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -9,6 +19,32 @@ const appDirectory = path.join(repositoryRoot, 'apps/editor')
 const standaloneDirectory = path.join(appDirectory, '.next/standalone')
 const standaloneAppDirectory = path.join(standaloneDirectory, 'apps/editor')
 const outputDirectory = path.join(packageDirectory, 'dist/runtime')
+
+/**
+ * `next build` copies its tracing root into `.next/standalone`, so the portable runtime
+ * inherits app sources, repository documentation and build-time-only assets that
+ * `server.js` never reads. Every entry below was checked against the staged tree: nothing
+ * in `.next`, `node_modules` or the bundled MCP server resolves it.
+ */
+const buildOnlyRuntimePaths = [
+  'apps/editor/app',
+  'apps/editor/components',
+  'apps/editor/lib',
+  'apps/editor/AGENTS.md',
+  'apps/editor/CLAUDE.md',
+  'apps/editor/README.md',
+  'apps/editor/bunfig.toml',
+  'apps/editor/next.config.ts',
+  'apps/editor/postcss.config.mjs',
+  'apps/editor/tsconfig.json',
+  'apps/editor/vercel.json',
+  // The radio catalogue is played by the hosted community app, which serves its own copy.
+  'apps/editor/public/audios/radios',
+  // `next/dist/server/font-utils.js` is the sole reader of these font metrics and is
+  // itself unreachable from the standalone server.
+  'node_modules/next/dist/server/capsize-font-metrics.json',
+  'node_modules/next/dist/server/font-utils.js',
+]
 
 const packageJson = JSON.parse(
   await readFile(path.join(packageDirectory, 'package.json'), 'utf8'),
@@ -38,6 +74,7 @@ await removeUnusedSharp(outputDirectory)
 await flattenBunNodeModules(outputDirectory)
 await materializeSymlinks(outputDirectory)
 await rm(path.join(outputDirectory, 'node_modules/.bun'), { recursive: true, force: true })
+await pruneBuildOnlyFiles(outputDirectory)
 const nativeFiles = await findNativeModules(outputDirectory)
 if (nativeFiles.length > 0) {
   throw new Error(`portable runtime contains native modules:\n${nativeFiles.join('\n')}`)
@@ -99,6 +136,70 @@ async function assertFile(filePath: string): Promise<void> {
       `standalone editor build not found at ${filePath}; run PASCAL_PORTABLE_BUILD=1 bun run build from apps/editor first`,
     )
   }
+}
+
+async function pruneBuildOnlyFiles(root: string): Promise<void> {
+  await Promise.all(
+    buildOnlyRuntimePaths.map((relative) =>
+      rm(path.join(root, relative), { recursive: true, force: true }),
+    ),
+  )
+  await removeStrayItemAssets(path.join(root, 'apps/editor/public/items'))
+  await removeTraceArtifacts(path.join(root, 'apps/editor/.next'))
+}
+
+/**
+ * Item directories are addressed by convention (`model.glb`, `thumbnail.*`, `floor-plan.*`).
+ * Anything else is an authoring leftover, so it is dropped and named on stdout: a future
+ * asset that does not follow the convention has to be reported rather than silently lost.
+ */
+async function removeStrayItemAssets(itemsDirectory: string): Promise<void> {
+  let entries
+  try {
+    entries = await readdir(itemsDirectory, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    return
+  }
+  const isConventional = (name: string): boolean =>
+    name === 'model.glb' || name.startsWith('thumbnail.') || name.startsWith('floor-plan.')
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const itemDirectory = path.join(itemsDirectory, entry.name)
+    for (const asset of await readdir(itemDirectory, { withFileTypes: true })) {
+      if (!asset.isFile() || isConventional(asset.name)) continue
+      const assetPath = path.join(itemDirectory, asset.name)
+      const { size } = await stat(assetPath)
+      await rm(assetPath, { force: true })
+      console.log(
+        `Dropped unreferenced item asset ${entry.name}/${asset.name} (${formatMegabytes(size)} MB)`,
+      )
+    }
+  }
+}
+
+function formatMegabytes(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(2)
+}
+
+async function removeTraceArtifacts(nextDirectory: string): Promise<void> {
+  const walk = async (directory: string): Promise<void> => {
+    let entries
+    try {
+      entries = await readdir(directory, { withFileTypes: true })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      return
+    }
+    for (const entry of entries) {
+      const absolute = path.join(directory, entry.name)
+      if (entry.isDirectory()) await walk(absolute)
+      else if (entry.name.endsWith('.nft.json') || entry.name.endsWith('.map')) {
+        await rm(absolute, { force: true })
+      }
+    }
+  }
+  await walk(nextDirectory)
 }
 
 async function removeUnusedSharp(root: string): Promise<void> {


### PR DESCRIPTION
## What does this PR do?

The published `@pascal-app/cli` was 107 MB compressed / 149 MB unpacked / 2,956 files. `stage-runtime` copies the standalone editor app plus `public/`, and most of the weight was dead: 39 MB of radio MP3s nothing in this repo references (the community app serves its own copy), a 4 MB build-time font-metrics table unreachable from `server.js`, a 3 MB stray screenshot and an unreferenced `.glb`, raw `.ts/.tsx` sources Turbopack had already bundled, and `.nft.json` trace files. The prune prints every file it drops so a future non-conventional asset is reported, not silently lost.

Result: **64.6 MB compressed / 101.7 MB unpacked / 2,870 files** (−40% / −32%). `smoke-runtime` passes and its budget is tightened from 110/160 MB to 75/115 MB so it is a guardrail again. Beyond the smoke test, the packed CLI was started on a temp `PASCAL_HOME`: `/`, `/scenes`, `/api/health`, `/scene/:id`, icons, sfx, HDRI, a `.glb`, a `.webp` texture and `demos/demo_1.json` all 200, and all 84 `/_next/static` references on the scene page resolve.

Left for follow-ups (outside `packages/cli`): `public/icons/fittings` is 11 MB of 1254 px RGBA PNGs used as small icons (~10.5 MB recoverable as 256 px webp); `items/small-kitchen-cabinet/model.glb` is 10.65 MB, 78% of all models. And the structural change: `pascal mcp connect` runs the bundled MCP server with only SQLite and never needs the web runtime, so the CLI could ship at ~0.5 MB and download the 65 MB web runtime on first `pascal editor`, verified by a committed SHA-256. Recorded in the private repo plans.

## How to test

1. `PASCAL_PORTABLE_BUILD=1 bun run build --filter editor && cd packages/cli && bun run build && bun run stage-runtime && bun run smoke-runtime` → `Packed runtime smoke passed (64.6 MB compressed, 101.7 MB unpacked, 2870 files)`.
2. `npm pack --dry-run` in `packages/cli` and compare with `npm view @pascal-app/cli@beta dist.unpackedSize`.
3. Start the packed CLI and open a scene; check the network panel for 404s.

## Screenshots / screen recording

N/A

## Checklist

- [ ] I've tested this locally with `bun dev` (packed runtime exercised instead)
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release packaging changes can drop assets the editor still needs at runtime; mitigation is explicit path lists, conventional item-asset rules with logging, and the existing smoke test on `npm pack`.
> 
> **Overview**
> **Shrinks the published `@pascal-app/cli` portable runtime** by pruning dead weight during `stage-runtime` after the standalone Next.js tree is copied, targeting roughly **40% smaller** compressed artifacts (per PR validation).
> 
> **New pruning step** (`pruneBuildOnlyFiles`): removes a curated list of build-only paths (editor `app`/`components`/`lib`, config/docs, hosted-only radio MP3s, unreachable Next font-metrics files), strips **non-conventional** files under `public/items` (keeps `model.glb`, `thumbnail.*`, `floor-plan.*`) with **stdout logs** for anything dropped, and deletes `.nft.json` / `.map` trace artifacts under `.next`.
> 
> **Smoke guardrails** in `smoke-packed-runtime` are tightened to match the smaller artifact: **75 MB** compressed (was 110), **115 MB** unpacked (was 160), **3,200** files (was 4,000).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ac05e5be5b5c8bc09a823a67e8aa981c862dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->