### PR TITLE
fix(skills): compare bundle paths without a hardcoded separator

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check:fix": "biome check --write",
     "check-types": "turbo run check-types",
     "test": "turbo run test",
-    "skills:validate": "bun scripts/validate-skills.ts && bun test scripts/clawhub-ignore-policy.test.ts scripts/claude-mcp-config-policy.test.ts scripts/openai-tool-annotation-policy.test.ts scripts/public-skill-discovery-policy.test.ts",
+    "skills:validate": "bun scripts/validate-skills.ts && bun test scripts/clawhub-ignore-policy.test.ts scripts/claude-mcp-config-policy.test.ts scripts/openai-tool-annotation-policy.test.ts scripts/path-containment.test.ts scripts/public-skill-discovery-policy.test.ts",
     "kill": "lsof -ti:3002 | xargs kill -9 2>/dev/null || echo 'No processes found on port 3002'",
     "clean:cache": "rm -rf apps/*/.next apps/*/.swc apps/*/.turbo packages/*/.turbo tooling/*/.turbo .turbo node_modules/.cache",
     "restart": "bun kill && bun clean:cache && bun dev",

--- a/scripts/path-containment.test.ts
+++ b/scripts/path-containment.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+import { isPathInside } from './path-containment'
+
+describe('isPathInside', () => {
+  test.each([
+    ['windows separators', 'C:\\repo\\skills\\pascal-3d', 'C:\\repo\\skills\\pascal-3d\\a.md'],
+    ['posix separators', '/repo/skills/pascal-3d', '/repo/skills/pascal-3d/a.md'],
+    ['mixed separators', 'C:\\repo\\skills\\pascal-3d', 'C:/repo/skills/pascal-3d/a.md'],
+    ['nested directory', '/repo/skills/pascal-3d', '/repo/skills/pascal-3d/examples/a.md'],
+    ['drive root', 'C:\\', 'C:\\a.md'],
+    ['trailing separator on the parent', '/repo/skills/', '/repo/skills/a.md'],
+  ])('accepts a target inside the parent with %s', (_label, parent, target) => {
+    expect(isPathInside(parent, target)).toBe(true)
+  })
+
+  test.each([
+    ['a sibling sharing the name prefix', '/repo/skills', '/repo/skills-extra/a.md'],
+    ['a parent directory', '/repo/skills/pascal-3d', '/repo/skills/a.md'],
+    ['an unrelated directory', '/repo/skills', '/repo/other/a.md'],
+    ['the parent itself', '/repo/skills', '/repo/skills'],
+    ['a traversal out of the parent', '/repo/skills', '/repo/other/../skills-evil/a.md'],
+    ['a different drive', 'C:\\repo\\skills', 'D:\\repo\\skills\\a.md'],
+  ])('rejects %s', (_label, parent, target) => {
+    expect(isPathInside(parent, target)).toBe(false)
+  })
+})

