### PR TITLE
ci(release): drop registry-url so npm uses OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,10 +77,14 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      # No registry-url here: with it, actions/setup-node writes an .npmrc whose
+      # auth token falls back to the placeholder XXXXX-XXXXX-XXXXX-XXXXX, npm
+      # sends that fake token, the registry answers 404, and the OIDC trusted
+      # publishing exchange never runs. npm publishes to registry.npmjs.org by
+      # default and each publish step passes --access public explicitly.
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: "https://registry.npmjs.org"
 
       # npm refuses direct publishing with 2FA-bypass tokens (EOTP, see
       # https://gh.io/npm-gat-bypass2fa-deprecation), so no NODE_AUTH_TOKEN is set


### PR DESCRIPTION
## What does this PR do?

Release run 34624024769 failed at "Build & publish core" with `E404 Not Found - PUT …/@pascal-app/core`. The job's environment shows `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX` and `NPM_CONFIG_USERCONFIG: …/_temp/.npmrc`: `actions/setup-node` with `registry-url` writes an `.npmrc` whose `_authToken` falls back to that placeholder when no token is provided, so npm authenticated with a fake token (masked as 404) and never attempted the OIDC trusted-publishing exchange.

Removes `registry-url` from the release job's `setup-node` step. npm publishes to registry.npmjs.org by default and every publish step already passes `--access public`. The `cli-smoke` job is unchanged.

## How to test

1. Dispatch `release.yml` with `package=all`, `bump=major`, `dry-run=false` after the seven `@pascal-app/*` packages have a trusted publisher (org `pascalorg`, repo `editor`, workflow `release.yml`, environment `npm`).
2. The "Build & publish core" step log should show `npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access` followed by success, with no `NODE_AUTH_TOKEN` in the step environment.

## Screenshots / screen recording

N/A

## Checklist

- [ ] I've tested this locally with `bun dev` (not applicable)
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to npm auth during release; no application runtime impact, but failed publishes would block releases until fixed.
> 
> **Overview**
> Fixes failed release publishes where npm authenticated with a **placeholder** `NODE_AUTH_TOKEN` and returned **404** instead of using GitHub Actions **OIDC trusted publishing**.
> 
> The release job’s `actions/setup-node` step **no longer sets** `registry-url`. That option was causing `setup-node` to write an `.npmrc` with a fake `_authToken`, which blocked npm ≥11.5 from exchanging the workflow OIDC token. Publishing still targets the public registry (npm’s default) and existing `npm publish --access public` steps are unchanged.
> 
> A short **comment** in `release.yml` documents this behavior so `registry-url` is not re-added by mistake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a68f2d0996c34ce204cfb0a3f5ecf933fa21387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->