### PR TITLE
fix(mcp): emit Node-resolvable ESM imports

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Build mcp
         run: bun run --cwd packages/mcp build
 
+      - name: Smoke-test the published Node entrypoint
+        run: bun run --cwd packages/mcp smoke:node
+
       - name: Test mcp
         run: bun test --cwd packages/mcp
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,12 +72,13 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && bun ../../scripts/fix-node-esm-imports.ts dist",
     "dev": "tsgo --build --watch",
     "test": "bun test src",
     "bench:registry": "bun run src/registry/__bench__/relations-resolver.bench.ts",
     "bench:schema": "bun run src/schema/__bench__/node-parsers.bench.ts",
-    "prepublishOnly": "npm run build"
+    "smoke:node": "node --input-type=module -e \"await import('./dist/index.js')\"",
+    "prepublishOnly": "npm run build && npm run smoke:node"
   },
   "peerDependencies": {
     "@react-three/drei": "^10",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The published ESM output now resolves relative JavaScript imports under Node,
+  so `pascal-mcp` and package subpath exports no longer require Bun's
+  extensionless import fallback.
 - Tool schemas in `tools/list` now declare the JSON Schema 2020-12 dialect
   instead of the SDK default `draft-07`, so clients that enforce 2020-12 no
   longer reject every tool call.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,7 +47,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc --build && bun ../../scripts/fix-node-esm-imports.ts dist",
+    "build": "tsc --build && bun ../../scripts/fix-node-esm-imports.ts ../core/dist && bun ../../scripts/fix-node-esm-imports.ts dist",
     "dev": "tsgo --build --watch",
     "start": "bun dist/bin/pascal-mcp.js",
     "test": "bun test",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,12 +47,13 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && bun ../../scripts/fix-node-esm-imports.ts dist",
     "dev": "tsgo --build --watch",
     "start": "bun dist/bin/pascal-mcp.js",
     "test": "bun test",
     "smoke": "bun run scripts/smoke.ts",
-    "prepublishOnly": "bun run build && bun test"
+    "smoke:node": "node dist/bin/pascal-mcp.js --help",
+    "prepublishOnly": "bun run build && bun test && bun run smoke:node"
   },
   "peerDependencies": {
     "@pascal-app/core": "^1.0.0"

--- a/scripts/fix-node-esm-imports.ts
+++ b/scripts/fix-node-esm-imports.ts
@@ -1,0 +1,64 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, extname, join, resolve } from 'node:path'
+import ts from 'typescript'
+
+const distDir = resolve(process.cwd(), process.argv[2] ?? 'dist')
+
+function javascriptFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return javascriptFiles(path)
+    return entry.isFile() && entry.name.endsWith('.js') ? [path] : []
+  })
+}
+
+function moduleSpecifiers(sourceFile: ts.SourceFile): ts.StringLiteral[] {
+  const specifiers: ts.StringLiteral[] = []
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier)
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0]!)
+    ) {
+      specifiers.push(node.arguments[0]!)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return specifiers
+}
+
+function resolvedSpecifier(file: string, specifier: string): string {
+  if (!specifier.startsWith('.') || extname(specifier)) return specifier
+  const target = resolve(dirname(file), specifier)
+  if (existsSync(`${target}.js`)) return `${specifier}.js`
+  if (existsSync(join(target, 'index.js'))) return `${specifier.replace(/\/$/, '')}/index.js`
+  throw new Error(`Cannot resolve extensionless ESM import ${specifier} from ${file}`)
+}
+
+for (const file of javascriptFiles(distDir)) {
+  const source = readFileSync(file, 'utf8')
+  const parsed = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS)
+  const replacements = moduleSpecifiers(parsed)
+    .map((node) => ({
+      start: node.getStart(parsed) + 1,
+      end: node.getEnd() - 1,
+      value: resolvedSpecifier(file, node.text),
+    }))
+    .filter((replacement) => source.slice(replacement.start, replacement.end) !== replacement.value)
+    .sort((a, b) => b.start - a.start)
+
+  let rewritten = source
+  for (const replacement of replacements) {
+    rewritten =
+      rewritten.slice(0, replacement.start) + replacement.value + rewritten.slice(replacement.end)
+  }
+  if (rewritten !== source) writeFileSync(file, rewritten)
+}

