### PR TITLE
fix(editor): declare @react-three/test-renderer where the lifecycle test imports it

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -229,6 +229,7 @@
         "@pascal-app/core": "^1.0.0-beta.5",
         "@pascal-app/viewer": "^1.0.0-beta.5",
         "@pascal/typescript-config": "*",
+        "@react-three/test-renderer": "^9.1.0",
         "@types/blob-stream": "^0.1.33",
         "@types/bun": "^1.3.0",
         "@types/howler": "^2.2.12",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -64,6 +64,7 @@
     "@pascal-app/core": "^1.0.0-beta.5",
     "@pascal-app/viewer": "^1.0.0-beta.5",
     "@pascal/typescript-config": "*",
+    "@react-three/test-renderer": "^9.1.0",
     "@types/blob-stream": "^0.1.33",
     "@types/bun": "^1.3.0",
     "@types/howler": "^2.2.12",


### PR DESCRIPTION
## What does this PR do?

Declare `@react-three/test-renderer: ^9.1.0` in `packages/editor` devDependencies, matching viewer, and add its editor workspace entry to `bun.lock`. #831 added the dependency only to viewer even though `registered-tool-install-lifecycle.test.tsx` imports it from editor. This repo's hoisted install masks the missing declaration; private-editor CI uses Bun 1.3.0 with isolated, per-package dependency links and fails module resolution.

## How to test

1. On the base commit, run `bun install --linker isolated`. In a fresh clone, build workspace dependencies with `(cd packages/viewer && bun run build)`, then run `(cd packages/editor && bun test src/components/tools/registered-tool-install-lifecycle.test.tsx)`. Reproduced on Bun 1.3.14: `Cannot find module '@react-three/test-renderer'` from the lifecycle test; **0 pass, 1 fail, 1 error**.
2. With this change, run `bun install --linker isolated` and repeat the lifecycle test, then `(cd packages/editor && bun test)`. Verified with Bun 1.3.0, matching private-editor CI: lifecycle **2 pass, 0 fail, 40 assertions**; full editor suite **933 pass, 0 fail, 14,096 assertions across 126 files** (7.23 seconds).
3. Remove the root, package, and app `node_modules` directories and restore a hoisted install. The final diff contains only the new devDependency line in each of `packages/editor/package.json` and `bun.lock`; no package-resolution entries change.

Additional verification: `bun run check packages/editor/package.json` passed. Scanned 604 test files across packages, apps, and tooling for `@react-three/test-renderer`, `@testing-library/*`, `happy-dom`, and `jsdom`, comparing each match with its owning package manifest. Only editor lacked a declaration; viewer's three test imports are already covered. No other dependency changes were needed.

Installer note: Bun 1.3.14 repeatedly stalled at high CPU usage while re-resolving existing GitHub plugin dependencies. Bun 1.3.0 completed the isolated install and generated the editor dependency entry. The hoisted restore succeeded with Bun 1.3.0 using its generated lockfile (`--linker hoisted --frozen-lockfile`); the lockfile was byte-for-byte unchanged between isolated and hoisted installs. Bun 1.3.0's unrelated removal of `configVersion` and existing archive integrity fields was reverted afterward to preserve the repository's lockfile format. Non-frozen hoisted install attempts also stalled and were stopped; the successful frozen install left the clone in hoisted mode.

## Screenshots / screen recording

N/A — non-visual dependency declaration.

## Checklist

- [ ] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Jmmz2AMwTzcnKsSHHPEMhN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency declaration; fixes test module resolution with no production behavior impact.
> 
> **Overview**
> Adds **`@react-three/test-renderer` (^9.1.0)** to **`packages/editor`** devDependencies and updates **`bun.lock`**, aligning editor with viewer where the package was already declared.
> 
> **`registered-tool-install-lifecycle.test.tsx`** imports from this package; under **isolated** Bun installs (private-editor CI), module resolution failed because editor did not list the dependency—hoisted installs hid the gap. No application or runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0af573d9ca5c059e389839405615de8fa8cf650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->