### PR TITLE
ci(release): log npm verbosely to surface OIDC exchange errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,11 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    env:
+      # Verbose npm logs show the OIDC token exchange and the registry's
+      # rejection reason when trusted publishing is misconfigured; tokens are
+      # redacted by npm.
+      NPM_CONFIG_LOGLEVEL: verbose
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What does this PR do?

Sets `NPM_CONFIG_LOGLEVEL: verbose` on the release job so a failed trusted-publishing exchange prints the registry's reason (npm logs the OIDC attempt at verbose level and redacts tokens). The last run failed with `ENEEDAUTH` after the exchange was rejected, and the default log level hides why.

## How to test

1. Dispatch `release.yml` (`package=all`, `bump=major`, `dry-run=false`); read the `oidc` lines in the "Build & publish core" step.

## Screenshots / screen recording

N/A

## Checklist

- [ ] I've tested this locally with `bun dev` (not applicable)
- [x] My code follows the existing code style (run `bun check` to verify)
- [x] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only logging change on the release job; no application or publish behavior changes.
> 
> **Overview**
> Adds **`NPM_CONFIG_LOGLEVEL: verbose`** at the **`release`** job level in `release.yml` so npm publish steps emit verbose logs during GitHub Actions OIDC trusted publishing.
> 
> The intent is to surface registry rejection details when publish fails with auth errors like **`ENEEDAUTH`**, without changing publish logic or credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e43081baf68ec0b983dea407cd2db099511578e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->