--- a/scripts/fix-node-esm-imports.ts
+++ b/scripts/fix-node-esm-imports.ts
@@ -1,14 +1,16 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, extname, join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import ts from 'typescript'
 
 const distDir = resolve(process.cwd(), process.argv[2] ?? 'dist')
 
-function javascriptFiles(directory: string): string[] {
+function emittedModuleFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = join(directory, entry.name)
-    if (entry.isDirectory()) return javascriptFiles(path)
-    return entry.isFile() && entry.name.endsWith('.js') ? [path] : []
+    if (entry.isDirectory()) return emittedModuleFiles(path)
+    return entry.isFile() && (entry.name.endsWith('.js') || entry.name.endsWith('.d.ts'))
+      ? [path]
+      : []
   })
 }
 
@@ -28,6 +30,12 @@ function moduleSpecifiers(sourceFile: ts.SourceFile): ts.StringLiteral[] {
       ts.isStringLiteral(node.arguments[0]!)
     ) {
       specifiers.push(node.arguments[0]!)
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      specifiers.push(node.argument.literal)
     }
     ts.forEachChild(node, visit)
   }
@@ -36,16 +44,25 @@ function moduleSpecifiers(sourceFile: ts.SourceFile): ts.StringLiteral[] {
 }
 
 function resolvedSpecifier(file: string, specifier: string): string {
-  if (!specifier.startsWith('.') || extname(specifier)) return specifier
+  if (!specifier.startsWith('.') || /\.(?:[cm]?js|json|node)$/.test(specifier)) return specifier
   const target = resolve(dirname(file), specifier)
-  if (existsSync(`${target}.js`)) return `${specifier}.js`
-  if (existsSync(join(target, 'index.js'))) return `${specifier.replace(/\/$/, '')}/index.js`
+  const emittedExtension = file.endsWith('.d.ts') ? '.d.ts' : '.js'
+  if (existsSync(`${target}${emittedExtension}`)) return `${specifier}.js`
+  if (existsSync(join(target, `index${emittedExtension}`))) {
+    return `${specifier.replace(/\/$/, '')}/index.js`
+  }
   throw new Error(`Cannot resolve extensionless ESM import ${specifier} from ${file}`)
 }
 
-for (const file of javascriptFiles(distDir)) {
+for (const file of emittedModuleFiles(distDir)) {
   const source = readFileSync(file, 'utf8')
-  const parsed = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS)
+  const parsed = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    file.endsWith('.d.ts') ? ts.ScriptKind.TS : ts.ScriptKind.JS,
+  )
   const replacements = moduleSpecifiers(parsed)
     .map((node) => ({
       start: node.getStart(parsed) + 1,


### PR DESCRIPTION
The published `@pascal-app/mcp@1.0.0` exits under Node before transport setup because both MCP and its `@pascal-app/core` peer emit extensionless relative ESM imports. For example, Node cannot resolve `dist/bridge/node-shims` from the CLI entrypoint.

This adds a shared post-build rewrite for emitted JavaScript in core and MCP, then gates the MCP workflow and both packages' publish hooks with real Node imports. It fixes the runtime half of #704; the cloud-to-local capture handoff remains tracked by #737.

Validation:
- `@pascal-app/core` build + Node import smoke
- `@pascal-app/mcp` build + Node CLI/subpath import smoke
- MCP suite: 366 passed
- packed core and MCP tarballs installed into an isolated consumer and loaded under Node 26
- Biome and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time rewriting of all published ESM output affects every consumer import path; mitigated by Node smoke tests in CI and publish hooks.
> 
> **Overview**
> Fixes **Node ESM resolution** for published `@pascal-app/core` and `@pascal-app/mcp` by rewriting extensionless relative imports in emitted `dist` `.js` and `.d.ts` after `tsc`.
> 
> Adds **`scripts/fix-node-esm-imports.ts`**, wired into both packages’ **`build`** (MCP also rewrites sibling **`../core/dist`**). **`smoke:node`** checks (`node` import of core entry; `pascal-mcp --help` for MCP) run in **`prepublishOnly`** and in **mcp-ci** after the MCP build. **CHANGELOG** notes that `pascal-mcp` and subpath exports no longer depend on Bun’s extensionless import behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fbcc6e3b08639f6c88a12bab07d3cba323f84a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->