### PR TITLE
ci(release): publish through npm trusted publishing only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,12 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      # npm refuses direct publishing with 2FA-bypass tokens (EOTP, see
+      # https://gh.io/npm-gat-bypass2fa-deprecation), so no NODE_AUTH_TOKEN is set
+      # and npm >= 11.5 exchanges the GitHub Actions OIDC token itself. Every
+      # @pascal-app package must list this repository, this workflow file and
+      # the `npm` environment as a trusted publisher on npmjs.com; a package that
+      # does not exist on npm yet needs one manual first publish before that.
       - name: Enable npm trusted publishing
         run: |
           npm install --global npm@11.19.1
@@ -214,8 +220,6 @@ jobs:
       - name: Build & publish capture protocol
         if: inputs.package == 'capture-protocol' || inputs.package == 'all'
         working-directory: packages/capture-protocol
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           bun run build
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -242,8 +246,6 @@ jobs:
       - name: Build & publish core
         if: inputs.package == 'core' || inputs.package == 'all'
         working-directory: packages/core
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           bun run build
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -259,8 +261,6 @@ jobs:
       - name: Build & publish viewer
         if: inputs.package == 'viewer' || inputs.package == 'all'
         working-directory: packages/viewer
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           bun run build
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -276,8 +276,6 @@ jobs:
       - name: Build & publish capture viewer
         if: inputs.package == 'capture-viewer' || inputs.package == 'all'
         working-directory: packages/capture-viewer
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           bun run build
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -293,8 +291,6 @@ jobs:
       - name: Publish editor
         if: inputs.package == 'editor' || inputs.package == 'all'
         working-directory: packages/editor
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ "${{ inputs.dry-run }}" = "true" ]; then
             echo "🏜️ Dry run — would publish @pascal-app/editor@$EDITOR_VERSION"
@@ -309,8 +305,6 @@ jobs:
       - name: Build & publish nodes
         if: inputs.package == 'nodes' || inputs.package == 'all'
         working-directory: packages/nodes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           bun run build
           if [ "${{ inputs.dry-run }}" = "true" ]; then
@@ -340,8 +334,6 @@ jobs:
 
       - name: Build & publish ifc-converter
         if: inputs.package == 'ifc-converter' || inputs.package == 'all'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # ifc-converter depends on @pascal-app/core (workspace) — build it first
           bun run build --filter @pascal-app/core 2>/dev/null || (cd packages/core && bun run build)


### PR DESCRIPTION
## What does this PR do?

The 1.0.0 all-package release (run 34540888970) failed on its first publish with `npm error code EOTP … tokens that bypass 2FA are being restricted for … direct publishing`. Nothing was published and no release commit or tag was created.

This removes `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from every publish step so npm 11 uses GitHub OIDC trusted publishing (the job already has `id-token: write`, `environment: npm`, and installs npm 11.19.1). A comment at the setup step records the prerequisite: each `@pascal-app/*` package must list `pascalorg/editor`, `release.yml`, environment `npm` as a trusted publisher on npmjs.com, and `capture-protocol` / `capture-viewer`, which have never been published, need one manual first publish before a trusted publisher can be attached.

Do not merge until the trusted publishers are configured; without them the run fails with E404 instead of EOTP.

## How to test

1. Configure trusted publishers for the nine packages; publish the two new ones once manually.
2. Dispatch `release.yml` with `package=all`, `bump=major`, `dry-run=true` (dry run does not exercise auth), then `dry-run=false`.

## Screenshots / screen recording

N/A

## Checklist

- [ ] I've tested this locally with `bun dev` (not applicable)
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release publishing depends on npm trusted-publisher configuration; misconfiguration blocks all publishes (E404) until setup is complete.
> 
> **Overview**
> Switches the **release** workflow from **`NPM_TOKEN` / `NODE_AUTH_TOKEN`** to **npm trusted publishing** so publishes work under npm’s restriction on 2FA-bypass tokens (the failure mode that blocked the 1.0.0 all-package run with **EOTP**).
> 
> **`NODE_AUTH_TOKEN`** is removed from every package publish step; auth is expected via the job’s existing **GitHub Actions OIDC** setup (**`id-token: write`**, **`environment: npm`**, global **npm 11.19.1**). A comment documents prerequisites: each **`@pascal-app/*`** package must be configured as a trusted publisher for this repo, **`release.yml`**, and the **`npm`** environment; packages that have never been on npm need a one-time manual publish first.
> 
> Publish logic (dry-run, idempotent “already published” recovery, tags) is unchanged aside from dropping the secret env on each step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5696b3a83a691ec6e413ad59b577f31e049c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->