--- a/scripts/path-containment.ts
+++ b/scripts/path-containment.ts
@@ -1,0 +1,16 @@
+/**
+ * Containment check for paths produced by `resolve()` / `join()`.
+ *
+ * A `${parentDir}/` string prefix is not portable: `resolve()` returns
+ * backslash-separated paths on Windows, so the prefix never matches there and
+ * every file that is genuinely inside the directory is reported as outside.
+ * Comparing on a normalized separator keeps the check identical on every
+ * platform.
+ */
+function normalizeSeparators(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+export function isPathInside(parentDir: string, target: string): boolean {
+  return normalizeSeparators(target).startsWith(`${normalizeSeparators(parentDir)}/`)
+}

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -5,6 +5,7 @@ import { XMLParser, XMLValidator } from 'fast-xml-parser'
 import { validateClaudeMcpPolicy } from './claude-mcp-config-policy'
 import { validateClawHubIgnorePolicy } from './clawhub-ignore-policy'
 import { validateOpenAiToolAnnotationPacket } from './openai-tool-annotation-policy'
+import { isPathInside } from './path-containment'
 import {
   collectSkillDiscoveryEntries,
   validatePublicSkillDiscoverySurface,
@@ -384,7 +385,7 @@ for (const skillName of skillNames) {
         const target = match[1]!
         if (/^(?:https?:|mailto:|#)/.test(target)) continue
         const resolvedTarget = resolve(dirname(path), target.split('#')[0]!)
-        if (!resolvedTarget.startsWith(`${skillRoot}/`)) {
+        if (!isPathInside(skillRoot, resolvedTarget)) {
           fail(`${relative(root, path)} links outside its standalone skill bundle: ${target}`)
         }
       }
@@ -1079,7 +1080,7 @@ for (const field of ['composerIcon', 'logo']) {
     continue
   }
   const asset = resolve(root, value)
-  if (!asset.startsWith(`${root}/`) || !existsSync(asset) || !lstatSync(asset).isFile()) {
+  if (!isPathInside(root, asset) || !existsSync(asset) || !lstatSync(asset).isFile()) {
     fail(`OpenAI ${field} must reference an existing file inside the plugin`)
     continue
   }


### PR DESCRIPTION
## What does this PR do?

`bun run skills:validate` fails on Windows on an unmodified checkout, with 13 errors that all name files which do exist inside the plugin:

```
skills\pascal-3d\SKILL.md links outside its standalone skill bundle: references/setup.md
skills\pascal-3d\SKILL.md links outside its standalone skill bundle: references/tool-workflows.md
skills\furniture-fit\SKILL.md links outside its standalone skill bundle: references/setup.md
... (8 more bundle links)
OpenAI composerIcon must reference an existing file inside the plugin
OpenAI logo must reference an existing file inside the plugin
```

Cause: `scripts/validate-skills.ts` checks containment with a `` `${parentDir}/` `` string prefix, but `resolve()` returns backslash-separated paths on Windows, so that prefix never matches. Both operands are produced by `resolve()`, so the paths are genuinely inside the directory — only the comparison is wrong. Linux CI is unaffected, which is why this only breaks the gate for Windows contributors.

This replaces both prefix comparisons with an `isPathInside()` helper that compares on a normalized separator, and covers it with a focused test.

## How to test

1. `bun install --frozen-lockfile`
2. `bun run skills:validate`
   - before, on Windows: `Skill validation failed (13):` and exit 1
   - after, on Windows: `Validated 2 skills (pascal-3d@0.1.0, furniture-fit@0.1.4) ...` and `63 pass, 0 fail`
3. `bun test scripts/path-containment.test.ts` — 4 of the 12 cases fail against the previous `` `${parentDir}/` `` logic (Windows separators, mixed separators, drive root, trailing separator) and pass now.

`bun run check` is clean on the changed files.

The new test file is added to the `skills:validate` command because root `scripts/*.test.ts` are not part of a turbo workspace, so `bun run test` would not pick it up.

## Screenshots / screen recording

Not a visual change.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect local skill-validation path checks; behavior on POSIX is equivalent and Windows false failures are removed.
> 
> **Overview**
> Fixes **`bun run skills:validate`** falsely failing on Windows when markdown links and OpenAI asset paths are actually inside the skill bundle or plugin root.
> 
> Skill validation used a **`${parentDir}/`** string prefix on paths from **`resolve()`**, which uses backslashes on Windows, so containment checks never matched. The PR adds **`isPathInside()`** in **`scripts/path-containment.ts`**, which normalizes separators before comparing, and wires it into **`validate-skills.ts`** for bundle link checks and OpenAI **`composerIcon`** / **`logo`** resolution.
> 
> **`scripts/path-containment.test.ts`** covers Windows, POSIX, mixed separators, and rejection cases (prefix siblings, traversal, different drives). The test is included in the **`skills:validate`** npm script so it runs with the other root **`scripts/*.test.ts`** files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b224627f7a84485831d90e15f6ca3c308a1eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->