### PR TITLE
fix(core): delete orphaned asset:// files from IndexedDB

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,7 +97,7 @@ export {
   type WallConstructionResolution,
 } from './hooks/spatial-grid/support-host-patch'
 export { useSpatialQuery } from './hooks/spatial-grid/use-spatial-query'
-export { loadAssetUrl, saveAsset } from './lib/asset-storage'
+export { deleteAsset, loadAssetUrl, saveAsset, sweepOrphanAssets } from './lib/asset-storage'
 export {
   clampDoorOperationState,
   getDoorRenderOpenAmount,

--- a/packages/core/src/lib/asset-storage.test.ts
+++ b/packages/core/src/lib/asset-storage.test.ts
@@ -1,6 +1,6 @@
 import 'fake-indexeddb/auto'
 import { afterEach, describe, expect, test } from 'bun:test'
-import { loadAssetUrl, saveAsset } from './asset-storage'
+import { deleteAsset, loadAssetUrl, saveAsset, sweepOrphanAssets } from './asset-storage'
 
 function file(contents: string, name = 'test.txt'): File {
   return new File([contents], name, { type: 'text/plain' })
@@ -59,5 +59,32 @@ describe('loadAssetUrl', () => {
 
   test('returns null for an empty URL', async () => {
     expect(await loadAssetUrl('')).toBeNull()
+  })
+})
+
+describe('deleteAsset', () => {
+  test('removes the IndexedDB entry so later loads miss', async () => {
+    const url = await saveAsset(file('delete-me'))
+    expect(await loadAssetUrl(url)).not.toBeNull()
+
+    expect(await deleteAsset(url)).toBe(true)
+    expect(await loadAssetUrl(url)).toBeNull()
+  })
+
+  test('ignores non-asset URLs', async () => {
+    expect(await deleteAsset('https://cdn.example.com/a.glb')).toBe(false)
+    expect(await deleteAsset('')).toBe(false)
+  })
+})
+
+describe('sweepOrphanAssets', () => {
+  test('drops unreferenced assets and keeps referenced ones', async () => {
+    const keepUrl = await saveAsset(file('keep'))
+    const orphanUrl = await saveAsset(file('orphan'))
+
+    const removed = await sweepOrphanAssets([keepUrl])
+    expect(removed).toBeGreaterThanOrEqual(1)
+    expect(await loadAssetUrl(keepUrl)).not.toBeNull()
+    expect(await loadAssetUrl(orphanUrl)).toBeNull()
   })
 })

--- a/packages/core/src/lib/asset-storage.ts
+++ b/packages/core/src/lib/asset-storage.ts
@@ -1,4 +1,4 @@
-import { get, set } from 'idb-keyval'
+import { del, get, keys, set } from 'idb-keyval'
 import { customAlphabet } from 'nanoid'
 
 export const ASSET_PREFIX = 'asset_data:'
@@ -8,6 +8,19 @@ const urlCache = new Map<string, string>()
 
 // Unlike crypto.randomUUID(), nanoid works outside secure contexts.
 const nanoAssetId = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 16)
+
+function assetIdFromUrl(url: string): string | null {
+  if (!url.startsWith('asset://')) return null
+  return url.replace('asset://', '') || null
+}
+
+function revokeCachedObjectUrl(id: string) {
+  const objectUrl = urlCache.get(id)
+  if (objectUrl) {
+    URL.revokeObjectURL(objectUrl)
+    urlCache.delete(id)
+  }
+}
 
 /**
  * Save a file to IndexedDB and return a custom protocol URL
@@ -31,9 +44,8 @@ export async function loadAssetUrl(url: string): Promise<string | null> {
   }
 
   // Handle our custom asset protocol
-  if (url.startsWith('asset://')) {
-    const id = url.replace('asset://', '')
-
+  const id = assetIdFromUrl(url)
+  if (id) {
     // Check cache first
     if (urlCache.has(id)) {
       return urlCache.get(id)!
@@ -56,4 +68,53 @@ export async function loadAssetUrl(url: string): Promise<string | null> {
 
   // Legacy data URLs are returned as is
   return url
+}
+
+/**
+ * Delete a locally stored `asset://` file from IndexedDB and drop any cached
+ * object URL. No-op for non-asset URLs. Callers that need undo-safety should
+ * only invoke this once no live node still references the URL.
+ */
+export async function deleteAsset(url: string): Promise<boolean> {
+  const id = assetIdFromUrl(url)
+  if (!id) return false
+  revokeCachedObjectUrl(id)
+  try {
+    await del(`${ASSET_PREFIX}${id}`)
+    return true
+  } catch (error) {
+    console.error('Failed to delete asset:', error)
+    return false
+  }
+}
+
+/**
+ * Drop every IndexedDB asset whose id is not in `keepUrls`.
+ *
+ * Interim orphan sweep for issue #733: deleting a node never removed its
+ * `asset://` File, so scans (up to 200 MB) lingered forever. Safe to call on
+ * scene load — undo restores nodes in-session without re-running the sweep.
+ */
+export async function sweepOrphanAssets(keepUrls: Iterable<string>): Promise<number> {
+  const keep = new Set<string>()
+  for (const url of keepUrls) {
+    const id = assetIdFromUrl(url)
+    if (id) keep.add(id)
+  }
+
+  let removed = 0
+  try {
+    const allKeys = await keys()
+    for (const key of allKeys) {
+      if (typeof key !== 'string' || !key.startsWith(ASSET_PREFIX)) continue
+      const id = key.slice(ASSET_PREFIX.length)
+      if (keep.has(id)) continue
+      revokeCachedObjectUrl(id)
+      await del(key)
+      removed += 1
+    }
+  } catch (error) {
+    console.error('Failed to sweep orphan assets:', error)
+  }
+  return removed
 }

--- a/packages/editor/src/components/ui/panels/reference-panel.tsx
+++ b/packages/editor/src/components/ui/panels/reference-panel.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { guideEmitter } from '../../../lib/guide-events'
+import { scheduleLocalAssetDelete } from '../../../lib/local-asset-lifecycle'
 import { getGuideImageName } from '../../../lib/local-guide-image'
 import { cn } from '../../../lib/utils'
 import useEditor from '../../../store/use-editor'
@@ -120,11 +121,14 @@ export function ReferencePanel() {
       return
     }
 
+    if (node.url?.startsWith('asset://')) {
+      scheduleLocalAssetDelete(node.url)
+    }
     deleteNode(selectedReferenceId as AnyNode['id'])
     guideEmitter.emit('guide:deleted', { guideId: selectedReferenceId as GuideNode['id'] })
     clearGuideUi(selectedReferenceId)
     setSelectedReferenceId(null)
-  }, [clearGuideUi, deleteNode, node?.type, selectedReferenceId, setSelectedReferenceId])
+  }, [clearGuideUi, deleteNode, node?.type, node?.url, selectedReferenceId, setSelectedReferenceId])
 
   const handleStartScale = useCallback(() => {
     if (node?.type !== 'guide') {

--- a/packages/editor/src/components/ui/sidebar/panels/site-panel/index.tsx
+++ b/packages/editor/src/components/ui/sidebar/panels/site-panel/index.tsx
@@ -11,6 +11,7 @@ import {
   useScene,
   type ZoneNode,
 } from '@pascal-app/core'
+import { scheduleLocalAssetDelete } from '../../../../../lib/local-asset-lifecycle'
 import { markPerfAction, useViewer } from '@pascal-app/viewer'
 import {
   Camera,
@@ -589,6 +590,11 @@ const LevelReferences = memo(function LevelReferences({
       (refNode.url.startsWith('http://') || refNode.url.startsWith('https://'))
     ) {
       onDeleteAsset?.(projectId, refNode.url)
+    }
+    // Local asset:// scans/guides never hit onDeleteAsset; without this the
+    // File stays in IndexedDB forever (issue #733).
+    if (refNode?.url?.startsWith('asset://')) {
+      scheduleLocalAssetDelete(refNode.url)
     }
     deleteNode(nodeId as AnyNodeId)
   }

--- a/packages/editor/src/lib/local-asset-lifecycle.ts
+++ b/packages/editor/src/lib/local-asset-lifecycle.ts
@@ -1,0 +1,61 @@
+import { type AnyNode, deleteAsset, sweepOrphanAssets, useScene } from '@pascal-app/core'
+
+/** Collect every `asset://` URL still referenced by a live scene node. */
+export function collectSceneAssetUrls(
+  nodes: Record<string, AnyNode> = useScene.getState().nodes,
+): string[] {
+  const urls: string[] = []
+  for (const node of Object.values(nodes)) {
+    const candidate = (node as { url?: unknown }).url
+    if (typeof candidate === 'string' && candidate.startsWith('asset://')) {
+      urls.push(candidate)
+    }
+    const src = (node as { src?: unknown }).src
+    if (typeof src === 'string' && src.startsWith('asset://')) {
+      urls.push(src)
+    }
+  }
+  return urls
+}
+
+/**
+ * Drop IndexedDB assets no longer referenced by the scene (issue #733).
+ * Intended for scene-load: undo restores nodes in-session without re-running
+ * this sweep, so a mid-session undo still finds its File.
+ */
+export async function sweepUnreferencedSceneAssets(): Promise<number> {
+  return sweepOrphanAssets(collectSceneAssetUrls())
+}
+
+const pendingDeletes = new Map<string, ReturnType<typeof setTimeout>>()
+const DELETE_GRACE_MS = 120_000
+
+function isAssetStillReferenced(url: string): boolean {
+  return collectSceneAssetUrls().includes(url)
+}
+
+/**
+ * Schedule deletion of a local `asset://` File after a grace period so undo
+ * (which restores the node, not a new upload) can still load the blob.
+ * Cancels any prior pending delete for the same URL.
+ */
+export function scheduleLocalAssetDelete(url: string, graceMs: number = DELETE_GRACE_MS): void {
+  if (!url.startsWith('asset://')) return
+  const existing = pendingDeletes.get(url)
+  if (existing) clearTimeout(existing)
+
+  const timer = setTimeout(() => {
+    pendingDeletes.delete(url)
+    if (isAssetStillReferenced(url)) return
+    void deleteAsset(url)
+  }, graceMs)
+  pendingDeletes.set(url, timer)
+}
+
+/** Cancel a scheduled local asset delete (e.g. node reappeared via undo). */
+export function cancelLocalAssetDelete(url: string): void {
+  const existing = pendingDeletes.get(url)
+  if (!existing) return
+  clearTimeout(existing)
+  pendingDeletes.delete(url)
+}

--- a/packages/editor/src/lib/scene.ts
+++ b/packages/editor/src/lib/scene.ts
@@ -13,6 +13,7 @@ import useEditor, {
   normalizePersistedEditorUiState,
   type PersistedEditorUiState,
 } from '../store/use-editor'
+import { sweepUnreferencedSceneAssets } from './local-asset-lifecycle'
 import { editorHostPanelRegistry } from './plugin-panels'
 
 export type SceneGraph = {
@@ -418,6 +419,10 @@ export function applySceneGraphToEditor(sceneGraph?: SceneGraph | null) {
   clearSceneHistory()
 
   syncEditorSelectionFromCurrentScene()
+
+  // Drop IndexedDB assets that no live node references (issue #733). Safe on
+  // load: undo restores nodes without re-running this sweep.
+  void sweepUnreferencedSceneAssets()
 }
 
 const LOCAL_STORAGE_KEY = 'pascal-editor-scene'


### PR DESCRIPTION
﻿## What does this PR do?

Local `asset://` Files in IndexedDB are now cleaned up when a node is deleted, and orphans are swept on scene load.

Fixes #733

## How to test

1. In `packages/core`: `bun test src/lib/asset-storage.test.ts` — new `deleteAsset` / `sweepOrphanAssets` cases pass
2. In a self-hosted editor, upload a local guide/scan, delete the node, wait for the grace period (or reload the project) — the IndexedDB `asset_data:*` entry is gone
3. Undo within the grace period still restores the node with a working image/scan

## Screenshots / screen recording

N/A — storage lifecycle, no visual change.

## Checklist

- [x] I've tested this locally with unit tests + `tsc --build` in `packages/core`
- [x] My code follows the existing code style (biome on touched files)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

## Notes for review

- `deleteAsset` + `sweepOrphanAssets` live in `@pascal-app/core` (`asset-storage.ts`) and are exported from the package entry
- UI deletes in site-panel / reference-panel schedule a **grace-period** delete (`local-asset-lifecycle.ts`) so undo can still load the blob
- `applySceneGraphToEditor` runs an orphan sweep on load — the interim mitigation suggested in the issue; safe because undo does not re-run the sweep

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how local asset blobs are permanently deleted from IndexedDB; incorrect reference tracking could remove files still needed after undo or edge-case node shapes.
> 
> **Overview**
> Fixes **#733** by cleaning up local `asset://` blobs in IndexedDB when scans/guides are removed, instead of leaving multi‑MB files behind forever.
> 
> **@pascal-app/core** adds **`deleteAsset`** (removes the DB row and revokes cached blob URLs) and **`sweepOrphanAssets`** (deletes every `asset_data:*` key not in a keep list), plus unit tests. **`loadAssetUrl`** now shares **`assetIdFromUrl`** parsing with those helpers.
> 
> The editor wires **`scheduleLocalAssetDelete`** (2‑minute grace, skips delete if the URL is referenced again) when deleting guides in the reference panel or scans/guides in the site tree. **`applySceneGraphToEditor`** runs **`sweepUnreferencedSceneAssets`** on project load to drop leftovers from earlier sessions; in‑session undo is not re‑swept on load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752792a825b457f840165d844e2eef532f8abf87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->