### PR TITLE
fix(editor): respect export scope when collecting floorplan schedules

### DIFF
--- a/packages/editor/src/lib/floorplan/floorplan-export.test.ts
+++ b/packages/editor/src/lib/floorplan/floorplan-export.test.ts
@@ -15,6 +15,7 @@ import { splitFloorplanOverlay } from '../../components/editor-2d/renderers/floo
 import { DEFAULT_FLOORPLAN_ANNOTATION_VISIBILITY } from './annotation-visibility'
 import {
   collectFloorplanGeometry,
+  collectFloorplanSchedules,
   filterFloorplanExportOverlay,
   fitPlanToBox,
   isFloorplanExportAnnotationGeometry,
@@ -421,6 +422,81 @@ describe('isFloorplanNodeInExportScope', () => {
   test('handles an undefined definition like a no-category node', () => {
     expect(isFloorplanNodeInExportScope(undefined, 'full')).toBe(true)
     expect(isFloorplanNodeInExportScope(undefined, 'structure')).toBe(false)
+  })
+})
+
+describe('collectFloorplanSchedules', () => {
+  test('omits non-structure schedule contributors under structure scope', () => {
+    const restoreRegistry = nodeRegistry._snapshot()
+    const structureKind = 'test:structure-schedule'
+    const siteKind = 'test:site-schedule'
+    const levelId = 'level_schedules' as AnyNode['id']
+    const structureNodeId = 'structure_scheduled' as AnyNode['id']
+    const siteNodeId = 'site_scheduled' as AnyNode['id']
+
+    const scheduleFor = (title: string) => ({
+      id: title.toLowerCase(),
+      title,
+      columns: [{ key: 'id', label: 'ID' }],
+      rows: [{ id: 'row', cells: { id: '1' } }],
+    })
+
+    try {
+      nodeRegistry._reset()
+      registerNode({
+        kind: structureKind,
+        schemaVersion: 1,
+        schema: z.object({ type: z.literal(structureKind) }) as never,
+        category: 'structure',
+        defaults: () => ({}) as never,
+        capabilities: {},
+        extensions: {
+          'pascal:editor/floorplan': {
+            schedule: () => scheduleFor('Doors'),
+          },
+        },
+      } as AnyNodeDefinition)
+      registerNode({
+        kind: siteKind,
+        schemaVersion: 1,
+        schema: z.object({ type: z.literal(siteKind) }) as never,
+        category: 'site',
+        defaults: () => ({}) as never,
+        capabilities: {},
+        extensions: {
+          'pascal:editor/floorplan': {
+            schedule: () => scheduleFor('Rooms'),
+          },
+        },
+      } as AnyNodeDefinition)
+
+      const nodes = {
+        [levelId]: {
+          id: levelId,
+          type: 'level',
+          visible: true,
+          children: [structureNodeId, siteNodeId],
+        },
+        [structureNodeId]: {
+          id: structureNodeId,
+          type: structureKind,
+          visible: true,
+        },
+        [siteNodeId]: {
+          id: siteNodeId,
+          type: siteKind,
+          visible: true,
+        },
+      } as unknown as Record<string, AnyNode>
+
+      const full = collectFloorplanSchedules(nodes, levelId, 'metric', 'full')
+      expect(full.map((schedule) => schedule.title).sort()).toEqual(['Doors', 'Rooms'])
+
+      const structure = collectFloorplanSchedules(nodes, levelId, 'metric', 'structure')
+      expect(structure.map((schedule) => schedule.title)).toEqual(['Doors'])
+    } finally {
+      restoreRegistry()
+    }
   })
 })
 

--- a/packages/editor/src/lib/floorplan/floorplan-export.tsx
+++ b/packages/editor/src/lib/floorplan/floorplan-export.tsx
@@ -219,7 +219,7 @@ export async function exportFloorplanPdf(scope: FloorplanExportScope): Promise<v
         wallDimensionReference,
         installedPlugins,
       )
-      const schedules = collectFloorplanSchedules(nodes, level.id, unit)
+      const schedules = collectFloorplanSchedules(nodes, level.id, unit, scope)
       if (geometries.length === 0 && schedules.length === 0) continue
       const layout = resolveFloorplanPageLayout(A4_LANDSCAPE_WIDTH_PT, A4_LANDSCAPE_HEIGHT_PT)
 
@@ -305,6 +305,7 @@ export function collectFloorplanSchedules(
   nodes: Record<string, AnyNode>,
   levelId: AnyNodeId,
   unit: 'metric' | 'imperial',
+  scope: FloorplanExportScope = 'full',
 ): FloorplanSchedule[] {
   const siblingsByType = new Map<string, AnyNode[]>()
   const visit = (id: AnyNodeId) => {
@@ -324,6 +325,9 @@ export function collectFloorplanSchedules(
   for (const [kind, definition] of nodeRegistry.entries()) {
     const scheduleContribution = getFloorplanNodeExtension(definition)?.schedule
     if (!scheduleContribution) continue
+    // Same scope gate as geometry: a structure-only PDF must not list rooms
+    // or other site-category contributors whose plan geometry was excluded.
+    if (!isFloorplanNodeInExportScope(definition, scope)) continue
     const siblings = siblingsByType.get(kind) ?? []
     const schedule = scheduleContribution({ siblings, nodes, levelId, unit })
     if (schedule && schedule.rows.length > 0) schedules.push(schedule)


### PR DESCRIPTION
﻿## What does this PR do?

Fixes #631.

`collectFloorplanSchedules` walked the entire level subtree and never took `FloorplanExportScope` into account. A `'structure'` PDF still emitted zone/room schedule pages (and other non-structure contributors) whose plan geometry the same export excluded.

`exportFloorplanPdf` already passes `scope` into `collectFloorplanGeometry`. This threads the same scope into schedule collection and gates each schedule-contributing node kind with `isFloorplanNodeInExportScope`.

## How to test

1. Open a model with doors/windows (structure) and rooms/zones (site).
2. Export a floorplan PDF with scope `structure`.
3. Confirm the PDF has door/window schedules but **no** room/zone schedule pages.
4. Export with scope `full` — all schedules should still appear.
5. Focused unit test: `collectFloorplanSchedules` with registered structure vs site kinds.

## Screenshots / screen recording

N/A — export content only.

## Checklist

- [x] I've tested this locally with `bun dev`
- [x] My code follows the existing code style (run `bun check` to verify)
- [ ] I've updated relevant documentation (if applicable)
- [x] This PR targets the `main` branch

## Validation

- `packages/editor`: `floorplan-export.test.ts` 25/25 pass (includes new scope test)
- `@pascal-app/core` and `@pascal-app/viewer` builds clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only behavior change with a default-preserving API and focused unit coverage; no auth or data-path changes.
> 
> **Overview**
> Structure-scoped floorplan PDFs no longer include schedule pages for node kinds whose plan geometry is already excluded from that export (e.g. room/zone schedules when only structure is exported).
> 
> **`collectFloorplanSchedules`** now accepts **`FloorplanExportScope`** (default **`full`**) and skips schedule contributors that fail **`isFloorplanNodeInExportScope`**, matching **`collectFloorplanGeometry`**. **`exportFloorplanPdf`** passes the same **`scope`** used for geometry into schedule collection.
> 
> Adds a unit test that registers structure vs site schedule contributors and asserts **`structure`** yields only structure schedules while **`full`** keeps both.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5304783328afb1d5d8aa2e0b92cd7a35a3b724b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->